### PR TITLE
feat: use mongodb-memory-server for local mongo dev

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -5,6 +5,7 @@ export const dependencyVersionMap = {
   "@elysiajs/node": "^1.4.5",
   "@types/node": "^25.6.2",
   dotenv: "^17.4.2",
+  "mongodb-memory-server": "^11.1.0",
   tsx: "^4.21.0",
 } as const;
 

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -2,18 +2,14 @@ import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
-import {
-  getDependencyVersion,
-  getPrismaNextPackageSpecifier,
-  getCreateTemplateDependencies,
-} from "../constants/dependencies";
+import { getDependencyVersion, getCreateTemplateDependencies } from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
-import { getInstallArgs } from "../utils/package-manager";
+import { getDenoPrismaSpecifier, getInstallArgs } from "../utils/package-manager";
 
 function getPrismaNextScriptMap(packageManager: PackageManager) {
   if (packageManager === "deno") {
-    const prismaNextCli = `deno run -A --env-file=.env npm:${getPrismaNextPackageSpecifier("prisma-next")}`;
+    const prismaNextCli = `deno run -A --env-file=.env ${getDenoPrismaSpecifier()}`;
 
     return {
       "contract:emit": `${prismaNextCli} contract emit`,

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -9,7 +9,7 @@ import {
   PRISMA_POSTGRES_TEMPORARY_NOTICE,
   provisionPrismaPostgres,
 } from "./prisma-postgres";
-import { getPrismaNextPackageSpecifier } from "../constants/dependencies";
+import { getDependencyVersion, getPrismaNextPackageSpecifier } from "../constants/dependencies";
 import {
   AuthoringStyleSchema,
   DatabaseProviderSchema,
@@ -21,6 +21,7 @@ import {
 } from "../types";
 import {
   detectPackageManager,
+  getDenoPrismaSpecifier,
   getInstallCommand,
   getPackageExecutionArgs,
   getLocalPackageBinaryArgs,
@@ -79,27 +80,43 @@ const DEFAULT_EMIT = true;
 const DEFAULT_INTERACTIVE_PRISMA_POSTGRES = true;
 const DEFAULT_AUTOMATED_PRISMA_POSTGRES = false;
 
-const MONGO_MEMORY_SERVER_VERSION = "^11.1.0";
-
 const MONGO_MEMORY_SERVER_SCRIPT = `import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
+const defaultDatabaseUrl = "mongodb://localhost:27017/mydb?replicaSet=rs0&directConnection=true";
 const dbPath = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
 const pidFile = path.join(dbPath, "mongo.pid");
 const logFile = path.join(dbPath, "mongo.log");
-const port = Number(process.env.MONGO_PORT ?? 27017);
-const replSetName = process.env.MONGO_REPLSET ?? "rs0";
 const readyTimeoutMs = Number(process.env.MONGO_READY_TIMEOUT_MS ?? 60_000);
 
-function readPid(): number | null {
+function getMongoConfig() {
+  const databaseUrl = process.env.DATABASE_URL ?? defaultDatabaseUrl;
+  const url = new URL(databaseUrl);
+  if (url.protocol !== "mongodb:") {
+    throw new Error("DATABASE_URL must use the mongodb:// protocol.");
+  }
+
+  const port = Number(url.port || "27017");
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(\`DATABASE_URL has an invalid MongoDB port: \${url.port}\`);
+  }
+
+  return {
+    databaseUrl,
+    port,
+    replSetName: url.searchParams.get("replicaSet") || "rs0",
+  };
+}
+
+function readPid() {
   if (!existsSync(pidFile)) return null;
   const raw = readFileSync(pidFile, "utf8").trim();
   const pid = Number(raw);
   return Number.isFinite(pid) && pid > 0 ? pid : null;
 }
 
-function isAlive(pid: number): boolean {
+function isAlive(pid) {
   try {
     process.kill(pid, 0);
     return true;
@@ -108,22 +125,23 @@ function isAlive(pid: number): boolean {
   }
 }
 
-function getChildCommand(): { command: string; args: string[] } {
+function getChildCommand() {
   const scriptPath = path.resolve(process.argv[1] ?? "");
-  const versions = process.versions as Record<string, string | undefined>;
-  if (versions.bun) return { command: process.execPath, args: [scriptPath, "_run"] };
+  const versions = process.versions;
   if (versions.deno) return { command: process.execPath, args: ["run", "-A", scriptPath, "_run"] };
-  return { command: "tsx", args: [scriptPath, "_run"] };
+  return { command: process.execPath, args: [scriptPath, "_run"] };
 }
 
-async function runServer(): Promise<void> {
+async function runServer() {
   mkdirSync(dbPath, { recursive: true });
-  const { MongoMemoryReplSet } = await import("mongodb-memory-server");
+  const config = getMongoConfig();
+  const memoryServer = await import("mongodb-memory-server");
+  const { MongoMemoryReplSet } = memoryServer.default ?? memoryServer;
   const replSet = await MongoMemoryReplSet.create({
-    replSet: { name: replSetName, count: 1, storageEngine: "wiredTiger" },
-    instanceOpts: [{ port, storageEngine: "wiredTiger", dbPath }],
+    replSet: { name: config.replSetName, count: 1, storageEngine: "wiredTiger" },
+    instanceOpts: [{ port: config.port, storageEngine: "wiredTiger", dbPath }],
   });
-  console.log(\`MongoDB memory server ready at \${replSet.getUri()}\`);
+  console.log(\`MongoDB server ready for \${config.databaseUrl}\`);
   console.log(\`Data directory: \${dbPath}\`);
   const shutdown = async () => {
     await replSet.stop();
@@ -133,7 +151,7 @@ async function runServer(): Promise<void> {
   process.on("SIGTERM", shutdown);
 }
 
-async function up(): Promise<void> {
+async function up() {
   mkdirSync(dbPath, { recursive: true });
   const existing = readPid();
   if (existing !== null && isAlive(existing)) {
@@ -145,11 +163,16 @@ async function up(): Promise<void> {
   writeFileSync(logFile, "");
   const logFd = openSync(logFile, "a");
   const { command, args } = getChildCommand();
-  const child = spawn(command, args, {
-    detached: true,
-    stdio: ["ignore", logFd, logFd],
-    env: process.env,
-  });
+  const child = spawn(
+    command,
+    args,
+    {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env: process.env,
+    },
+  );
+  closeSync(logFd);
   if (typeof child.pid !== "number") throw new Error("Failed to spawn MongoDB child process.");
   writeFileSync(pidFile, String(child.pid));
   child.unref();
@@ -163,7 +186,7 @@ async function up(): Promise<void> {
       process.exit(1);
     }
     const log = readFileSync(logFile, "utf8");
-    if (log.includes("MongoDB memory server ready")) {
+    if (log.includes("MongoDB server ready")) {
       for (const line of log.split("\\n")) {
         if (line.trim().length > 0) console.log(line);
       }
@@ -184,7 +207,7 @@ async function up(): Promise<void> {
   process.exit(1);
 }
 
-async function down(wipe: boolean): Promise<void> {
+async function down(wipe) {
   const pid = readPid();
   if (pid !== null && isAlive(pid)) {
     process.kill(pid, "SIGTERM");
@@ -237,21 +260,21 @@ function getMongoMemoryScripts(packageManager: PackageManager): Record<string, s
   switch (packageManager) {
     case "bun":
       return {
-        "db:up": "bun scripts/mongo.ts up",
-        "db:down": "bun scripts/mongo.ts down",
-        "db:reset": "bun scripts/mongo.ts reset",
+        "db:up": "bun --env-file=.env scripts/mongo.mjs up",
+        "db:down": "bun --env-file=.env scripts/mongo.mjs down",
+        "db:reset": "bun --env-file=.env scripts/mongo.mjs reset",
       };
     case "deno":
       return {
-        "db:up": "deno run -A scripts/mongo.ts up",
-        "db:down": "deno run -A scripts/mongo.ts down",
-        "db:reset": "deno run -A scripts/mongo.ts reset",
+        "db:up": "deno run -A --env-file=.env scripts/mongo.mjs up",
+        "db:down": "deno run -A --env-file=.env scripts/mongo.mjs down",
+        "db:reset": "deno run -A --env-file=.env scripts/mongo.mjs reset",
       };
     default:
       return {
-        "db:up": "tsx scripts/mongo.ts up",
-        "db:down": "tsx scripts/mongo.ts down",
-        "db:reset": "tsx scripts/mongo.ts reset",
+        "db:up": "node --env-file=.env scripts/mongo.mjs up",
+        "db:down": "node --env-file=.env scripts/mongo.mjs down",
+        "db:reset": "node --env-file=.env scripts/mongo.mjs reset",
       };
   }
 }
@@ -649,7 +672,7 @@ async function ensurePackageScripts(
 }
 
 async function ensureMongoMemoryServerScript(projectDir: string): Promise<void> {
-  const scriptPath = path.join(projectDir, "scripts", "mongo.ts");
+  const scriptPath = path.join(projectDir, "scripts", "mongo.mjs");
   if (await fs.pathExists(scriptPath)) {
     return;
   }
@@ -669,11 +692,12 @@ async function ensureMongoMemoryServerDevDependency(projectDir: string): Promise
     packageJson.devDependencies = {};
   }
 
-  if (packageJson.devDependencies["mongodb-memory-server"] === MONGO_MEMORY_SERVER_VERSION) {
+  const memoryServerVersion = getDependencyVersion("mongodb-memory-server");
+  if (packageJson.devDependencies["mongodb-memory-server"] === memoryServerVersion) {
     return;
   }
 
-  packageJson.devDependencies["mongodb-memory-server"] = MONGO_MEMORY_SERVER_VERSION;
+  packageJson.devDependencies["mongodb-memory-server"] = memoryServerVersion;
   packageJson.devDependencies = Object.fromEntries(
     Object.entries(packageJson.devDependencies as Record<string, string>).sort(([a], [b]) =>
       a.localeCompare(b),
@@ -935,7 +959,7 @@ async function finalizePrismaFilesForContext(
 
 function getPrismaNextCliCommand(packageManager: PackageManager, prismaNextArgs: string[]): string {
   if (packageManager === "deno") {
-    return `deno run -A --env-file=.env npm:${getPrismaNextCliPackageSpecifier()} ${prismaNextArgs.join(" ")}`;
+    return `deno run -A --env-file=.env ${getDenoPrismaSpecifier()} ${prismaNextArgs.join(" ")}`;
   }
 
   return getLocalPackageBinaryCommand(packageManager, "prisma-next", prismaNextArgs);
@@ -948,13 +972,7 @@ function getPrismaNextCliArgs(
   if (packageManager === "deno") {
     return {
       command: "deno",
-      args: [
-        "run",
-        "-A",
-        "--env-file=.env",
-        `npm:${getPrismaNextCliPackageSpecifier()}`,
-        ...prismaNextArgs,
-      ],
+      args: ["run", "-A", "--env-file=.env", getDenoPrismaSpecifier(), ...prismaNextArgs],
     };
   }
 
@@ -1053,7 +1071,7 @@ function buildNextStepsForContext(opts: {
     nextSteps.push({
       command: getRunScriptCommand(context.packageManager, "db:up"),
       description:
-        "Start the local in-memory MongoDB replica set, detached (mongodb-memory-server). Stop with `db:down`, wipe with `db:reset`.",
+        "Start the local MongoDB replica set with mongodb-memory-server. Stop with `db:down`, wipe with `db:reset`.",
     });
   }
   nextSteps.push({
@@ -1131,6 +1149,12 @@ export async function executePrismaSetupContext(
     return false;
   }
 
+  const didWriteMongoLocalHelpers = await writeMongoLocalHelpersForContext(context, projectDir);
+  if (!didWriteMongoLocalHelpers) {
+    stopProgressOnFailure();
+    return false;
+  }
+
   if (context.shouldInstall) {
     progressSpinner?.message("Installing dependencies...");
   }
@@ -1147,12 +1171,6 @@ export async function executePrismaSetupContext(
     provisionResult,
   );
   if (!didFinalizePrismaFiles) {
-    stopProgressOnFailure();
-    return false;
-  }
-
-  const didWriteMongoLocalHelpers = await writeMongoLocalHelpersForContext(context, projectDir);
-  if (!didWriteMongoLocalHelpers) {
     stopProgressOnFailure();
     return false;
   }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -81,43 +81,178 @@ const DEFAULT_AUTOMATED_PRISMA_POSTGRES = false;
 
 const MONGO_MEMORY_SERVER_VERSION = "^11.1.0";
 
-const MONGO_MEMORY_SERVER_SCRIPT = `import { mkdirSync } from "node:fs";
+const MONGO_MEMORY_SERVER_SCRIPT = `import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { MongoMemoryReplSet } from "mongodb-memory-server";
 
+const dbPath = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
+const pidFile = path.join(dbPath, "mongo.pid");
+const logFile = path.join(dbPath, "mongo.log");
 const port = Number(process.env.MONGO_PORT ?? 27017);
 const replSetName = process.env.MONGO_REPLSET ?? "rs0";
-const dbPath = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
+const readyTimeoutMs = Number(process.env.MONGO_READY_TIMEOUT_MS ?? 60_000);
 
-// Persist data across restarts. Delete the directory for a clean slate.
-mkdirSync(dbPath, { recursive: true });
+function readPid(): number | null {
+  if (!existsSync(pidFile)) return null;
+  const raw = readFileSync(pidFile, "utf8").trim();
+  const pid = Number(raw);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
 
-const replSet = await MongoMemoryReplSet.create({
-  replSet: { name: replSetName, count: 1, storageEngine: "wiredTiger" },
-  instanceOpts: [{ port, storageEngine: "wiredTiger", dbPath }],
-});
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-console.log(\`MongoDB memory server ready at \${replSet.getUri()}\`);
-console.log(\`Data directory: \${dbPath}\`);
-console.log("Press Ctrl+C to stop.");
+function getChildCommand(): { command: string; args: string[] } {
+  const scriptPath = path.resolve(process.argv[1] ?? "");
+  const versions = process.versions as Record<string, string | undefined>;
+  if (versions.bun) return { command: process.execPath, args: [scriptPath, "_run"] };
+  if (versions.deno) return { command: process.execPath, args: ["run", "-A", scriptPath, "_run"] };
+  return { command: "tsx", args: [scriptPath, "_run"] };
+}
 
-const shutdown = async () => {
-  await replSet.stop();
-  process.exit(0);
-};
+async function runServer(): Promise<void> {
+  mkdirSync(dbPath, { recursive: true });
+  const { MongoMemoryReplSet } = await import("mongodb-memory-server");
+  const replSet = await MongoMemoryReplSet.create({
+    replSet: { name: replSetName, count: 1, storageEngine: "wiredTiger" },
+    instanceOpts: [{ port, storageEngine: "wiredTiger", dbPath }],
+  });
+  console.log(\`MongoDB memory server ready at \${replSet.getUri()}\`);
+  console.log(\`Data directory: \${dbPath}\`);
+  const shutdown = async () => {
+    await replSet.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+async function up(): Promise<void> {
+  mkdirSync(dbPath, { recursive: true });
+  const existing = readPid();
+  if (existing !== null && isAlive(existing)) {
+    console.log(\`MongoDB is already running (PID \${existing}). Use \\\`db:down\\\` to stop.\`);
+    return;
+  }
+  if (existing !== null) rmSync(pidFile, { force: true });
+
+  writeFileSync(logFile, "");
+  const logFd = openSync(logFile, "a");
+  const { command, args } = getChildCommand();
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+    env: process.env,
+  });
+  if (typeof child.pid !== "number") throw new Error("Failed to spawn MongoDB child process.");
+  writeFileSync(pidFile, String(child.pid));
+  child.unref();
+
+  const start = Date.now();
+  while (Date.now() - start < readyTimeoutMs) {
+    if (!isAlive(child.pid)) {
+      console.error("MongoDB failed to start:");
+      console.error(readFileSync(logFile, "utf8"));
+      rmSync(pidFile, { force: true });
+      process.exit(1);
+    }
+    const log = readFileSync(logFile, "utf8");
+    if (log.includes("MongoDB memory server ready")) {
+      for (const line of log.split("\\n")) {
+        if (line.trim().length > 0) console.log(line);
+      }
+      console.log(\`Detached (PID \${child.pid}). Logs: \${logFile}\`);
+      console.log("Stop with \`db:down\` or wipe with \`db:reset\`.");
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  console.error(\`Timed out waiting for MongoDB after \${readyTimeoutMs}ms.\`);
+  console.error(readFileSync(logFile, "utf8"));
+  try {
+    process.kill(child.pid, "SIGTERM");
+  } catch {
+    // ignore
+  }
+  rmSync(pidFile, { force: true });
+  process.exit(1);
+}
+
+async function down(wipe: boolean): Promise<void> {
+  const pid = readPid();
+  if (pid !== null && isAlive(pid)) {
+    process.kill(pid, "SIGTERM");
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline && isAlive(pid)) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    if (isAlive(pid)) {
+      console.warn(\`MongoDB (PID \${pid}) did not exit within 10s; sending SIGKILL.\`);
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // ignore
+      }
+    }
+    console.log(\`Stopped MongoDB (PID \${pid}).\`);
+  } else if (pid !== null) {
+    console.log("MongoDB was not running (stale PID file).");
+  } else {
+    console.log("MongoDB is not running.");
+  }
+  rmSync(pidFile, { force: true });
+  if (wipe) {
+    rmSync(dbPath, { recursive: true, force: true });
+    console.log(\`Removed \${dbPath}.\`);
+  }
+}
+
+const cmd = process.argv[2] ?? "up";
+switch (cmd) {
+  case "up":
+    await up();
+    break;
+  case "down":
+    await down(false);
+    break;
+  case "reset":
+    await down(true);
+    break;
+  case "_run":
+    await runServer();
+    break;
+  default:
+    console.error(\`Unknown command: \${cmd}. Use: up | down | reset\`);
+    process.exit(2);
+}
 `;
 
 function getMongoMemoryScripts(packageManager: PackageManager): Record<string, string> {
   switch (packageManager) {
     case "bun":
-      return { "db:up": "bun scripts/start-mongo.ts" };
+      return {
+        "db:up": "bun scripts/mongo.ts up",
+        "db:down": "bun scripts/mongo.ts down",
+        "db:reset": "bun scripts/mongo.ts reset",
+      };
     case "deno":
-      return { "db:up": "deno run -A scripts/start-mongo.ts" };
+      return {
+        "db:up": "deno run -A scripts/mongo.ts up",
+        "db:down": "deno run -A scripts/mongo.ts down",
+        "db:reset": "deno run -A scripts/mongo.ts reset",
+      };
     default:
-      return { "db:up": "tsx scripts/start-mongo.ts" };
+      return {
+        "db:up": "tsx scripts/mongo.ts up",
+        "db:down": "tsx scripts/mongo.ts down",
+        "db:reset": "tsx scripts/mongo.ts reset",
+      };
   }
 }
 
@@ -514,7 +649,7 @@ async function ensurePackageScripts(
 }
 
 async function ensureMongoMemoryServerScript(projectDir: string): Promise<void> {
-  const scriptPath = path.join(projectDir, "scripts", "start-mongo.ts");
+  const scriptPath = path.join(projectDir, "scripts", "mongo.ts");
   if (await fs.pathExists(scriptPath)) {
     return;
   }
@@ -917,7 +1052,8 @@ function buildNextStepsForContext(opts: {
   if (context.databaseProvider === "mongo" && !context.databaseUrl) {
     nextSteps.push({
       command: getRunScriptCommand(context.packageManager, "db:up"),
-      description: "Start the local in-memory MongoDB replica set (mongodb-memory-server).",
+      description:
+        "Start the local in-memory MongoDB replica set, detached (mongodb-memory-server). Stop with `db:down`, wipe with `db:reset`.",
     });
   }
   nextSteps.push({

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -78,33 +78,41 @@ const DEFAULT_INSTALL = true;
 const DEFAULT_EMIT = true;
 const DEFAULT_INTERACTIVE_PRISMA_POSTGRES = true;
 const DEFAULT_AUTOMATED_PRISMA_POSTGRES = false;
-const MONGO_DOCKER_COMPOSE = `services:
-  mongodb:
-    image: mongo:latest
-    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
-    ports:
-      - "27017:27017"
-    volumes:
-      - mongodb-data:/data/db
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "mongosh --quiet --eval 'try { rs.status().members.some((member) => member.stateStr === \\"PRIMARY\\") } catch (error) { rs.initiate({_id: \\"rs0\\", members: [{ _id: 0, host: \\"localhost:27017\\" }] }); false }' | grep true",
-        ]
-      interval: 5s
-      timeout: 5s
-      retries: 30
-      start_period: 5s
 
-volumes:
-  mongodb-data:
+const MONGO_MEMORY_SERVER_VERSION = "^11.1.0";
+
+const MONGO_MEMORY_SERVER_SCRIPT = `import { MongoMemoryReplSet } from "mongodb-memory-server";
+
+const port = Number(process.env.MONGO_PORT ?? 27017);
+const replSetName = process.env.MONGO_REPLSET ?? "rs0";
+
+const replSet = await MongoMemoryReplSet.create({
+  replSet: { name: replSetName, count: 1, storageEngine: "wiredTiger" },
+  instanceOpts: [{ port, storageEngine: "wiredTiger" }],
+});
+
+console.log(\`MongoDB memory server ready at \${replSet.getUri()}\`);
+console.log("Press Ctrl+C to stop.");
+
+const shutdown = async () => {
+  await replSet.stop();
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
 `;
 
-const mongoDockerScripts = {
-  "db:up": "docker compose up -d --wait",
-  "db:down": "docker compose down",
-} as const;
+function getMongoMemoryScripts(packageManager: PackageManager): Record<string, string> {
+  switch (packageManager) {
+    case "bun":
+      return { "db:up": "bun scripts/start-mongo.ts" };
+    case "deno":
+      return { "db:up": "deno run -A scripts/start-mongo.ts" };
+    default:
+      return { "db:up": "tsx scripts/start-mongo.ts" };
+  }
+}
 
 const requiredPrismaFileGroups = [
   ["prisma/contract.prisma", "prisma/contract.ts"],
@@ -498,16 +506,44 @@ async function ensurePackageScripts(
   }
 }
 
-async function ensureMongoDockerCompose(projectDir: string): Promise<void> {
-  const composePath = path.join(projectDir, "docker-compose.yml");
-  if (await fs.pathExists(composePath)) {
+async function ensureMongoMemoryServerScript(projectDir: string): Promise<void> {
+  const scriptPath = path.join(projectDir, "scripts", "start-mongo.ts");
+  if (await fs.pathExists(scriptPath)) {
     return;
   }
 
-  await fs.writeFile(composePath, MONGO_DOCKER_COMPOSE, "utf8");
+  await fs.ensureDir(path.dirname(scriptPath));
+  await fs.writeFile(scriptPath, MONGO_MEMORY_SERVER_SCRIPT, "utf8");
 }
 
-async function writeMongoDockerHelpersForContext(
+async function ensureMongoMemoryServerDevDependency(projectDir: string): Promise<void> {
+  const packageJsonPath = path.join(projectDir, "package.json");
+  if (!(await fs.pathExists(packageJsonPath))) {
+    return;
+  }
+
+  const packageJson = await fs.readJson(packageJsonPath);
+  if (!packageJson.devDependencies) {
+    packageJson.devDependencies = {};
+  }
+
+  if (packageJson.devDependencies["mongodb-memory-server"] === MONGO_MEMORY_SERVER_VERSION) {
+    return;
+  }
+
+  packageJson.devDependencies["mongodb-memory-server"] = MONGO_MEMORY_SERVER_VERSION;
+  packageJson.devDependencies = Object.fromEntries(
+    Object.entries(packageJson.devDependencies as Record<string, string>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    ),
+  );
+
+  await fs.writeJson(packageJsonPath, packageJson, {
+    spaces: 2,
+  });
+}
+
+async function writeMongoLocalHelpersForContext(
   context: PrismaSetupContext,
   projectDir: string,
 ): Promise<boolean> {
@@ -516,8 +552,9 @@ async function writeMongoDockerHelpersForContext(
   }
 
   try {
-    await ensureMongoDockerCompose(projectDir);
-    await ensurePackageScripts(projectDir, mongoDockerScripts);
+    await ensureMongoMemoryServerScript(projectDir);
+    await ensureMongoMemoryServerDevDependency(projectDir);
+    await ensurePackageScripts(projectDir, getMongoMemoryScripts(context.packageManager));
     return true;
   } catch (error) {
     cancel(getCommandErrorMessage(error));
@@ -872,7 +909,7 @@ function buildNextStepsForContext(opts: {
   if (context.databaseProvider === "mongo" && !context.databaseUrl) {
     nextSteps.push({
       command: getRunScriptCommand(context.packageManager, "db:up"),
-      description: "Start the local MongoDB replica set with Docker.",
+      description: "Start the local in-memory MongoDB replica set (mongodb-memory-server).",
     });
   }
   nextSteps.push({
@@ -970,8 +1007,8 @@ export async function executePrismaSetupContext(
     return false;
   }
 
-  const didWriteMongoDockerHelpers = await writeMongoDockerHelpersForContext(context, projectDir);
-  if (!didWriteMongoDockerHelpers) {
+  const didWriteMongoLocalHelpers = await writeMongoLocalHelpersForContext(context, projectDir);
+  if (!didWriteMongoLocalHelpers) {
     stopProgressOnFailure();
     return false;
   }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -85,9 +85,10 @@ import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, write
 import path from "node:path";
 
 const defaultDatabaseUrl = "mongodb://localhost:27017/mydb?replicaSet=rs0&directConnection=true";
-const dbPath = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
-const pidFile = path.join(dbPath, "mongo.pid");
-const logFile = path.join(dbPath, "mongo.log");
+const dataRoot = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
+const dbPath = path.join(dataRoot, "db");
+const pidFile = path.join(dataRoot, "mongo.pid");
+const logFile = path.join(dataRoot, "mongo.log");
 const readyTimeoutMs = Number(process.env.MONGO_READY_TIMEOUT_MS ?? 60_000);
 
 function getMongoConfig() {
@@ -138,7 +139,7 @@ async function runServer() {
   const memoryServer = await import("mongodb-memory-server");
   const { MongoMemoryReplSet } = memoryServer.default ?? memoryServer;
   const replSet = await MongoMemoryReplSet.create({
-    replSet: { name: config.replSetName, count: 1, storageEngine: "wiredTiger" },
+    replSet: { name: config.replSetName, count: 1 },
     instanceOpts: [{ port: config.port, storageEngine: "wiredTiger", dbPath }],
   });
   console.log(\`MongoDB server ready for \${config.databaseUrl}\`);
@@ -152,7 +153,7 @@ async function runServer() {
 }
 
 async function up() {
-  mkdirSync(dbPath, { recursive: true });
+  mkdirSync(dataRoot, { recursive: true });
   const existing = readPid();
   if (existing !== null && isAlive(existing)) {
     console.log(\`MongoDB is already running (PID \${existing}). Use \\\`db:down\\\` to stop.\`);
@@ -231,8 +232,8 @@ async function down(wipe) {
   }
   rmSync(pidFile, { force: true });
   if (wipe) {
-    rmSync(dbPath, { recursive: true, force: true });
-    console.log(\`Removed \${dbPath}.\`);
+    rmSync(dataRoot, { recursive: true, force: true });
+    console.log(\`Removed \${dataRoot}.\`);
   }
 }
 

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -81,17 +81,24 @@ const DEFAULT_AUTOMATED_PRISMA_POSTGRES = false;
 
 const MONGO_MEMORY_SERVER_VERSION = "^11.1.0";
 
-const MONGO_MEMORY_SERVER_SCRIPT = `import { MongoMemoryReplSet } from "mongodb-memory-server";
+const MONGO_MEMORY_SERVER_SCRIPT = `import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
 
 const port = Number(process.env.MONGO_PORT ?? 27017);
 const replSetName = process.env.MONGO_REPLSET ?? "rs0";
+const dbPath = path.resolve(process.env.MONGO_DB_PATH ?? ".mongo-data");
+
+// Persist data across restarts. Delete the directory for a clean slate.
+mkdirSync(dbPath, { recursive: true });
 
 const replSet = await MongoMemoryReplSet.create({
   replSet: { name: replSetName, count: 1, storageEngine: "wiredTiger" },
-  instanceOpts: [{ port, storageEngine: "wiredTiger" }],
+  instanceOpts: [{ port, storageEngine: "wiredTiger", dbPath }],
 });
 
 console.log(\`MongoDB memory server ready at \${replSet.getUri()}\`);
+console.log(\`Data directory: \${dbPath}\`);
 console.log("Press Ctrl+C to stop.");
 
 const shutdown = async () => {
@@ -555,6 +562,7 @@ async function writeMongoLocalHelpersForContext(
     await ensureMongoMemoryServerScript(projectDir);
     await ensureMongoMemoryServerDevDependency(projectDir);
     await ensurePackageScripts(projectDir, getMongoMemoryScripts(context.packageManager));
+    await ensureGitignoreEntry(projectDir, ".mongo-data");
     return true;
   } catch (error) {
     cancel(getCommandErrorMessage(error));

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,7 +1,6 @@
 import fs from "fs-extra";
 import path from "node:path";
 
-import { getPrismaNextPackageSpecifier } from "../constants/dependencies";
 import { PackageManagerSchema, type PackageManager } from "../types";
 
 type CommandAndArgs = {
@@ -134,14 +133,19 @@ export function getPackageManagerManifestValue(
 }
 
 export function getDenoPrismaSpecifier(): string {
-  return `npm:${getPrismaNextPackageSpecifier("prisma-next")}`;
+  return "npm:prisma-next";
+}
+
+function getDenoNpmSpecifier(packageSpecifier: string): string {
+  return `npm:${packageSpecifier.replace(/@latest$/, "")}`;
 }
 
 function getDenoAllowedScriptSpecifiers(): string {
   return [
-    `npm:${getPrismaNextPackageSpecifier("prisma-next")}`,
-    `npm:${getPrismaNextPackageSpecifier("@prisma-next/postgres")}`,
-    `npm:${getPrismaNextPackageSpecifier("@prisma-next/mongo")}`,
+    "npm:prisma-next",
+    "npm:@prisma-next/postgres",
+    "npm:@prisma-next/mongo",
+    "npm:mongodb-memory-server",
   ].join(",");
 }
 
@@ -260,7 +264,7 @@ export function getPackageExecutionArgs(
 
       return {
         command: "deno",
-        args: ["run", "-A", `npm:${packageName}`, ...args],
+        args: ["run", "-A", getDenoNpmSpecifier(packageName), ...args],
       };
     }
     case "npm":

--- a/templates/create/astro/README.md.hbs
+++ b/templates/create/astro/README.md.hbs
@@ -22,8 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/astro/README.md.hbs
+++ b/templates/create/astro/README.md.hbs
@@ -22,7 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/astro/README.md.hbs
+++ b/templates/create/astro/README.md.hbs
@@ -22,7 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/astro/README.md.hbs
+++ b/templates/create/astro/README.md.hbs
@@ -22,7 +22,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/elysia/README.md.hbs
+++ b/templates/create/elysia/README.md.hbs
@@ -20,8 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/elysia/README.md.hbs
+++ b/templates/create/elysia/README.md.hbs
@@ -20,7 +20,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/elysia/README.md.hbs
+++ b/templates/create/elysia/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/elysia/README.md.hbs
+++ b/templates/create/elysia/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/hono/README.md.hbs
+++ b/templates/create/hono/README.md.hbs
@@ -20,8 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/hono/README.md.hbs
+++ b/templates/create/hono/README.md.hbs
@@ -20,7 +20,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/hono/README.md.hbs
+++ b/templates/create/hono/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/hono/README.md.hbs
+++ b/templates/create/hono/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/minimal/README.md.hbs
+++ b/templates/create/minimal/README.md.hbs
@@ -19,8 +19,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/minimal/README.md.hbs
+++ b/templates/create/minimal/README.md.hbs
@@ -19,7 +19,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/minimal/README.md.hbs
+++ b/templates/create/minimal/README.md.hbs
@@ -19,7 +19,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/minimal/README.md.hbs
+++ b/templates/create/minimal/README.md.hbs
@@ -19,7 +19,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nest/README.md.hbs
+++ b/templates/create/nest/README.md.hbs
@@ -21,7 +21,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nest/README.md.hbs
+++ b/templates/create/nest/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/nest/README.md.hbs
+++ b/templates/create/nest/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nest/README.md.hbs
+++ b/templates/create/nest/README.md.hbs
@@ -21,8 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/next/README.md.hbs
+++ b/templates/create/next/README.md.hbs
@@ -20,8 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/next/README.md.hbs
+++ b/templates/create/next/README.md.hbs
@@ -20,7 +20,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/next/README.md.hbs
+++ b/templates/create/next/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/next/README.md.hbs
+++ b/templates/create/next/README.md.hbs
@@ -20,7 +20,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nuxt/README.md.hbs
+++ b/templates/create/nuxt/README.md.hbs
@@ -22,8 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nuxt/README.md.hbs
+++ b/templates/create/nuxt/README.md.hbs
@@ -22,7 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/nuxt/README.md.hbs
+++ b/templates/create/nuxt/README.md.hbs
@@ -22,7 +22,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/nuxt/README.md.hbs
+++ b/templates/create/nuxt/README.md.hbs
@@ -22,7 +22,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/svelte/README.md.hbs
+++ b/templates/create/svelte/README.md.hbs
@@ -21,7 +21,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/svelte/README.md.hbs
+++ b/templates/create/svelte/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/svelte/README.md.hbs
+++ b/templates/create/svelte/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/svelte/README.md.hbs
+++ b/templates/create/svelte/README.md.hbs
@@ -21,8 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/tanstack-start/README.md.hbs
+++ b/templates/create/tanstack-start/README.md.hbs
@@ -21,7 +21,9 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
+- `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/tanstack-start/README.md.hbs
+++ b/templates/create/tanstack-start/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server`, detached. Data persists in `.mongo-data/` across restarts.
+- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set with `mongodb-memory-server`. Data persists in `.mongo-data/` across restarts.
 - `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB process (data preserved)
 - `{{runScriptCommand packageManager "db:reset"}}` - stop and wipe `.mongo-data/` for a clean slate
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan

--- a/templates/create/tanstack-start/README.md.hbs
+++ b/templates/create/tanstack-start/README.md.hbs
@@ -21,7 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop). Data persists in `.mongo-data/` across restarts; delete that folder for a clean slate.
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/templates/create/tanstack-start/README.md.hbs
+++ b/templates/create/tanstack-start/README.md.hbs
@@ -21,8 +21,7 @@ Database helper scripts are added to `package.json`:
 
 - `{{runScriptCommand packageManager "contract:emit"}}` - emit contract artifacts after contract changes
 {{#if (eq provider "mongo")}}
-- `{{runScriptCommand packageManager "db:up"}}` - start the local MongoDB replica set
-- `{{runScriptCommand packageManager "db:down"}}` - stop the local MongoDB replica set
+- `{{runScriptCommand packageManager "db:up"}}` - start an in-memory MongoDB replica set via `mongodb-memory-server` (foreground; Ctrl+C to stop)
 - `{{runScriptCommand packageManager "migration:plan"}}` - create a MongoDB migration plan
 - `{{runScriptCommand packageManager "migrate"}}` - apply the planned MongoDB migration
 {{else}}

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -44,7 +44,11 @@ async function createDevDatabase(options?: ServerOptions): Promise<DevDatabase> 
   };
 }
 
-async function runCommand(projectDir: string, args: string[]): Promise<string> {
+async function runCommand(
+  projectDir: string,
+  args: string[],
+  extraEnv: Record<string, string> = {},
+): Promise<string> {
   const proc = Bun.spawn({
     cmd: args,
     cwd: projectDir,
@@ -52,6 +56,7 @@ async function runCommand(projectDir: string, args: string[]): Promise<string> {
       ...process.env,
       CI: "1",
       CREATE_PRISMA_DISABLE_TELEMETRY: "1",
+      ...extraEnv,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -73,8 +78,12 @@ async function runCommand(projectDir: string, args: string[]): Promise<string> {
   return [stdout, stderr].filter(Boolean).join("\n");
 }
 
-async function runScript(projectDir: string, scriptName: string): Promise<string> {
-  return runCommand(projectDir, ["bun", "run", scriptName]);
+async function runScript(
+  projectDir: string,
+  scriptName: string,
+  extraEnv: Record<string, string> = {},
+): Promise<string> {
+  return runCommand(projectDir, ["bun", "run", scriptName], extraEnv);
 }
 
 async function writeDatabaseUrl(projectDir: string, databaseUrl: string): Promise<void> {
@@ -225,94 +234,19 @@ async function startMemoryMongo(projectDir: string): Promise<MemoryMongoHandle> 
     projectDir,
     `mongodb://localhost:${port}/mydb?replicaSet=rs0&directConnection=true`,
   );
-
-  const proc = Bun.spawn({
-    cmd: ["bun", "run", "db:up"],
-    cwd: projectDir,
-    env: {
-      ...process.env,
-      MONGO_PORT: String(port),
-      CI: "1",
-      CREATE_PRISMA_DISABLE_TELEMETRY: "1",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
+  // db:up is detached and exits when ready, so this returns once the server is listening.
+  await runScript(projectDir, "db:up", {
+    MONGO_PORT: String(port),
+    MONGO_READY_TIMEOUT_MS: String(MONGO_STARTUP_TIMEOUT),
   });
-
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-
-  const consume = async (
-    stream: ReadableStream<Uint8Array> | null | undefined,
-    sink: string[],
-  ): Promise<void> => {
-    if (!stream) return;
-    const reader = stream.getReader();
-    const decoder = new TextDecoder();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) return;
-        sink.push(decoder.decode(value, { stream: true }));
-      }
-    } catch {
-      // stream closed
-    }
-  };
-
-  const stdoutConsumer = consume(
-    proc.stdout as ReadableStream<Uint8Array> | null | undefined,
-    stdoutChunks,
-  );
-  const stderrConsumer = consume(
-    proc.stderr as ReadableStream<Uint8Array> | null | undefined,
-    stderrChunks,
-  );
-
-  const ready = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timed out waiting for db:up to be ready.\nstdout:\n${stdoutChunks.join("")}\nstderr:\n${stderrChunks.join("")}`,
-        ),
-      );
-    }, MONGO_STARTUP_TIMEOUT);
-    const interval = setInterval(() => {
-      if (stdoutChunks.join("").includes("MongoDB memory server ready")) {
-        clearTimeout(timeout);
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    proc.exited
-      .then((code) => {
-        if (!stdoutChunks.join("").includes("MongoDB memory server ready")) {
-          clearTimeout(timeout);
-          clearInterval(interval);
-          reject(
-            new Error(
-              `db:up exited prematurely with code ${code}.\nstdout:\n${stdoutChunks.join("")}\nstderr:\n${stderrChunks.join("")}`,
-            ),
-          );
-        }
-      })
-      .catch(() => {
-        // ignore
-      });
-  });
-
-  await ready;
-
   return {
     port,
     stop: async () => {
-      proc.kill("SIGTERM");
       try {
-        await proc.exited;
+        await runScript(projectDir, "db:down");
       } catch {
-        // ignore
+        // best-effort cleanup
       }
-      await Promise.allSettled([stdoutConsumer, stderrConsumer]);
     },
   };
 }
@@ -369,10 +303,12 @@ describe("create-prisma e2e", () => {
       async () => {
         const project = await scaffoldProject({ template, provider: "mongo" });
 
-        expect(await pathExists(path.join(project.projectDir, "scripts/start-mongo.ts"))).toBe(
-          true,
-        );
+        expect(await pathExists(path.join(project.projectDir, "scripts/mongo.ts"))).toBe(true);
         const pkgJson = await readJsonFile(path.join(project.projectDir, "package.json"));
+        const scriptsPkg = pkgJson.scripts as Record<string, string> | undefined;
+        expect(scriptsPkg?.["db:up"]).toContain("scripts/mongo.ts up");
+        expect(scriptsPkg?.["db:down"]).toContain("scripts/mongo.ts down");
+        expect(scriptsPkg?.["db:reset"]).toContain("scripts/mongo.ts reset");
         const devDeps = pkgJson.devDependencies as Record<string, string> | undefined;
         expect(devDeps?.["mongodb-memory-server"]).toBeDefined();
         expect(await pathExists(path.join(project.projectDir, "docker-compose.yml"))).toBe(false);

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -236,7 +236,6 @@ async function startMemoryMongo(projectDir: string): Promise<MemoryMongoHandle> 
   );
   // db:up is detached and exits when ready, so this returns once the server is listening.
   await runScript(projectDir, "db:up", {
-    MONGO_PORT: String(port),
     MONGO_READY_TIMEOUT_MS: String(MONGO_STARTUP_TIMEOUT),
   });
   return {
@@ -303,12 +302,12 @@ describe("create-prisma e2e", () => {
       async () => {
         const project = await scaffoldProject({ template, provider: "mongo" });
 
-        expect(await pathExists(path.join(project.projectDir, "scripts/mongo.ts"))).toBe(true);
+        expect(await pathExists(path.join(project.projectDir, "scripts/mongo.mjs"))).toBe(true);
         const pkgJson = await readJsonFile(path.join(project.projectDir, "package.json"));
         const scriptsPkg = pkgJson.scripts as Record<string, string> | undefined;
-        expect(scriptsPkg?.["db:up"]).toContain("scripts/mongo.ts up");
-        expect(scriptsPkg?.["db:down"]).toContain("scripts/mongo.ts down");
-        expect(scriptsPkg?.["db:reset"]).toContain("scripts/mongo.ts reset");
+        expect(scriptsPkg?.["db:up"]).toContain("scripts/mongo.mjs up");
+        expect(scriptsPkg?.["db:down"]).toContain("scripts/mongo.mjs down");
+        expect(scriptsPkg?.["db:reset"]).toContain("scripts/mongo.mjs reset");
         const devDeps = pkgJson.devDependencies as Record<string, string> | undefined;
         expect(devDeps?.["mongodb-memory-server"]).toBeDefined();
         expect(await pathExists(path.join(project.projectDir, "docker-compose.yml"))).toBe(false);

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -316,6 +316,14 @@ describe("create-prisma e2e", () => {
 
         const mongo = await startMemoryMongo(project.projectDir);
         try {
+          expect(await pathExists(path.join(project.projectDir, ".mongo-data", "db"))).toBe(true);
+          expect(await pathExists(path.join(project.projectDir, ".mongo-data", "mongo.log"))).toBe(
+            true,
+          );
+          expect(await pathExists(path.join(project.projectDir, ".mongo-data", "mongo.pid"))).toBe(
+            true,
+          );
+
           await runScript(project.projectDir, "migration:plan");
           await runScript(project.projectDir, "migrate");
           await runScript(project.projectDir, "db:seed");

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { startPrismaDevServer, type ServerOptions } from "@prisma/dev";
-import { MongoMemoryReplSet } from "mongodb-memory-server";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runCreateCommand } from "../../src/commands/create";
-import type { DatabaseProvider } from "../../src/types";
+import type { CreateTemplate, DatabaseProvider } from "../../src/types";
 
-const TEST_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_TIMEOUT_MS ?? 180_000);
-const MONGO_STARTUP_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_MONGO_TIMEOUT_MS ?? 60_000);
+const TEST_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_TIMEOUT_MS ?? 240_000);
+const MONGO_STARTUP_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_MONGO_TIMEOUT_MS ?? 90_000);
 
 type DevDatabase = {
   connectionString: string;
@@ -42,12 +42,6 @@ async function createDevDatabase(options?: ServerOptions): Promise<DevDatabase> 
     connectionString: normalizePostgresConnectionString(server.database.connectionString),
     close: () => server.close(),
   };
-}
-
-function buildMongoUri(baseUri: string, dbName: string): string {
-  const [hostPart, query] = baseUri.split("?");
-  const hostWithSlash = (hostPart ?? "").replace(/\/?$/, "/");
-  return query ? `${hostWithSlash}${dbName}?${query}` : `${hostWithSlash}${dbName}`;
 }
 
 async function runCommand(projectDir: string, args: string[]): Promise<string> {
@@ -96,20 +90,26 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
-async function scaffoldProject(
-  provider: DatabaseProvider,
-  databaseUrl: string,
-): Promise<GeneratedProject> {
-  const rootDir = await mkdtemp(path.join(tmpdir(), `create-prisma-e2e-${provider}-`));
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(filePath, "utf8")) as Record<string, unknown>;
+}
+
+async function scaffoldProject(opts: {
+  template: CreateTemplate;
+  provider: DatabaseProvider;
+  databaseUrl?: string;
+}): Promise<GeneratedProject> {
+  const { template, provider, databaseUrl } = opts;
+  const rootDir = await mkdtemp(path.join(tmpdir(), `create-prisma-e2e-${template}-${provider}-`));
   tempRoots.push(rootDir);
 
-  const projectName = `${provider}-app`;
+  const projectName = `${template}-${provider}-app`;
   const previousCwd = process.cwd();
   process.chdir(rootDir);
   try {
     await runCreateCommand({
       name: projectName,
-      template: "hono",
+      template,
       provider,
       authoring: "psl",
       packageManager: "bun",
@@ -129,14 +129,33 @@ async function scaffoldProject(
   };
 }
 
+function getPrismaModuleSpecifier(template: CreateTemplate): string {
+  switch (template) {
+    case "nuxt":
+      return "./server/utils/prisma";
+    case "svelte":
+      return "./src/lib/server/prisma";
+    case "tanstack-start":
+      return "./src/lib/prisma.server";
+    default:
+      return "./src/lib/prisma";
+  }
+}
+
 async function writeVerificationScript(
   projectDir: string,
+  template: CreateTemplate,
   provider: DatabaseProvider,
 ): Promise<string> {
   const verifyPath = path.join(projectDir, "verify-seed.ts");
-  const script =
+  const modulePath = getPrismaModuleSpecifier(template);
+  const closeCall = provider === "mongo" ? "await db.close();" : "await db.runtime().close();";
+  const aliceQuery =
     provider === "mongo"
-      ? `import { db, listUsers } from "./src/lib/prisma";
+      ? 'await db.orm.users.where({ email: "alice@prisma.io" }).first()'
+      : 'await db.orm.User.where({ email: "alice@prisma.io" }).first()';
+
+  const script = `import { db, listUsers } from "${modulePath}";
 
 try {
   const users = await listUsers();
@@ -145,29 +164,12 @@ try {
     throw new Error(\`Expected 3 seeded users, received \${JSON.stringify(users)}\`);
   }
 
-  const alice = await db.orm.users.where({ email: "alice@prisma.io" }).first();
+  const alice = ${aliceQuery};
   if (!alice || alice.name !== "Alice") {
     throw new Error(\`Expected Alice query result, received \${JSON.stringify(alice)}\`);
   }
 } finally {
-  await db.close();
-}
-`
-      : `import { db, listUsers } from "./src/lib/prisma";
-
-try {
-  const users = await listUsers();
-  const emails = users.map((user) => user.email).sort();
-  if (users.length !== 3 || emails.join(",") !== "alice@prisma.io,bob@prisma.io,carol@prisma.io") {
-    throw new Error(\`Expected 3 seeded users, received \${JSON.stringify(users)}\`);
-  }
-
-  const alice = await db.orm.User.where({ email: "alice@prisma.io" }).first();
-  if (!alice || alice.name !== "Alice") {
-    throw new Error(\`Expected Alice query result, received \${JSON.stringify(alice)}\`);
-  }
-} finally {
-  await db.runtime().close();
+  ${closeCall}
 }
 `;
 
@@ -186,11 +188,133 @@ async function installAndEmit(projectDir: string): Promise<void> {
 
 async function verifyGeneratedProject(
   projectDir: string,
+  template: CreateTemplate,
   provider: DatabaseProvider,
 ): Promise<void> {
-  const verifyPath = await writeVerificationScript(projectDir, provider);
+  const verifyPath = await writeVerificationScript(projectDir, template, provider);
   await runCommand(projectDir, ["bun", verifyPath]);
   await runScript(projectDir, "build");
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address !== "object" || address === null) {
+        server.close();
+        reject(new Error("Could not determine free port"));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+type MemoryMongoHandle = {
+  port: number;
+  stop: () => Promise<void>;
+};
+
+async function startMemoryMongo(projectDir: string): Promise<MemoryMongoHandle> {
+  const port = await getFreePort();
+  await writeDatabaseUrl(
+    projectDir,
+    `mongodb://localhost:${port}/mydb?replicaSet=rs0&directConnection=true`,
+  );
+
+  const proc = Bun.spawn({
+    cmd: ["bun", "run", "db:up"],
+    cwd: projectDir,
+    env: {
+      ...process.env,
+      MONGO_PORT: String(port),
+      CI: "1",
+      CREATE_PRISMA_DISABLE_TELEMETRY: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  const consume = async (
+    stream: ReadableStream<Uint8Array> | null | undefined,
+    sink: string[],
+  ): Promise<void> => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        sink.push(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      // stream closed
+    }
+  };
+
+  const stdoutConsumer = consume(
+    proc.stdout as ReadableStream<Uint8Array> | null | undefined,
+    stdoutChunks,
+  );
+  const stderrConsumer = consume(
+    proc.stderr as ReadableStream<Uint8Array> | null | undefined,
+    stderrChunks,
+  );
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out waiting for db:up to be ready.\nstdout:\n${stdoutChunks.join("")}\nstderr:\n${stderrChunks.join("")}`,
+        ),
+      );
+    }, MONGO_STARTUP_TIMEOUT);
+    const interval = setInterval(() => {
+      if (stdoutChunks.join("").includes("MongoDB memory server ready")) {
+        clearTimeout(timeout);
+        clearInterval(interval);
+        resolve();
+      }
+    }, 100);
+    proc.exited
+      .then((code) => {
+        if (!stdoutChunks.join("").includes("MongoDB memory server ready")) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          reject(
+            new Error(
+              `db:up exited prematurely with code ${code}.\nstdout:\n${stdoutChunks.join("")}\nstderr:\n${stderrChunks.join("")}`,
+            ),
+          );
+        }
+      })
+      .catch(() => {
+        // ignore
+      });
+  });
+
+  await ready;
+
+  return {
+    port,
+    stop: async () => {
+      proc.kill("SIGTERM");
+      try {
+        await proc.exited;
+      } catch {
+        // ignore
+      }
+      await Promise.allSettled([stdoutConsumer, stderrConsumer]);
+    },
+  };
 }
 
 afterEach(async () => {
@@ -202,58 +326,70 @@ afterEach(async () => {
   }
 });
 
+const templates: CreateTemplate[] = ["hono", "next"];
+
 describe("create-prisma e2e", () => {
-  test(
-    "postgres runs db init, migrations, seed, generated queries, and build",
-    async () => {
-      const initDb = await createDevDatabase();
-      let project: GeneratedProject | undefined;
-      try {
-        project = await scaffoldProject("postgres", initDb.connectionString);
+  for (const template of templates) {
+    test(
+      `${template} + postgres runs db init, migrations, seed, generated queries, and build`,
+      async () => {
+        const initDb = await createDevDatabase();
+        let project: GeneratedProject | undefined;
+        try {
+          project = await scaffoldProject({
+            template,
+            provider: "postgres",
+            databaseUrl: initDb.connectionString,
+          });
+          await installAndEmit(project.projectDir);
+
+          await runScript(project.projectDir, "db:init");
+          await runScript(project.projectDir, "db:verify");
+        } finally {
+          await initDb.close();
+        }
+
+        expect(project).toBeDefined();
+        const migrationDb = await createDevDatabase();
+        try {
+          await writeDatabaseUrl(project!.projectDir, migrationDb.connectionString);
+          await runScript(project!.projectDir, "migration:plan");
+          await runScript(project!.projectDir, "migrate");
+          await runScript(project!.projectDir, "db:seed");
+          await verifyGeneratedProject(project!.projectDir, template, "postgres");
+        } finally {
+          await migrationDb.close();
+        }
+      },
+      TEST_TIMEOUT,
+    );
+
+    test(
+      `${template} + mongo provisions in-memory mongo via generated db:up`,
+      async () => {
+        const project = await scaffoldProject({ template, provider: "mongo" });
+
+        expect(await pathExists(path.join(project.projectDir, "scripts/start-mongo.ts"))).toBe(
+          true,
+        );
+        const pkgJson = await readJsonFile(path.join(project.projectDir, "package.json"));
+        const devDeps = pkgJson.devDependencies as Record<string, string> | undefined;
+        expect(devDeps?.["mongodb-memory-server"]).toBeDefined();
+        expect(await pathExists(path.join(project.projectDir, "docker-compose.yml"))).toBe(false);
+
         await installAndEmit(project.projectDir);
 
-        await runScript(project.projectDir, "db:init");
-        await runScript(project.projectDir, "db:verify");
-      } finally {
-        await initDb.close();
-      }
-
-      expect(project).toBeDefined();
-      const migrationDb = await createDevDatabase();
-      try {
-        await writeDatabaseUrl(project!.projectDir, migrationDb.connectionString);
-        await runScript(project!.projectDir, "migration:plan");
-        await runScript(project!.projectDir, "migrate");
-        await runScript(project!.projectDir, "db:seed");
-        await verifyGeneratedProject(project!.projectDir, "postgres");
-      } finally {
-        await migrationDb.close();
-      }
-    },
-    TEST_TIMEOUT,
-  );
-
-  test(
-    "mongodb runs migrations, seed, generated queries, and build",
-    async () => {
-      let replSet: MongoMemoryReplSet | undefined;
-      try {
-        replSet = await MongoMemoryReplSet.create({
-          instanceOpts: [{ launchTimeout: MONGO_STARTUP_TIMEOUT, storageEngine: "wiredTiger" }],
-          replSet: { count: 1, storageEngine: "wiredTiger" },
-        });
-        const databaseUrl = buildMongoUri(replSet.getUri(), "create_prisma_e2e");
-        const project = await scaffoldProject("mongo", databaseUrl);
-
-        await installAndEmit(project.projectDir);
-        await runScript(project.projectDir, "migration:plan");
-        await runScript(project.projectDir, "migrate");
-        await runScript(project.projectDir, "db:seed");
-        await verifyGeneratedProject(project.projectDir, "mongo");
-      } finally {
-        await replSet?.stop();
-      }
-    },
-    TEST_TIMEOUT,
-  );
+        const mongo = await startMemoryMongo(project.projectDir);
+        try {
+          await runScript(project.projectDir, "migration:plan");
+          await runScript(project.projectDir, "migrate");
+          await runScript(project.projectDir, "db:seed");
+          await verifyGeneratedProject(project.projectDir, template, "mongo");
+        } finally {
+          await mongo.stop();
+        }
+      },
+      TEST_TIMEOUT,
+    );
+  }
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -106,8 +106,8 @@ describe("writePrismaDependencies", () => {
         const packageJson = await readPackageJson(projectDir);
 
         expect(packageJson.scripts).toMatchObject({
-          "contract:emit": `deno run -A --env-file=.env npm:prisma-next@${PRISMA_NEXT_PACKAGE_VERSION} contract emit`,
-          "migration:plan": `deno run -A --env-file=.env npm:prisma-next@${PRISMA_NEXT_PACKAGE_VERSION} migration plan`,
+          "contract:emit": "deno run -A --env-file=.env npm:prisma-next contract emit",
+          "migration:plan": "deno run -A --env-file=.env npm:prisma-next migration plan",
         });
       },
     );
@@ -272,13 +272,14 @@ describe("getInstallArgs", () => {
     expect(getInstallArgs("bun")).toEqual({ command: "bun", args: ["install"] });
   });
 
-  test("uses Prisma Next latest npm specifiers for Deno installs", () => {
-    expect(getDenoPrismaSpecifier()).toBe(`npm:prisma-next@${PRISMA_NEXT_PACKAGE_VERSION}`);
+  test("uses Deno-compatible npm specifiers for Deno installs", () => {
+    expect(PRISMA_NEXT_PACKAGE_VERSION).toBe("latest");
+    expect(getDenoPrismaSpecifier()).toBe("npm:prisma-next");
     expect(getInstallArgs("deno")).toEqual({
       command: "deno",
       args: [
         "install",
-        `--allow-scripts=npm:prisma-next@${PRISMA_NEXT_PACKAGE_VERSION},npm:@prisma-next/postgres@${PRISMA_NEXT_PACKAGE_VERSION},npm:@prisma-next/mongo@${PRISMA_NEXT_PACKAGE_VERSION}`,
+        "--allow-scripts=npm:prisma-next,npm:@prisma-next/postgres,npm:@prisma-next/mongo,npm:mongodb-memory-server",
       ],
     });
   });


### PR DESCRIPTION
## Summary

Adds Docker-free local MongoDB dev support for Prisma Next scaffolds using `mongodb-memory-server`.

- Adds generated `db:up`, `db:down`, and `db:reset` scripts for MongoDB projects
- Starts a detached local MongoDB replica set so Prisma Next migrations can run
- Persists Mongo data in `.mongo-data/db` across restarts
- Stores helper metadata in `.mongo-data/mongo.pid` and `.mongo-data/mongo.log`
- Adds `mongodb-memory-server` only for MongoDB scaffolds
- Keeps Docker Compose out of generated MongoDB projects
- Supports Bun, npm, pnpm, Yarn, and Deno script generation

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test ./tests/install.test.ts ./tests/telemetry.test.ts`
- `bun run build`
- `bun test --timeout 240000 ./tests/e2e/create-prisma.e2e.test.ts`
- Smoke scaffold matrix: 9 templates x 2 providers x 5 package managers = 90/90 passed
- Manual minimal Mongo + Bun flow: install, contract emit, `db:up`, migration plan/apply, seed, query via dev script, `db:down`, `db:reset`
