### PR TITLE
chore(release): 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Create and initialize Prisma 7 projects with first-party templates and great DX.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.1.4

This PR bumps `create-prisma` to `0.1.4`.

When this PR merges, GitHub Actions publishes to npm using trusted publishing.
