### PR TITLE
chore: disable telemetry in preview builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,6 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      CREATE_PRISMA_TELEMETRY_API_KEY: ${{ secrets.CREATE_PRISMA_TELEMETRY_API_KEY }}
-      CREATE_PRISMA_TELEMETRY_HOST: ${{ vars.CREATE_PRISMA_TELEMETRY_HOST }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- stop injecting telemetry env vars into the PR preview build job
- keep telemetry enabled for release builds only

## Notes
- this only changes `.github/workflows/publish.yml`
- preview packages will now build without a baked PostHog key
- release packaging remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Simplified CI/CD workflow configuration by removing unused settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->