### PR TITLE
Add Oxc checks and PR preview publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,11 +78,8 @@ jobs:
           fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
           EOF
 
-      - name: Lint
-        run: bun run lint
-
-      - name: Format check
-        run: bun run format:check
+      - name: Check
+        run: bun run check
 
       - name: Typecheck
         run: bun run typecheck
@@ -175,13 +172,9 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         run: bun install --frozen-lockfile
 
-      - name: Lint
+      - name: Check
         if: steps.check-version.outputs.exists == 'false'
-        run: bun run lint
-
-      - name: Format check
-        if: steps.check-version.outputs.exists == 'false'
-        run: bun run format:check
+        run: bun run check
 
       - name: Typecheck
         if: steps.check-version.outputs.exists == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,126 @@
-name: Release
+name: Publish
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
+  group: publish-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  release:
-    name: Release to npm
-    if: startsWith(github.event.head_commit.message, 'chore(release):')
+  preview:
+    name: Publish PR preview
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Compute preview metadata
+        id: preview
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BASE_VERSION=$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version)")
+          PREVIEW_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${{ github.run_number }}.${{ github.run_attempt }}"
+          DIST_TAG="pr${PR_NUMBER}"
+
+          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "version=$PREVIEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure npm version for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          echo "Node: $(node --version)"
+          echo "npm: $(npm --version)"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Set preview package version
+        env:
+          PREVIEW_VERSION: ${{ steps.preview.outputs.version }}
+        run: |
+          node - <<'EOF'
+          const fs = require("fs");
+          const packageJsonPath = "package.json";
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+          packageJson.version = process.env.PREVIEW_VERSION;
+          fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+          EOF
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: npm publish --access public --tag "${{ steps.preview.outputs.dist_tag }}"
+
+      - name: Preview summary
+        run: |
+          echo "## PR preview published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: \`${{ steps.preview.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Install with Bun: \`bunx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Install with npm: \`npm install create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    name: Release to npm
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Extract version from commit message
         id: version
@@ -61,13 +158,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup Node.js
-        if: steps.check-version.outputs.exists == 'false'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22.14.0"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Ensure npm version for trusted publishing
         if: steps.check-version.outputs.exists == 'false'
         run: |
@@ -84,6 +174,14 @@ jobs:
       - name: Install dependencies
         if: steps.check-version.outputs.exists == 'false'
         run: bun install --frozen-lockfile
+
+      - name: Lint
+        if: steps.check-version.outputs.exists == 'false'
+        run: bun run lint
+
+      - name: Format check
+        if: steps.check-version.outputs.exists == 'false'
+        run: bun run format:check
 
       - name: Typecheck
         if: steps.check-version.outputs.exists == 'false'

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": ["templates/**/*.hbs"]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "rules": {
+    "unicorn/no-empty-file": "off"
+  },
+  "env": {
+    "builtin": true
+  },
+  "globals": {}
+}

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ Or run locally:
 
 ```bash
 bun install
-bun run lint
-bun run format:check
+bun run check
 bun run build
 bun run start
 ```
@@ -158,6 +157,7 @@ Generated projects also include `db:seed` and configure Prisma's `migrations.see
 ## Scripts
 
 - `bun run build` - Build to `dist/`
+- `bun run check` - Run formatting and lint checks
 - `bun run dev` - Watch mode build
 - `bun run start` - Run built CLI
 - `bun run lint` - Run `oxlint` with warnings treated as failures
@@ -177,7 +177,7 @@ This repo uses a manual, script-driven release flow:
 1. Run `bun run bump` (or pass `patch|minor|major|x.y.z`).
 2. The script creates a `release/vX.Y.Z` branch and a PR with commit `chore(release): X.Y.Z`.
 3. Merge that PR to `main` with squash (keep commit title `chore(release): X.Y.Z`).
-4. GitHub Actions runs `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run build` before publishing.
+4. GitHub Actions runs `bun run check`, `bun run typecheck`, and `bun run build` before publishing.
 5. GitHub Actions creates the `vX.Y.Z` tag and GitHub Release notes via `changelogithub`.
 6. GitHub Actions publishes only for `chore(release):` commits, using npm trusted publishing (OIDC, no npm token secret).
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ Or run locally:
 
 ```bash
 bun install
+bun run lint
+bun run format:check
 bun run build
 bun run start
 ```
 
 The CLI updates `package.json` with Prisma dependencies, optionally runs dependency installation with your selected package manager, and scaffolds Prisma 7 setup files directly inside each app template:
+
 - `prisma/schema.prisma`
 - `prisma/seed.ts`
 - `src/lib/prisma.ts`, `src/lib/prisma.server.ts`, `src/lib/server/prisma.ts`, `server/utils/prisma.ts`, or `packages/db/src/client.ts`
@@ -134,6 +137,7 @@ The CLI updates `package.json` with Prisma dependencies, optionally runs depende
 - runs `prisma generate` automatically after scaffolding
 
 `create` is the default command and currently supports:
+
 - templates: `hono`, `next`, `svelte`, `astro`, `nuxt`, `tanstack-start`, `turborepo`
 - project name via `--name`
 - schema presets via `--schema-preset empty|basic` (default: `basic`)
@@ -156,6 +160,10 @@ Generated projects also include `db:seed` and configure Prisma's `migrations.see
 - `bun run build` - Build to `dist/`
 - `bun run dev` - Watch mode build
 - `bun run start` - Run built CLI
+- `bun run lint` - Run `oxlint` with warnings treated as failures
+- `bun run lint:fix` - Apply safe `oxlint` fixes
+- `bun run format` - Format the repo with `oxfmt`
+- `bun run format:check` - Check formatting with `oxfmt`
 - `bun run typecheck` - TypeScript checks only
 - `bun run bump` - Create a release PR (interactive semver bump)
 - `bun run bump -- patch|minor|major|x.y.z` - Non-interactive bump
@@ -169,5 +177,8 @@ This repo uses a manual, script-driven release flow:
 1. Run `bun run bump` (or pass `patch|minor|major|x.y.z`).
 2. The script creates a `release/vX.Y.Z` branch and a PR with commit `chore(release): X.Y.Z`.
 3. Merge that PR to `main` with squash (keep commit title `chore(release): X.Y.Z`).
-4. GitHub Actions creates the `vX.Y.Z` tag and GitHub Release notes via `changelogithub`.
-5. GitHub Actions publishes only for `chore(release):` commits, using npm trusted publishing (OIDC, no npm token secret).
+4. GitHub Actions runs `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run build` before publishing.
+5. GitHub Actions creates the `vX.Y.Z` tag and GitHub Release notes via `changelogithub`.
+6. GitHub Actions publishes only for `chore(release):` commits, using npm trusted publishing (OIDC, no npm token secret).
+
+Every PR from a branch in this repository also publishes a preview package to npm using the dist-tag `pr<PR_NUMBER>`, so PR 3 is installable as `create-prisma@pr3`.

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,8 @@
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^25.3.0",
         "changelogithub": "^14.0.0",
+        "oxfmt": "^0.37.0",
+        "oxlint": "^1.52.0",
         "tsdown": "^0.20.3",
         "typescript": "^5.9.3",
       },
@@ -77,6 +79,82 @@
     "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5" } }, "sha512-pEvnaYtwXaw2Fjy0VJyvfZTma/AprSUGSJlOcnfBySo0TU3ZfsB54vhTlQCCN+WUCGjInZ75vCjIQnGj3Af3gg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
