### PR TITLE
Use runnable commands in PR preview comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,11 +107,11 @@ jobs:
               "",
               `- Version: \`${process.env.PREVIEW_VERSION}\``,
               `- Tag: \`${process.env.DIST_TAG}\``,
-              `- Install with Bun: \`bunx create-prisma@${process.env.DIST_TAG}\``,
-              `- Install with npm: \`npm install create-prisma@${process.env.DIST_TAG}\``,
-              `- Install with Yarn: \`yarn add create-prisma@${process.env.DIST_TAG}\``,
-              `- Install with pnpm: \`pnpm add create-prisma@${process.env.DIST_TAG}\``,
-              `- Install with Deno: \`deno run -A npm:create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with Bun: \`bunx create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with npm: \`npx create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with Yarn: \`yarn dlx create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with pnpm: \`pnpm dlx create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with Deno: \`deno run -A npm:create-prisma@${process.env.DIST_TAG}\``,
               `- Workflow run: ${process.env.RUN_URL}`,
             ].join("\n");
 
@@ -149,8 +149,11 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version: \`${{ steps.preview.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: \`${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Install with Bun: \`bunx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Install with npm: \`npm install create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with Bun: \`bunx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with npm: \`npx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with Yarn: \`yarn dlx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with pnpm: \`pnpm dlx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with Deno: \`deno run -A npm:create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   release:
     name: Release to npm


### PR DESCRIPTION
## Summary
- update the PR preview comment to show runnable commands instead of install commands
- align the Actions step summary with the same runnable commands
- keep the existing sticky PR comment behavior unchanged

## Examples
- `bunx create-prisma@pr17`
- `npx create-prisma@pr17`
- `yarn dlx create-prisma@pr17`
- `pnpm dlx create-prisma@pr17`
- `deno run -A npm:create-prisma@pr17`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager command instructions from "Install with" to "Run with" terminology in automated workflow outputs for Bun, npm, Yarn, pnpm, and Deno.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->