### PR TITLE
Use tsx for Deno Prisma seed

### DIFF
--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -139,6 +139,18 @@ export function getInstallCommand(packageManager: PackageManager): string {
   return `${packageManager} install`;
 }
 
+export function getPrismaSeedCommand(packageManager: PackageManager | undefined): string {
+  switch (packageManager) {
+    case "bun":
+      return "bun prisma/seed.ts";
+    case "deno":
+    case "pnpm":
+    case "yarn":
+    case "npm":
+    default:
+      return "tsx prisma/seed.ts";
+  }
+}
 export function getRunScriptCommand(packageManager: PackageManager, scriptName: string): string {
   switch (packageManager) {
     case "deno":


### PR DESCRIPTION
## Summary
- add a shared Prisma seed command helper
- use `tsx prisma/seed.ts` for Deno seed commands instead of `deno run -A prisma/seed.ts`

## Testing
- bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for package manager-aware Prisma seed command execution, automatically selecting the correct invocation syntax based on your configured package manager (Bun, npm, Yarn, pnpm, or Deno).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->