+
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.37.0", "", { "os": "android", "cpu": "arm" }, "sha512-2AW4VHG6mePEb1r4l6nBOVz1MwevNa0obayXd5Xce+gtP+cL/FCaoVK7JtpqCj4cEVxbLU4jijBUIWK41X2GGg=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.37.0", "", { "os": "android", "cpu": "arm64" }, "sha512-fW/oGfK337wYb/qfoeqKrcv3tMv7DlsKVmHca0DZrWHLMUYftpYD9z7TYOD5VQ1Lg8D/iTzQiTneT2CAMThPxg=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.37.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8sfuzKA8Ic43ZCC1ZMwk12rNVao9nn7K6crTvtLQy+yQVbXE1xxR4P1YTxqaLEOGJNq+sB2xyrfJywKVF9VODw=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.37.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-X67bSfIDL1ufBY5OLxK3oG5Gj8Jvp7f2yEDVSduvolV+a0k6KJ1ZDFqG9wyTfancKVb7aZ5lTs63pAOxZYrj4A=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.37.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ULQ6098xUjZoZbT38qHj3Bgwq1BbglgnLOpB01Dsi79n94Dd4V0dPD4TlnSCdX33Rr/DBje4S2IpzgnAs8kknw=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.37.0", "", { "os": "linux", "cpu": "arm" }, "sha512-GsNuj91bKV8jHdRBtnCxe7vpX06IADFbyOwkScmDaoroRooBOK9NeStctE0/wE4DT6QY7qfF0YzUTGB2e5tjzQ=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.37.0", "", { "os": "linux", "cpu": "arm" }, "sha512-13ywNNp291Tc1nUaISUS3u2Y2O26zERJoVy1xK2uO+/1oon3EAHxMrXd0bQjopT+Ia3rTPwO6iFxW1DZratehA=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.37.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JAYqsm6sTfZZbUp1CQfWZ+prXg9qBRSs5bO7bgLdD9SiqsDHn2+EfJXESL6uLqT/UO5FYvE16wivup0EOHit5w=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.37.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EZj3TurW1iLbq+7tBr++wsxwFyD+pvjMrTNRuSynDrs8J7w46cu/ZIzU/lFw7OG1/tDRDZ9nrKXxwbvIKXo2zA=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.37.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ELXrDe1xRj+f7VpzJO2j54izMbi+Hov+kdqusXO3T1BwVEbA5sWgZrVMqkwEsj4k6Lw/obJK1SLUeNulR1D//g=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.37.0", "", { "os": "linux", "cpu": "none" }, "sha512-79gMZgLD62dGmo5Xl4gaMc6NHRFj3GuxPrchHBlW54tcRSXTtb3gLh/J6Bl8nbbzSFRQGR7dkNQ8yYadXt6txQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.37.0", "", { "os": "linux", "cpu": "none" }, "sha512-QFdi9OhyWxnh975jeG490atcINXZwZb7epyNASPaT4wcodOTuDitrDgSPT8CFl8BcGOFTGZ6c3P/s8Afeg1Ngg=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.37.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-qweAj7+pLFQXfe3UU7EZiOmo+/2SWjzVZjyyTDcrZAT0E92zEKJBvYpHinUAOqipfo2Xlp8GIfq0FSb5Tmqd8g=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.37.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Lqc/0vS20qzZLw1ThpWn1hQgRqj4rM+E7PuBzrqp+wLH5lYFqieAiontGpl2pMPvJ0QrmQYav9mslHlAB5kOSQ=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.37.0", "", { "os": "linux", "cpu": "x64" }, "sha512-TnJm22+1cEcpYXzbcXS5Z9+9c+R0ronFdx5bG4OTdOL/wSpQQKzc2izgAXJ03QkP3tq7aAPhlhhxasvH3xgoUA=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.37.0", "", { "os": "none", "cpu": "arm64" }, "sha512-YLq27qMur3hPUponvV3Zr0oHxowox71j3+nc+/oCc1O+M0zFafhd6AoAoCiRrSYRW+asWhz3/UMPh0bYpimcMw=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.37.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0lYOsiYSODNh5RE9VqsydSUY7yMz8l+C4O2i3zpdZWEDNR6Tk949sMbakwUbtE5hViHnAq1cubr197DzKW+d6g=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.37.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-KHQF8DsMTE6nqQ5uBU0sx8sQsyBK/PzJdJV65+28lJGOJO59jCS5WlGcKnGtq14a2B3Xr6LoJGrSFi19xsBs/A=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.37.0", "", { "os": "win32", "cpu": "x64" }, "sha512-tDVVCHOPbIJ+sQE1z2DdWk82ewhmgcbXlYv4xUCnkY75vM7R3VkVgO2KqgEolMRXwI5RrsAbk+ZoP9/LKdzKVg=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.52.0", "", { "os": "android", "cpu": "arm" }, "sha512-fW2pmR1VzFEdcvOYeSiv+R7CqffOjr9Bv5QmZaHuHJ4ZCqouaF6o48N/hJ3H1n9Zd8PCMFgJkeqUvUsVce01mw=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.52.0", "", { "os": "android", "cpu": "arm64" }, "sha512-ptuJljIB+klNi8//qxXyGD51NLJXY9lv40Olc7l3/pEyjejWwXGvGMO0GM6f0JsjmbnDL+VkX7RVQNhByaX8WA=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.52.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5d079Uw43BHVZzOwm3uJI2PgSbsZJTpfHDq2jMOR6rRjGiEBlgasaEvAA26VBqpkO1++/59ZCKLBnEpkro3zIg=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.52.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vRTjnhPEHAyfUhO9w6GM1VkxeVXFcDs+huyB5YNMw+Py+6PRYDFFrrOEr0rZYcoGtSH25ScozZV8I1UXrzaDjQ=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.52.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vFthhhciRAliAjoKMsvi7UkkQp/EtMNhmCRYBuKsNiTH0k4H3SFfbuWWr80Q7+uTXijfBP91KO/EeF48RggC7A=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-qX3K4mKbju54ojUa8nigVxxZAUDBGu5MGzpoXvWmiw+7hafoQKaLAoTm94EqRlv9v27p864GQBgc4g3qYtMXXA=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x5D5/EUS9U4kndPncLB6mDfCsv7i8XcRLu0DZyTngXvyqapc96WwmyyOG2j8Dt26aE8Ykgh6AhsHp9bQtoBUAw=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-2Ep1tnGLuGG7lUkKG/nilIJ0/T2rebEcATxMJ7afuhD6Z2Sc9dDcpX00IngAMyR9l6hXrvaOw9YA5HUAJVSENg=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-54wxvb1Pztz0GMgTLUG9HsH8uhZSL4UbG7n4PDxWIRT9TygTVYKfD6D7iasYdKg6ZpWB5Y86VMxgjSJpR/Y7bQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.52.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-A82Zks1lJyLclrj8n2tJPHOw2ieZXCaBctnCarS1BRlPQMC1Y98vWCLqgvg9ssWy5ZAja0IjUHN1cYsp53mrqA=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-ci89Ou+u9vnA0r4eQqGm/KPEkpea+QEtZCLKkrOAD/K5ZBwjS8ToID6aMgsDbIOJUNBGufsmX0iCC7EWrNKQFA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-3/+DVDWajFSu69TaYnKkoUgMEcHR3puO8TcBu3fPCKRhbLjgwDiYIVRdvQX0QaSjkNPJARmpYq7vlPHWNo2cUA=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.52.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BU7CbceOh00NDmY1IYr72qZoj4sJVHB9DCL2tIq2vyNllNJIpZWTxqlzdqmC4FViXWMy8kZNkOa+SdauH+EcoQ=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JUVZ6TKYl1yArS3xGsNLQlZxgVpjNKtZFja6VxSTDy2ToN7H58PiDRcxWoN2XoIcWlHSvK7pkIPFNOyzdEJ23A=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IatLKG6UUbIbTBjBZ9SIAYp4SIvOpYIXPXn9cMLqWxh9HrHsu0fLNL+VQ67y4vdlIleYLeuIHkAp3M6saIN1RQ=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.52.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CWgJ6FepHryuc/lgQWStFf3lcvEkbFLSa9zqO0D0QLVfrdg43I4XItKpL/bnfm4n7obzwgG8j8sBggdoxJQKfw=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.52.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EuNAbPpctu8jYMZnvYh53Xw3YVY2nIi9bQlyMjY0eKiJxDv8ikHrAfcVcwTQW9xa5tp0eiMkmW7iHPP5CYUC9Q=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.52.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-wu3fquQttzSXwyy8DfdOG3Kyb17yAbRhwPlly7NHSXkrffAEAmZ6+o38tCNgsReGLugbn/wbq4uS4nEQubCq+A=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-wikx9I9J9/lPOZlrCCNgm8YjWkia8NZfhWd1TTvZTMguyChbw/oA2VEM6Fzx+kkpA+1qu5Mo7nrLdOXEJavw8g=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -286,6 +364,10 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
+    "oxfmt": ["oxfmt@0.37.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.37.0", "@oxfmt/binding-android-arm64": "0.37.0", "@oxfmt/binding-darwin-arm64": "0.37.0", "@oxfmt/binding-darwin-x64": "0.37.0", "@oxfmt/binding-freebsd-x64": "0.37.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.37.0", "@oxfmt/binding-linux-arm-musleabihf": "0.37.0", "@oxfmt/binding-linux-arm64-gnu": "0.37.0", "@oxfmt/binding-linux-arm64-musl": "0.37.0", "@oxfmt/binding-linux-ppc64-gnu": "0.37.0", "@oxfmt/binding-linux-riscv64-gnu": "0.37.0", "@oxfmt/binding-linux-riscv64-musl": "0.37.0", "@oxfmt/binding-linux-s390x-gnu": "0.37.0", "@oxfmt/binding-linux-x64-gnu": "0.37.0", "@oxfmt/binding-linux-x64-musl": "0.37.0", "@oxfmt/binding-openharmony-arm64": "0.37.0", "@oxfmt/binding-win32-arm64-msvc": "0.37.0", "@oxfmt/binding-win32-ia32-msvc": "0.37.0", "@oxfmt/binding-win32-x64-msvc": "0.37.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Kd47gakZAU/i9KkXv3F0EDRoMvSso9O5966kflf9zYto0oZ0NN+Fh5vKKrLwp2Mkt0efYBk5LjCAS0BNC0y0eQ=="],
+
+    "oxlint": ["oxlint@1.52.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.52.0", "@oxlint/binding-android-arm64": "1.52.0", "@oxlint/binding-darwin-arm64": "1.52.0", "@oxlint/binding-darwin-x64": "1.52.0", "@oxlint/binding-freebsd-x64": "1.52.0", "@oxlint/binding-linux-arm-gnueabihf": "1.52.0", "@oxlint/binding-linux-arm-musleabihf": "1.52.0", "@oxlint/binding-linux-arm64-gnu": "1.52.0", "@oxlint/binding-linux-arm64-musl": "1.52.0", "@oxlint/binding-linux-ppc64-gnu": "1.52.0", "@oxlint/binding-linux-riscv64-gnu": "1.52.0", "@oxlint/binding-linux-riscv64-musl": "1.52.0", "@oxlint/binding-linux-s390x-gnu": "1.52.0", "@oxlint/binding-linux-x64-gnu": "1.52.0", "@oxlint/binding-linux-x64-musl": "1.52.0", "@oxlint/binding-openharmony-arm64": "1.52.0", "@oxlint/binding-win32-arm64-msvc": "1.52.0", "@oxlint/binding-win32-ia32-msvc": "1.52.0", "@oxlint/binding-win32-x64-msvc": "1.52.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-InLldD+6+3iHJGIrtU1W37UIpsg+xoGCemkZCuSQhxUO3evMX+L872ONvbECyRza9k7ScMCukJIK3Al/2ZMDnQ=="],
+
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -343,6 +425,8 @@
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,26 @@
 {
   "name": "create-prisma",
   "version": "0.2.0",
+  "private": false,
   "description": "Create Prisma 7 projects with first-party templates and great DX.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/prisma/create-prisma"
-  },
   "homepage": "https://github.com/prisma/create-prisma",
   "bugs": {
     "url": "https://github.com/prisma/create-prisma/issues"
   },
