### PR TITLE
chore: rename release workflow to publish and fix tsdown CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 
 on:
   push:
@@ -12,11 +12,11 @@ permissions:
   id-token: write
 
 concurrency:
-  group: changesets-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Create release PR
+      - name: Create publish PR
         uses: changesets/action@v1
         with:
           version: bun run version-packages

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.met
 export default defineConfig({
   entry: ["src/index.ts", "src/cli.ts"],
   format: ["esm"],
+  inlineOnly: false,
   clean: true,
   shims: true,
   dts: true,


### PR DESCRIPTION
## Summary
- rename workflow file from `.github/workflows/release.yml` to `.github/workflows/publish.yml`
- rename workflow/job labels from Release to Publish
- fix `tsdown` CI failure by setting `inlineOnly: false` in `tsdown.config.ts`

## Why
- keeps workflow naming aligned with publish intent
- unblocks trusted publishing pipeline by preventing tsdown dependency warnings from failing CI
