### PR TITLE
fix(release): add repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "create-prisma",
   "version": "0.1.1",
   "description": "Create and initialize Prisma 7 projects with first-party templates and great DX.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/create-prisma"
+  },
+  "homepage": "https://github.com/prisma/create-prisma",
+  "bugs": {
+    "url": "https://github.com/prisma/create-prisma/issues"
+  },
   "private": false,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- add repository.url to package.json as https://github.com/prisma/create-prisma
- add homepage and bugs.url metadata for complete package provenance metadata

## Why
npm trusted publishing provenance validation failed with:
package.json: "repository.url" is "", expected to match "https://github.com/prisma/create-prisma"

## Validation
- bun run typecheck
- bun run build