-  "private": false,
-  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/create-prisma"
+  },
   "bin": {
     "create-prisma": "dist/cli.mjs"
   },
+  "files": [
+    "dist",
+    "templates",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
@@ -26,21 +32,14 @@
       "import": "./dist/cli.mjs"
     }
   },
-  "files": [
-    "dist",
-    "templates",
-    "README.md",
-    "CHANGELOG.md"
-  ],
-  "engines": {
-    "node": ">=18.0.0",
-    "bun": ">=1.3.0"
-  },
-  "packageManager": "bun@1.3.9",
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
+    "lint": "oxlint . --deny-warnings",
+    "lint:fix": "oxlint . --fix",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
     "bump": "bun run scripts/bump-version.ts",
     "release": "bun run bump",
@@ -60,7 +59,14 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.3.0",
     "changelogithub": "^14.0.0",
+    "oxfmt": "^0.37.0",
+    "oxlint": "^1.52.0",
     "tsdown": "^0.20.3",
     "typescript": "^5.9.3"
-  }
+  },
+  "engines": {
+    "bun": ">=1.3.0",
+    "node": ">=18.0.0"
+  },
+  "packageManager": "bun@1.3.9"
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
+    "check": "bun run format:check && bun run lint",
     "lint": "oxlint . --deny-warnings",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt --write .",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,18 +1,8 @@
-import {
-  cancel,
-  intro,
-  isCancel,
-  log,
-  select,
-  spinner,
-  text,
-} from "@clack/prompts";
+import { cancel, intro, isCancel, log, select, spinner, text } from "@clack/prompts";
 import fs from "fs-extra";
 import path from "node:path";
 
-import {
-  scaffoldCreateTemplate,
-} from "../templates/render-create-template";
+import { scaffoldCreateTemplate } from "../templates/render-create-template";
 import {
   CreateCommandInputSchema,
   CreateTemplateSchema,
@@ -22,10 +12,7 @@ import {
   type CreateTemplate,
   type SchemaPreset,
 } from "../types";
-import {
-  collectPrismaSetupContext,
-  executePrismaSetupContext,
-} from "../tasks/setup-prisma";
+import { collectPrismaSetupContext, executePrismaSetupContext } from "../tasks/setup-prisma";
 import {
   collectCreateAddonSetupContext,
   executeCreateAddonSetupContext,
@@ -173,16 +160,12 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
 
     await executeCreateContext(context);
   } catch (error) {
-    cancel(
-      `Create command failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
+    cancel(`Create command failed: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
 async function collectCreateContext(
-  input: CreateCommandInput
+  input: CreateCommandInput,
 ): Promise<CreatePromptContext | undefined> {
   const useDefaults = input.yes === true;
   const force = input.force === true;
@@ -194,8 +177,7 @@ async function collectCreateContext(
   }
 
   const template =
-    input.template ??
-    (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate());
+    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate());
   if (!template) {
     return;
   }
@@ -205,20 +187,16 @@ async function collectCreateContext(
   if (targetPathState.exists && !targetPathState.isDirectory) {
     cancel(
       `Target path ${formatPathForDisplay(
-        targetDirectory
-      )} already exists and is not a directory. Choose a different project name.`
+        targetDirectory,
+      )} already exists and is not a directory. Choose a different project name.`,
     );
     return;
   }
-  if (
-    targetPathState.exists &&
-    !targetPathState.isEmptyDirectory &&
-    !force
-  ) {
+  if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
     cancel(
       `Target directory ${formatPathForDisplay(
-        targetDirectory
-      )} is not empty. Use --force to continue.`
+        targetDirectory,
+      )} is not empty. Use --force to continue.`,
     );
     return;
   }
@@ -277,7 +255,7 @@ async function executeCreateContext(context: CreatePromptContext): Promise<void>
     context.force
   ) {
     log.warn(
-      `Used --force in non-empty directory ${formatPathForDisplay(context.targetDirectory)}.`
+      `Used --force in non-empty directory ${formatPathForDisplay(context.targetDirectory)}.`,
     );
   }
 

--- a/src/constants/db-packages.ts
+++ b/src/constants/db-packages.ts
@@ -17,9 +17,7 @@ export function getDbPackages(provider: DatabaseProvider): DbPackages {
       return { adapterPackage: "@prisma/adapter-mssql" };
     default: {
       const exhaustiveCheck: never = provider;
-      throw new Error(
-        `Unsupported database provider: ${String(exhaustiveCheck)}`
-      );
+      throw new Error(`Unsupported database provider: ${String(exhaustiveCheck)}`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { os } from "@orpc/server";
 import { createCli } from "trpc-cli";
 
 import { runCreateCommand } from "./commands/create";
-import {
-  CreateCommandInputSchema,
-  type CreateCommandInput,
-} from "./types";
+import { CreateCommandInputSchema, type CreateCommandInput } from "./types";
 
 const CLI_VERSION = process.env.CREATE_PRISMA_CLI_VERSION ?? "0.0.0";
 

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -3,16 +3,9 @@ import fs from "fs-extra";
 import path from "node:path";
 
 import { getDenoPrismaSpecifier } from "../utils/package-manager";
-import {
-  dependencyVersionMap,
-  type AvailableDependency,
-} from "../constants/dependencies";
+import { dependencyVersionMap, type AvailableDependency } from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
-import type {
-  DatabaseProvider,
-  DependencyWriteResult,
-  PackageManager,
-} from "../types";
+import type { DatabaseProvider, DependencyWriteResult, PackageManager } from "../types";
 import { getInstallArgs } from "../utils/package-manager";
 
 function getPrismaScriptMap(packageManager: PackageManager) {
@@ -44,9 +37,7 @@ function unique(items: string[]): string[] {
 }
 
 function sortRecord(record: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(record).sort(([a], [b]) => a.localeCompare(b))
-  );
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
 }
 
 export async function addPackageDependency(opts: {
@@ -76,7 +67,7 @@ export async function addPackageDependency(opts: {
   const pkgJsonPath = path.join(projectDir, "package.json");
   if (!(await fs.pathExists(pkgJsonPath))) {
     throw new Error(
-      `No package.json found in ${projectDir}. Run this command inside an existing JavaScript/TypeScript project.`
+      `No package.json found in ${projectDir}. Run this command inside an existing JavaScript/TypeScript project.`,
     );
   }
 
@@ -100,9 +91,7 @@ export async function addPackageDependency(opts: {
     if (version) {
       pkgJson.devDependencies[pkgName] = version;
     } else {
-      console.warn(
-        `Warning: Dev dependency ${pkgName} not found in version map.`
-      );
+      console.warn(`Warning: Dev dependency ${pkgName} not found in version map.`);
     }
   }
 
@@ -152,7 +141,7 @@ export async function addPackageDependency(opts: {
 export async function writePrismaDependencies(
   provider: DatabaseProvider,
   packageManager: PackageManager,
-  projectDir = process.cwd()
+  projectDir = process.cwd(),
 ): Promise<DependencyWriteResult> {
   const dependencies: string[] = ["@prisma/client", "dotenv"];
   const devDependencies: string[] = ["prisma"];
@@ -188,7 +177,7 @@ export async function installProjectDependencies(
   projectDir = process.cwd(),
   options: {
     verbose?: boolean;
-  } = {}
+  } = {},
 ): Promise<void> {
   const verbose = options.verbose === true;
   const installCommand = getInstallArgs(packageManager);

--- a/src/tasks/prisma-postgres.ts
+++ b/src/tasks/prisma-postgres.ts
@@ -1,10 +1,7 @@
 import { execa } from "execa";
 
 import type { PackageManager, PrismaPostgresResult } from "../types";
-import {
-  getPackageExecutionArgs,
-  getPackageExecutionCommand,
-} from "../utils/package-manager";
+import { getPackageExecutionArgs, getPackageExecutionCommand } from "../utils/package-manager";
 
 type CreateDbJsonPayload = {
   success?: boolean;
@@ -56,10 +53,7 @@ function pickConnectionString(payload: CreateDbJsonPayload): string | undefined 
   return undefined;
 }
 
-function extractErrorMessage(
-  payload: CreateDbJsonPayload,
-  fallback: string
-): string {
+function extractErrorMessage(payload: CreateDbJsonPayload, fallback: string): string {
   if (typeof payload.message === "string" && payload.message.length > 0) {
     return payload.message;
   }
@@ -73,11 +67,9 @@ function extractErrorMessage(
 
 export async function provisionPrismaPostgres(
   packageManager: PackageManager,
-  projectDir = process.cwd()
+  projectDir = process.cwd(),
 ): Promise<PrismaPostgresResult> {
-  const command = getPackageExecutionArgs(packageManager, [
-    ...CREATE_DB_COMMAND_ARGS,
-  ]);
+  const command = getPackageExecutionArgs(packageManager, [...CREATE_DB_COMMAND_ARGS]);
   const commandString = getCreateDbCommand(packageManager);
 
   let stdout: string;

--- a/src/tasks/setup-addons.ts
+++ b/src/tasks/setup-addons.ts
@@ -1,11 +1,4 @@
-import {
-  cancel,
-  isCancel,
-  log,
-  multiselect,
-  select,
-  spinner,
-} from "@clack/prompts";
+import { cancel, isCancel, log, multiselect, select, spinner } from "@clack/prompts";
 import { execa } from "execa";
 
 import type {
@@ -18,9 +11,7 @@ import type {
   PackageManager,
   PrismaSkillName,
 } from "../types";
-import {
-  getPackageExecutionArgs,
-} from "../utils/package-manager";
+import { getPackageExecutionArgs } from "../utils/package-manager";
 
 type AgentOption = {
   value: string;
@@ -198,7 +189,7 @@ function uniqueValues<T>(values: T[]): T[] {
 
 function getRecommendedPrismaSkills(
   provider: DatabaseProvider,
-  shouldUsePrismaPostgres: boolean
+  shouldUsePrismaPostgres: boolean,
 ): PrismaSkillName[] {
   const skills = [...getAvailablePrismaSkills(provider)];
 
@@ -252,7 +243,7 @@ async function promptForAddonScope(): Promise<AddonInstallScope | undefined> {
 
 async function promptForPrismaSkills(
   provider: DatabaseProvider,
-  recommendedSkills: PrismaSkillName[]
+  recommendedSkills: PrismaSkillName[],
 ): Promise<PrismaSkillName[] | undefined> {
   const options = getSkillOptions(provider);
   const optionValues = new Set(options.map((option) => option.value));
@@ -325,12 +316,10 @@ export async function collectCreateAddonSetupContext(
     useDefaults: boolean;
     provider: DatabaseProvider;
     shouldUsePrismaPostgres: boolean;
-  }
+  },
 ): Promise<CreateAddonSetupContext | null | undefined> {
   const hasExplicitAddonSelection =
-    input.skills !== undefined ||
-    input.mcp !== undefined ||
-    input.extension !== undefined;
+    input.skills !== undefined || input.mcp !== undefined || input.extension !== undefined;
   const selectedFromInput = collectAddonsFromInput(input);
   const selectedAddons =
     selectedFromInput.length > 0
@@ -361,44 +350,40 @@ export async function collectCreateAddonSetupContext(
 
   const recommendedSkills = getRecommendedPrismaSkills(
     options.provider,
-    options.shouldUsePrismaPostgres
+    options.shouldUsePrismaPostgres,
   );
-  const skills =
-    !addons.includes("skills")
-      ? []
-      : options.useDefaults
-        ? recommendedSkills
-        : await promptForPrismaSkills(options.provider, recommendedSkills);
+  const skills = !addons.includes("skills")
+    ? []
+    : options.useDefaults
+      ? recommendedSkills
+      : await promptForPrismaSkills(options.provider, recommendedSkills);
   if (!skills) {
     return undefined;
   }
 
-  const skillsAgents =
-    !addons.includes("skills")
-      ? []
-      : options.useDefaults
-        ? [...DEFAULT_SKILLS_AGENTS]
-        : await promptForSkillsAgents();
+  const skillsAgents = !addons.includes("skills")
+    ? []
+    : options.useDefaults
+      ? [...DEFAULT_SKILLS_AGENTS]
+      : await promptForSkillsAgents();
   if (!skillsAgents) {
     return undefined;
   }
 
-  const mcpAgents =
-    !addons.includes("mcp")
-      ? []
-      : options.useDefaults
-        ? [...DEFAULT_MCP_AGENTS]
-        : await promptForMcpAgents();
+  const mcpAgents = !addons.includes("mcp")
+    ? []
+    : options.useDefaults
+      ? [...DEFAULT_MCP_AGENTS]
+      : await promptForMcpAgents();
   if (!mcpAgents) {
     return undefined;
   }
 
-  const extensionTargets =
-    !addons.includes("extension")
-      ? []
-      : options.useDefaults
-        ? [...DEFAULT_EXTENSION_TARGETS]
-        : await promptForExtensionTargets();
+  const extensionTargets = !addons.includes("extension")
+    ? []
+    : options.useDefaults
+      ? [...DEFAULT_EXTENSION_TARGETS]
+      : await promptForExtensionTargets();
   if (!extensionTargets) {
     return undefined;
   }
@@ -464,9 +449,7 @@ async function installSkillsAddon(params: {
     });
     return;
   } catch (error) {
-    return `Skills addon failed: ${
-      error instanceof Error ? error.message : String(error)
-    }`;
+    return `Skills addon failed: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
 
@@ -504,9 +487,7 @@ async function installMcpAddon(params: {
     });
     return;
   } catch (error) {
-    return `MCP addon failed: ${
-      error instanceof Error ? error.message : String(error)
-    }`;
+    return `MCP addon failed: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
 
@@ -548,7 +529,7 @@ async function installExtensionAddon(params: {
       });
     } catch {
       warnings.push(
-        `Skipped ${target} extension install because the \`${binary}\` CLI is not available.`
+        `Skipped ${target} extension install because the \`${binary}\` CLI is not available.`,
       );
       continue;
     }
@@ -564,7 +545,7 @@ async function installExtensionAddon(params: {
       warnings.push(
         `${target} extension install failed: ${
           error instanceof Error ? error.message : String(error)
-        }`
+        }`,
       );
     }
   }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -1,20 +1,9 @@
-import {
-  cancel,
-  confirm,
-  isCancel,
-  log,
-  outro,
-  select,
-  spinner,
-} from "@clack/prompts";
+import { cancel, confirm, isCancel, log, outro, select, spinner } from "@clack/prompts";
 import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
-import {
-  installProjectDependencies,
-  writePrismaDependencies,
-} from "./install";
+import { installProjectDependencies, writePrismaDependencies } from "./install";
 import {
   getCreateDbCommand,
   PRISMA_POSTGRES_TEMPORARY_NOTICE,
@@ -99,7 +88,7 @@ async function promptForDatabaseProvider(): Promise<DatabaseProvider | undefined
 
 function getPackageManagerHint(
   option: PackageManager,
-  detected: PackageManager
+  detected: PackageManager,
 ): string | undefined {
   if (option === detected) {
     return "Detected";
@@ -117,7 +106,7 @@ function getPackageManagerHint(
 }
 
 async function promptForPackageManager(
-  detectedPackageManager: PackageManager
+  detectedPackageManager: PackageManager,
 ): Promise<PackageManager | undefined> {
   const packageManager = await select({
     message: "Choose package manager",
@@ -160,7 +149,7 @@ async function promptForPackageManager(
 }
 
 async function promptForDependencyInstall(
-  packageManager: PackageManager
+  packageManager: PackageManager,
 ): Promise<boolean | undefined> {
   const installCommand = getInstallCommand(packageManager);
   const shouldInstall = await confirm({
@@ -178,8 +167,7 @@ async function promptForDependencyInstall(
 
 async function promptForPrismaPostgres(): Promise<boolean | undefined> {
   const shouldUsePrismaPostgres = await confirm({
-    message:
-      "Use Prisma Postgres and auto-generate DATABASE_URL with create-db?",
+    message: "Use Prisma Postgres and auto-generate DATABASE_URL with create-db?",
     initialValue: true,
   });
 
@@ -207,7 +195,7 @@ export async function collectPrismaSetupContext(
   options: {
     projectDir?: string;
     defaultSchemaPreset?: SchemaPreset;
-  } = {}
+  } = {},
 ): Promise<PrismaSetupContext | undefined> {
   const projectDir = path.resolve(options.projectDir ?? process.cwd());
   const useDefaults = input.yes === true;
@@ -215,14 +203,12 @@ export async function collectPrismaSetupContext(
   const shouldGenerate = input.generate ?? DEFAULT_GENERATE;
 
   const databaseProvider =
-    input.provider ??
-    (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider());
+    input.provider ?? (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider());
   if (!databaseProvider) {
     return;
   }
 
-  const schemaPreset =
-    input.schemaPreset ?? options.defaultSchemaPreset ?? DEFAULT_SCHEMA_PRESET;
+  const schemaPreset = input.schemaPreset ?? options.defaultSchemaPreset ?? DEFAULT_SCHEMA_PRESET;
 
   const databaseUrl = input.databaseUrl;
   let shouldUsePrismaPostgres = false;
@@ -241,18 +227,14 @@ export async function collectPrismaSetupContext(
   const detectedPackageManager = await detectPackageManager(projectDir);
   const packageManager =
     input.packageManager ??
-    (useDefaults
-      ? detectedPackageManager
-      : await promptForPackageManager(detectedPackageManager));
+    (useDefaults ? detectedPackageManager : await promptForPackageManager(detectedPackageManager));
   if (!packageManager) {
     return;
   }
 
   const shouldInstall =
     input.install ??
-    (useDefaults
-      ? DEFAULT_INSTALL
-      : await promptForDependencyInstall(packageManager));
+    (useDefaults ? DEFAULT_INSTALL : await promptForDependencyInstall(packageManager));
   if (shouldInstall === undefined) {
     return;
   }
@@ -309,9 +291,7 @@ function hasEnvVar(content: string, envVarName: string): boolean {
 
 function hasEnvComment(content: string, comment: string): boolean {
   const escapedComment = escapeRegExp(comment);
-  return new RegExp(`(^|\\n)\\s*#\\s*${escapedComment}\\s*(?=\\n|$)`).test(
-    content
-  );
+  return new RegExp(`(^|\\n)\\s*#\\s*${escapedComment}\\s*(?=\\n|$)`).test(content);
 }
 
 async function ensureEnvVarInEnv(
@@ -321,15 +301,13 @@ async function ensureEnvVarInEnv(
   opts: {
     mode: EnvWriteMode;
     comment?: string;
-  }
+  },
 ): Promise<{ envPath: string; status: EnvStatus }> {
   const envPath = path.join(projectDir, ".env");
   const envLine = `${envVarName}="${escapeEnvValue(envVarValue)}"`;
 
   if (!(await fs.pathExists(envPath))) {
-    const content = opts.comment
-      ? `# ${opts.comment}\n${envLine}\n`
-      : `${envLine}\n`;
+    const content = opts.comment ? `# ${opts.comment}\n${envLine}\n` : `${envLine}\n`;
     await fs.writeFile(envPath, content, "utf8");
     return { envPath, status: "created" };
   }
@@ -341,10 +319,7 @@ async function ensureEnvVarInEnv(
     }
 
     const escapedName = escapeRegExp(envVarName);
-    const lineRegex = new RegExp(
-      `(^|\\n)\\s*${escapedName}\\s*=.*(?=\\n|$)`,
-      "gm"
-    );
+    const lineRegex = new RegExp(`(^|\\n)\\s*${escapedName}\\s*=.*(?=\\n|$)`, "gm");
     const updatedContent = existingContent.replace(lineRegex, `$1${envLine}`);
     if (updatedContent === existingContent) {
       return { envPath, status: "existing" };
@@ -362,10 +337,7 @@ async function ensureEnvVarInEnv(
   return { envPath, status: "appended" };
 }
 
-async function ensureEnvComment(
-  projectDir: string,
-  comment: string
-): Promise<void> {
+async function ensureEnvComment(projectDir: string, comment: string): Promise<void> {
   const envPath = path.join(projectDir, ".env");
   const commentLine = `# ${comment}`;
 
@@ -389,13 +361,13 @@ function hasGitignoreEntry(content: string, entry: string): boolean {
   const escapedWithTrailingSlash = escapeRegExp(`${entry}/`);
   const escapedWithLeadingAndTrailingSlash = escapeRegExp(`/${entry}/`);
   return new RegExp(
-    `(^|\\n)\\s*(?:${escapedEntry}|${escapedWithLeadingSlash}|${escapedWithTrailingSlash}|${escapedWithLeadingAndTrailingSlash})\\s*(?=\\n|$)`
+    `(^|\\n)\\s*(?:${escapedEntry}|${escapedWithLeadingSlash}|${escapedWithTrailingSlash}|${escapedWithLeadingAndTrailingSlash})\\s*(?=\\n|$)`,
   ).test(content);
 }
 
 async function ensureGitignoreEntry(
   projectDir: string,
-  entry: string
+  entry: string,
 ): Promise<{ gitignorePath: string; status: FileAppendStatus }> {
   const gitignorePath = path.join(projectDir, ".gitignore");
 
@@ -434,15 +406,11 @@ async function ensureRequiredPrismaFiles(projectDir: string): Promise<void> {
   }
 
   if (missingFiles.length > 0) {
-    throw new Error(
-      `Template is missing required Prisma files: ${missingFiles.join(", ")}`
-    );
+    throw new Error(`Template is missing required Prisma files: ${missingFiles.join(", ")}`);
   }
 }
 
-async function finalizePrismaFiles(
-  options: FinalizePrismaOptions
-): Promise<FinalizePrismaResult> {
+async function finalizePrismaFiles(options: FinalizePrismaOptions): Promise<FinalizePrismaResult> {
   const projectDir = options.projectDir ?? process.cwd();
   const prismaProjectDir = await resolvePrismaProjectDir(projectDir);
   const schemaPath = path.join(prismaProjectDir, "prisma/schema.prisma");
@@ -453,38 +421,27 @@ async function finalizePrismaFiles(
     ? path.join(prismaProjectDir, "src/lib/prisma.ts")
     : (await fs.pathExists(path.join(prismaProjectDir, "src/lib/prisma.server.ts")))
       ? path.join(prismaProjectDir, "src/lib/prisma.server.ts")
-    : (await fs.pathExists(path.join(prismaProjectDir, "src/lib/server/prisma.ts")))
-      ? path.join(prismaProjectDir, "src/lib/server/prisma.ts")
-      : (await fs.pathExists(path.join(prismaProjectDir, "server/utils/prisma.ts")))
-        ? path.join(prismaProjectDir, "server/utils/prisma.ts")
-        : path.join(prismaProjectDir, "src/client.ts");
+      : (await fs.pathExists(path.join(prismaProjectDir, "src/lib/server/prisma.ts")))
+        ? path.join(prismaProjectDir, "src/lib/server/prisma.ts")
+        : (await fs.pathExists(path.join(prismaProjectDir, "server/utils/prisma.ts")))
+          ? path.join(prismaProjectDir, "server/utils/prisma.ts")
+          : path.join(prismaProjectDir, "src/client.ts");
   const generatedDir = (await fs.pathExists(path.join(prismaProjectDir, "server/utils/prisma.ts")))
     ? "server/generated"
     : "src/generated";
 
-  const databaseUrl =
-    options.databaseUrl ?? getDefaultDatabaseUrl(options.provider);
-  const envResult = await ensureEnvVarInEnv(
-    prismaProjectDir,
-    "DATABASE_URL",
-    databaseUrl,
-    {
-      mode: options.databaseUrl ? "upsert" : "keep-existing",
-      comment: "Added by create-prisma",
-    }
-  );
+  const databaseUrl = options.databaseUrl ?? getDefaultDatabaseUrl(options.provider);
+  const envResult = await ensureEnvVarInEnv(prismaProjectDir, "DATABASE_URL", databaseUrl, {
+    mode: options.databaseUrl ? "upsert" : "keep-existing",
+    comment: "Added by create-prisma",
+  });
 
   let claimEnvStatus: EnvStatus | undefined;
   if (options.claimUrl) {
-    const claimResult = await ensureEnvVarInEnv(
-      prismaProjectDir,
-      "CLAIM_URL",
-      options.claimUrl,
-      {
-        mode: "upsert",
-        comment: PRISMA_POSTGRES_TEMPORARY_NOTICE,
-      }
-    );
+    const claimResult = await ensureEnvVarInEnv(prismaProjectDir, "CLAIM_URL", options.claimUrl, {
+      mode: "upsert",
+      comment: PRISMA_POSTGRES_TEMPORARY_NOTICE,
+    });
     claimEnvStatus = claimResult.status;
     await ensureEnvComment(prismaProjectDir, PRISMA_POSTGRES_TEMPORARY_NOTICE);
   }
@@ -505,7 +462,7 @@ async function finalizePrismaFiles(
 
 async function provisionPrismaPostgresIfNeeded(
   context: PrismaSetupContext,
-  projectDir: string
+  projectDir: string,
 ): Promise<PrismaPostgresProvisionResult | undefined> {
   if (!context.shouldUsePrismaPostgres) {
     return {
@@ -515,13 +472,10 @@ async function provisionPrismaPostgresIfNeeded(
 
   const createDbCommand = getCreateDbCommand(context.packageManager);
   const prismaPostgresSpinner = spinner();
-  prismaPostgresSpinner.start(
-    `Provisioning Prisma Postgres with ${createDbCommand}...`
-  );
+  prismaPostgresSpinner.start(`Provisioning Prisma Postgres with ${createDbCommand}...`);
 
   try {
-    const prismaPostgresResult =
-      await provisionPrismaPostgres(context.packageManager, projectDir);
+    const prismaPostgresResult = await provisionPrismaPostgres(context.packageManager, projectDir);
 
     prismaPostgresSpinner.stop("Prisma Postgres database provisioned.");
     return {
@@ -541,14 +495,14 @@ async function provisionPrismaPostgresIfNeeded(
 
 async function writeDependenciesForContext(
   context: PrismaSetupContext,
-  projectDir: string
+  projectDir: string,
 ): Promise<DependencyWriteResult | undefined> {
   const prismaProjectDir = await resolvePrismaProjectDir(projectDir);
   try {
     return await writePrismaDependencies(
       context.databaseProvider,
       context.packageManager,
-      prismaProjectDir
+      prismaProjectDir,
     );
   } catch (error) {
     cancel(getCommandErrorMessage(error));
@@ -558,7 +512,7 @@ async function writeDependenciesForContext(
 
 async function installDependenciesForContext(
   context: PrismaSetupContext,
-  projectDir: string
+  projectDir: string,
 ): Promise<boolean> {
   if (!context.shouldInstall) {
     return true;
@@ -597,7 +551,7 @@ async function installDependenciesForContext(
 async function finalizePrismaFilesForContext(
   context: PrismaSetupContext,
   projectDir: string,
-  provisionResult: PrismaPostgresProvisionResult
+  provisionResult: PrismaPostgresProvisionResult,
 ): Promise<FinalizePrismaResult | undefined> {
   const initSpinner = spinner();
   initSpinner.start("Preparing Prisma files...");
@@ -621,7 +575,7 @@ async function finalizePrismaFilesForContext(
 
 async function generatePrismaClientForContext(
   context: PrismaSetupContext,
-  projectDir: string
+  projectDir: string,
 ): Promise<PrismaGenerateResult> {
   const prismaProjectDir = await resolvePrismaProjectDir(projectDir);
   if (!context.shouldGenerate) {
@@ -630,9 +584,7 @@ async function generatePrismaClientForContext(
     };
   }
 
-  const generateCommand = getPrismaCliCommand(context.packageManager, [
-    "generate",
-  ]);
+  const generateCommand = getPrismaCliCommand(context.packageManager, ["generate"]);
   if (context.verbose) {
     log.step(`Running ${generateCommand}`);
   }
@@ -670,7 +622,7 @@ async function generatePrismaClientForContext(
 
 function buildWarningLines(
   provisionWarning: string | undefined,
-  generateWarning: string | undefined
+  generateWarning: string | undefined,
 ): string[] {
   const warningLines: string[] = [];
 
@@ -709,56 +661,39 @@ function buildNextStepsForContext(opts: {
 
 export async function executePrismaSetupContext(
   context: PrismaSetupContext,
-  options: PrismaSetupRunOptions = {}
+  options: PrismaSetupRunOptions = {},
 ): Promise<PrismaSetupResult | undefined> {
   const projectDir = path.resolve(options.projectDir ?? context.projectDir);
-  const provisionResult = await provisionPrismaPostgresIfNeeded(
-    context,
-    projectDir
-  );
+  const provisionResult = await provisionPrismaPostgresIfNeeded(context, projectDir);
   if (!provisionResult) {
     return;
   }
 
-  const dependencyWriteResult = await writeDependenciesForContext(
-    context,
-    projectDir
-  );
+  const dependencyWriteResult = await writeDependenciesForContext(context, projectDir);
   if (!dependencyWriteResult) {
     return;
   }
 
-  const dependenciesInstalled = await installDependenciesForContext(
-    context,
-    projectDir
-  );
+  const dependenciesInstalled = await installDependenciesForContext(context, projectDir);
   if (!dependenciesInstalled) {
     return;
   }
 
-  const finalizeResult = await finalizePrismaFilesForContext(
-    context,
-    projectDir,
-    provisionResult
-  );
+  const finalizeResult = await finalizePrismaFilesForContext(context, projectDir, provisionResult);
   if (!finalizeResult) {
     return;
   }
 
   const generateResult = await generatePrismaClientForContext(context, projectDir);
 
-  const warningLines = buildWarningLines(
-    provisionResult.warning,
-    generateResult.warning
-  );
+  const warningLines = buildWarningLines(provisionResult.warning, generateResult.warning);
   const nextSteps = buildNextStepsForContext({
     context,
     options,
     didGenerateClient: generateResult.didGenerateClient,
   });
 
-  const warningSection =
-    warningLines.length > 0 ? `\n\n${warningLines.join("\n")}` : "";
+  const warningSection = warningLines.length > 0 ? `\n\n${warningLines.join("\n")}` : "";
 
   outro(`Setup complete.${warningSection}
 

--- a/src/templates/render-create-template.ts
+++ b/src/templates/render-create-template.ts
@@ -5,10 +5,7 @@ import type {
   PackageManager,
   SchemaPreset,
 } from "../types";
-import {
-  renderTemplateTree,
-  resolveTemplatesDir,
-} from "./shared";
+import { renderTemplateTree, resolveTemplatesDir } from "./shared";
 
 function getCreateTemplateDir(template: CreateTemplate): string {
   return resolveTemplatesDir(`templates/create/${template}`);
@@ -18,7 +15,7 @@ function createTemplateContext(
   projectName: string,
   provider: DatabaseProvider,
   schemaPreset: SchemaPreset,
-  packageManager?: PackageManager
+  packageManager?: PackageManager,
 ): CreateTemplateContext {
   return {
     projectName,
@@ -36,21 +33,9 @@ export async function scaffoldCreateTemplate(opts: {
   schemaPreset: SchemaPreset;
   packageManager?: PackageManager;
 }): Promise<void> {
-  const {
-    projectDir,
-    projectName,
-    template,
-    provider,
-    schemaPreset,
-    packageManager,
-  } = opts;
+  const { projectDir, projectName, template, provider, schemaPreset, packageManager } = opts;
   const templateRoot = getCreateTemplateDir(template);
-  const context = createTemplateContext(
-    projectName,
-    provider,
-    schemaPreset,
-    packageManager
-  );
+  const context = createTemplateContext(projectName, provider, schemaPreset, packageManager);
   await renderTemplateTree<CreateTemplateContext>({
     templateRoot,
     outputDir: projectDir,

--- a/src/templates/shared.ts
+++ b/src/templates/shared.ts
@@ -12,20 +12,18 @@ import {
 } from "../utils/package-manager";
 
 Handlebars.registerHelper("eq", (left: unknown, right: unknown) => left === right);
-Handlebars.registerHelper(
-  "installCommand",
-  (packageManager: PackageManager | undefined) =>
-    packageManager ? getInstallCommand(packageManager) : ""
+Handlebars.registerHelper("installCommand", (packageManager: PackageManager | undefined) =>
+  packageManager ? getInstallCommand(packageManager) : "",
 );
 Handlebars.registerHelper(
   "runScriptCommand",
   (packageManager: PackageManager | undefined, scriptName: string) =>
-    packageManager ? getRunScriptCommand(packageManager, scriptName) : ""
+    packageManager ? getRunScriptCommand(packageManager, scriptName) : "",
 );
 Handlebars.registerHelper(
   "packageManagerManifestValue",
   (packageManager: PackageManager | undefined) =>
-    getPackageManagerManifestValue(packageManager) ?? ""
+    getPackageManagerManifestValue(packageManager) ?? "",
 );
 
 export function findPackageRoot(startDir: string): string {
@@ -74,7 +72,7 @@ async function getTemplateFilesRecursively(dir: string): Promise<string[]> {
       }
 
       return [entryPath];
-    })
+    }),
   );
 
   return files.flat();
@@ -102,10 +100,7 @@ export async function renderTemplateFile<TContext>(opts: {
       })(context)
     : templateContent;
 
-  if (
-    templateFilePath.endsWith(".hbs") &&
-    outputContent.trim().length === 0
-  ) {
+  if (templateFilePath.endsWith(".hbs") && outputContent.trim().length === 0) {
     return;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,53 +47,34 @@ export type ExtensionTarget = z.infer<typeof ExtensionTargetSchema>;
 export const PrismaSkillNameSchema = z.enum(prismaSkillNames);
 export type PrismaSkillName = z.infer<typeof PrismaSkillNameSchema>;
 
-export const DatabaseUrlSchema = z
-  .string()
-  .trim()
-  .min(1, "Please enter a valid database URL");
+export const DatabaseUrlSchema = z.string().trim().min(1, "Please enter a valid database URL");
 
 export const CommonCommandOptionsSchema = z.object({
-  yes: z
-    .boolean()
-    .optional()
-    .describe("Skip prompts and accept default choices"),
-  verbose: z
-    .boolean()
-    .optional()
-    .describe("Show verbose command output during setup"),
+  yes: z.boolean().optional().describe("Skip prompts and accept default choices"),
+  verbose: z.boolean().optional().describe("Show verbose command output during setup"),
 });
 
 export const PrismaSetupOptionsSchema = z.object({
   provider: DatabaseProviderSchema.optional().describe("Database provider"),
   packageManager: PackageManagerSchema.optional().describe(
-    "Package manager used for dependency installation"
+    "Package manager used for dependency installation",
   ),
   prismaPostgres: z
     .boolean()
     .optional()
-    .describe(
-      "Provision Prisma Postgres with create-db when provider is postgresql"
-    ),
+    .describe("Provision Prisma Postgres with create-db when provider is postgresql"),
   databaseUrl: DatabaseUrlSchema.optional().describe("DATABASE_URL value"),
-  install: z
-    .boolean()
-    .optional()
-    .describe("Install dependencies with selected package manager"),
-  generate: z
-    .boolean()
-    .optional()
-    .describe("Generate Prisma Client after scaffolding"),
+  install: z.boolean().optional().describe("Install dependencies with selected package manager"),
+  generate: z.boolean().optional().describe("Generate Prisma Client after scaffolding"),
   schemaPreset: SchemaPresetSchema.optional().describe(
-    "Schema preset to scaffold in prisma/schema.prisma"
+    "Schema preset to scaffold in prisma/schema.prisma",
   ),
 });
 
 export const PrismaSetupCommandInputSchema = CommonCommandOptionsSchema.extend(
-  PrismaSetupOptionsSchema.shape
+  PrismaSetupOptionsSchema.shape,
 );
-export type PrismaSetupCommandInput = z.infer<
-  typeof PrismaSetupCommandInputSchema
->;
+export type PrismaSetupCommandInput = z.infer<typeof PrismaSetupCommandInputSchema>;
 
 export const CreateScaffoldOptionsSchema = z.object({
   name: z
@@ -103,26 +84,14 @@ export const CreateScaffoldOptionsSchema = z.object({
     .optional()
     .describe("Project name / directory"),
   template: CreateTemplateSchema.optional().describe("Project template"),
-  skills: z
-    .boolean()
-    .optional()
-    .describe("Enable skills addon"),
-  mcp: z
-    .boolean()
-    .optional()
-    .describe("Enable MCP addon"),
-  extension: z
-    .boolean()
-    .optional()
-    .describe("Enable extension addon"),
-  force: z
-    .boolean()
-    .optional()
-    .describe("Allow scaffolding into a non-empty target directory"),
+  skills: z.boolean().optional().describe("Enable skills addon"),
+  mcp: z.boolean().optional().describe("Enable MCP addon"),
+  extension: z.boolean().optional().describe("Enable extension addon"),
+  force: z.boolean().optional().describe("Allow scaffolding into a non-empty target directory"),
 });
 
 export const CreateCommandInputSchema = PrismaSetupCommandInputSchema.extend(
-  CreateScaffoldOptionsSchema.shape
+  CreateScaffoldOptionsSchema.shape,
 );
 export type CreateCommandInput = z.infer<typeof CreateCommandInputSchema>;
 

--- a/src/ui/branding.ts
+++ b/src/ui/branding.ts
@@ -2,7 +2,7 @@ import { styleText } from "node:util";
 
 const prismaTitle = `${styleText(["bold", "cyan"], "Create")} ${styleText(
   ["bold", "magenta"],
-  "Prisma"
+  "Prisma",
 )}`;
 
 export function getCreatePrismaIntro(): string {

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -2,10 +2,7 @@ import fs from "fs-extra";
 import path from "node:path";
 
 import { dependencyVersionMap } from "../constants/dependencies";
-import {
-  PackageManagerSchema,
-  type PackageManager,
-} from "../types";
+import { PackageManagerSchema, type PackageManager } from "../types";
 
 type CommandAndArgs = {
   command: string;
@@ -43,9 +40,7 @@ function parseUserAgent(userAgent: string | undefined): PackageManager | null {
   return null;
 }
 
-function parsePackageManagerField(
-  packageManagerField: unknown
-): PackageManager | null {
+function parsePackageManagerField(packageManagerField: unknown): PackageManager | null {
   if (typeof packageManagerField !== "string" || packageManagerField.length === 0) {
     return null;
   }
@@ -55,9 +50,7 @@ function parsePackageManagerField(
   return parsed.success ? parsed.data : null;
 }
 
-async function detectFromPackageJson(
-  projectDir: string
-): Promise<PackageManager | null> {
+async function detectFromPackageJson(projectDir: string): Promise<PackageManager | null> {
   const packageJsonPath = path.join(projectDir, "package.json");
   if (!(await fs.pathExists(packageJsonPath))) {
     return null;
@@ -67,9 +60,7 @@ async function detectFromPackageJson(
   return parsePackageManagerField(packageJson.packageManager);
 }
 
-async function detectFromDenoConfig(
-  projectDir: string
-): Promise<PackageManager | null> {
+async function detectFromDenoConfig(projectDir: string): Promise<PackageManager | null> {
   const configCandidates = ["deno.json", "deno.jsonc"];
 
   for (const configFile of configCandidates) {
@@ -81,9 +72,7 @@ async function detectFromDenoConfig(
   return null;
 }
 
-async function detectFromLockfile(
-  projectDir: string
-): Promise<PackageManager | null> {
+async function detectFromLockfile(projectDir: string): Promise<PackageManager | null> {
   const lockfileChecks: Array<{ manager: PackageManager; lockfile: string }> = [
     { manager: "pnpm", lockfile: "pnpm-lock.yaml" },
     { manager: "yarn", lockfile: "yarn.lock" },
@@ -103,9 +92,7 @@ async function detectFromLockfile(
   return null;
 }
 
-export async function detectPackageManager(
-  projectDir = process.cwd()
-): Promise<PackageManager> {
+export async function detectPackageManager(projectDir = process.cwd()): Promise<PackageManager> {
   const fromPackageJson = await detectFromPackageJson(projectDir);
   if (fromPackageJson) {
     return fromPackageJson;
@@ -130,7 +117,7 @@ export async function detectPackageManager(
 }
 
 export function getPackageManagerManifestValue(
-  packageManager: PackageManager | undefined
+  packageManager: PackageManager | undefined,
 ): string | undefined {
   if (!packageManager || packageManager === "deno") {
     return undefined;
@@ -152,10 +139,7 @@ export function getInstallCommand(packageManager: PackageManager): string {
   return `${packageManager} install`;
 }
 
-export function getRunScriptCommand(
-  packageManager: PackageManager,
-  scriptName: string
-): string {
+export function getRunScriptCommand(packageManager: PackageManager, scriptName: string): string {
   switch (packageManager) {
     case "deno":
       return `deno task ${scriptName}`;
@@ -171,9 +155,7 @@ export function getRunScriptCommand(
   }
 }
 
-export function getInstallArgs(
-  packageManager: PackageManager
-): CommandAndArgs {
+export function getInstallArgs(packageManager: PackageManager): CommandAndArgs {
   if (packageManager === "deno") {
     return {
       command: "deno",
@@ -189,7 +171,7 @@ export function getInstallArgs(
 
 export function getPackageExecutionArgs(
   packageManager: PackageManager,
-  commandArgs: string[]
+  commandArgs: string[],
 ): CommandAndArgs {
   switch (packageManager) {
     case "pnpm":
@@ -217,7 +199,7 @@ export function getPackageExecutionArgs(
 
 export function getPackageExecutionCommand(
   packageManager: PackageManager,
-  commandArgs: string[]
+  commandArgs: string[],
 ): string {
   const execution = getPackageExecutionArgs(packageManager, commandArgs);
   return [execution.command, ...execution.args].join(" ");
@@ -225,14 +207,10 @@ export function getPackageExecutionCommand(
 
 export function getPrismaCliArgs(
   packageManager: PackageManager,
-  prismaArgs: string[]
+  prismaArgs: string[],
 ): CommandAndArgs {
   if (packageManager === "bun") {
-    return getPackageExecutionArgs(packageManager, [
-      "--bun",
-      "prisma",
-      ...prismaArgs,
-    ]);
+    return getPackageExecutionArgs(packageManager, ["--bun", "prisma", ...prismaArgs]);
   }
 
   if (packageManager === "deno") {
@@ -245,10 +223,7 @@ export function getPrismaCliArgs(
   return getPackageExecutionArgs(packageManager, ["prisma", ...prismaArgs]);
 }
 
-export function getPrismaCliCommand(
-  packageManager: PackageManager,
-  prismaArgs: string[]
-): string {
+export function getPrismaCliCommand(packageManager: PackageManager, prismaArgs: string[]): string {
   const execution = getPrismaCliArgs(packageManager, prismaArgs);
   return [execution.command, ...execution.args].join(" ");
 }

--- a/templates/create/next/eslint.config.mjs
+++ b/templates/create/next/eslint.config.mjs
@@ -5,12 +5,7 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  globalIgnores([
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);
 
 export default eslintConfig;

--- a/templates/create/next/src/app/globals.css
+++ b/templates/create/next/src/app/globals.css
@@ -12,10 +12,7 @@ html {
 
 body {
   margin: 0;
-  font-family:
-    "Instrument Sans",
-    "Segoe UI",
-    sans-serif;
+  font-family: "Instrument Sans", "Segoe UI", sans-serif;
   background: #f7f8fb;
   color: #0f172a;
 }
@@ -116,10 +113,7 @@ code {
   padding: 0.15rem 0.4rem;
   border-radius: 0.35rem;
   background: #eef2f7;
-  font-family:
-    SFMono-Regular,
-    Consolas,
-    monospace;
+  font-family: SFMono-Regular, Consolas, monospace;
   font-size: 0.95em;
 }
 

--- a/templates/create/svelte/.vscode/extensions.json
+++ b/templates/create/svelte/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["svelte.svelte-vscode"]
+  "recommendations": ["svelte.svelte-vscode"]
 }

--- a/templates/create/svelte/src/app.d.ts
+++ b/templates/create/svelte/src/app.d.ts
@@ -1,13 +1,13 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {
-	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
-	}
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+  }
 }
 
 export {};

--- a/templates/create/svelte/src/app.html
+++ b/templates/create/svelte/src/app.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>

--- a/templates/create/svelte/svelte.config.js
+++ b/templates/create/svelte/svelte.config.js
@@ -1,13 +1,13 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from "@sveltejs/adapter-auto";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
-	}
+  kit: {
+    // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+    // See https://svelte.dev/docs/kit/adapters for more information about adapters.
+    adapter: adapter(),
+  },
 };
 
 export default config;

--- a/templates/create/svelte/tsconfig.json
+++ b/templates/create/svelte/tsconfig.json
@@ -1,20 +1,20 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"rewriteRelativeImportExtensions": true,
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true,
-		"moduleResolution": "bundler"
-	}
-	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
-	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
-	//
-	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "rewriteRelativeImportExtensions": true,
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+  // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+  // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
+  //
+  // To make changes to top-level options such as include and exclude, we recommend extending
+  // the generated config; see https://svelte.dev/docs/kit/configuration#typescript
 }

--- a/templates/create/svelte/vite.config.ts
+++ b/templates/create/svelte/vite.config.ts
@@ -1,6 +1,6 @@
-import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [sveltekit()]
+  plugins: [sveltekit()],
 });

--- a/templates/create/tanstack-start/prisma.config.ts
+++ b/templates/create/tanstack-start/prisma.config.ts
@@ -11,4 +11,3 @@ export default defineConfig({
     url: env("DATABASE_URL"),
   },
 });
-

--- a/templates/create/tanstack-start/src/router.tsx
+++ b/templates/create/tanstack-start/src/router.tsx
@@ -16,4 +16,3 @@ declare module "@tanstack/react-router" {
     router: ReturnType<typeof getRouter>;
   }
 }
-

--- a/templates/create/tanstack-start/src/styles.css
+++ b/templates/create/tanstack-start/src/styles.css
@@ -185,4 +185,3 @@ code {
     align-items: flex-start;
   }
 }
-

--- a/templates/create/tanstack-start/vite.config.ts
+++ b/templates/create/tanstack-start/vite.config.ts
@@ -4,9 +4,5 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({ projects: ["./tsconfig.json"] }),
-    tanstackStart(),
-    viteReact(),
-  ],
+  plugins: [tsconfigPaths({ projects: ["./tsconfig.json"] }), tanstackStart(), viteReact()],
 });

--- a/templates/create/turborepo/apps/api/tsconfig.json
+++ b/templates/create/turborepo/apps/api/tsconfig.json
@@ -11,7 +11,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/templates/create/turborepo/packages/db/tsconfig.json
+++ b/templates/create/turborepo/packages/db/tsconfig.json
@@ -11,9 +11,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": [
-    "src/**/*.ts",
-    "prisma/**/*.ts",
-    "prisma.config.ts"
-  ]
+  "include": ["src/**/*.ts", "prisma/**/*.ts", "prisma.config.ts"]
 }

--- a/templates/create/turborepo/turbo.json
+++ b/templates/create/turborepo/turbo.json
@@ -2,21 +2,15 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
     },
     "dev": {
       "cache": false,
       "persistent": true
     },
     "typecheck": {
-      "dependsOn": [
-        "^typecheck"
-      ]
+      "dependsOn": ["^typecheck"]
     },
     "db:generate": {
       "cache": false


### PR DESCRIPTION
## Summary
- add `oxlint` and `oxfmt` to the repo with `lint`, `lint:fix`, `format`, and `format:check` scripts
- add baseline Oxc config and format the supported repo files
- keep `templates/**/*.hbs` out of `oxfmt` for now because some Handlebars templates do not parse cleanly yet
- update the publish workflow so same-repo PRs automatically publish preview builds to npm with dist-tags like `create-prisma@pr18`
- keep the existing main release flow, but gate it on lint, format check, typecheck, and build

## Preview publish behavior
For a PR like `#18`, GitHub Actions now publishes a unique prerelease version of `create-prisma` and tags it with `pr18` on npm.

That means reviewers can install the latest build for the PR with:
- `bunx create-prisma@pr18`
- `npm install create-prisma@pr18`
- `yarn add create-prisma@pr18`
- `pnpm add create-prisma@pr18`

Each new push to the PR republishes a fresh preview version behind the same `pr18` tag.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR preview npm package publishing with per-PR distribution tags.

* **Documentation**
  * Expanded template support list; added new scripts (check, lint, format) to documentation; clarified preview package publishing workflow.

* **Chores**
  * Integrated code quality and formatting tools; enhanced release workflow with automated version validation and tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->