### PR TITLE
feat: let create-prisma target a specific Prisma Next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Use Prisma Postgres auto-provisioning:
 create-prisma --name my-app --template nest --provider postgres --prisma-postgres
 ```
 
+Target a specific Prisma Next release (useful for regression / bisect work):
+
+```bash
+create-prisma --name my-app --template hono --prisma-next-version 0.10.0
+```
+
+Scaffold against an open PR via pkg.pr.new:
+
+```bash
+create-prisma --name my-app --template hono --prisma-next-version pkg-pr-new:bad6795
+```
+
 ## Supported Templates
 
 - `minimal` - script-first Prisma Next starter with no web framework
@@ -130,6 +142,10 @@ create-prisma --name my-app --template nest --provider postgres --prisma-postgre
 - `--no-install` scaffold only
 - `--no-emit` skip `prisma-next contract emit`
 - `--prisma-postgres` provision Prisma Postgres for PostgreSQL
+- `--prisma-next-version <spec>` target a specific Prisma Next release, npm dist-tag, or
+  pkg.pr.new PR preview. Accepts a published version (`0.10.0`, `0.11.0-dev.9`),
+  an npm dist-tag (`latest` (default), `dev`, `next`, …), or `pkg-pr-new:<sha|branch|pr-number>`
+  to install from `https://pkg.pr.new/prisma/prisma-next/<package>@<ref>`.
 - `--force` allow scaffolding into a non-empty directory
 - `--verbose` print full command output
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
     "test": "bun run test:unit && bun run test:e2e",
-    "test:unit": "bun test ./tests/install.test.ts ./tests/telemetry.test.ts",
+    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/install.test.ts ./tests/telemetry.test.ts",
     "test:e2e": "bun test --timeout 180000 ./tests/e2e/create-prisma.e2e.test.ts",
     "check": "bun run format:check && bun run lint",
     "lint": "oxlint . --deny-warnings",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -334,6 +334,7 @@ async function executeCreateContext(
       template: context.template,
       packageManager: context.prismaSetupContext.packageManager,
       projectDir: context.targetDirectory,
+      prismaNextSpec: context.prismaSetupContext.prismaNextSpec,
     });
   } catch (error) {
     createSpinner?.stop("Could not create Prisma Next project.");

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -9,7 +9,42 @@ export const dependencyVersionMap = {
   tsx: "^4.21.0",
 } as const;
 
-export const PRISMA_NEXT_PACKAGE_VERSION = "latest";
+export const PRISMA_NEXT_DEFAULT_VERSION = "latest";
+const PKG_PR_NEW_PREFIX = "pkg-pr-new:";
+const PKG_PR_NEW_BASE_URL = "https://pkg.pr.new/prisma/prisma-next";
+
+export type ResolvedPrismaNextSpec =
+  | { kind: "npm"; spec: string }
+  | { kind: "pkg-pr-new"; ref: string };
+
+export const DEFAULT_PRISMA_NEXT_SPEC: ResolvedPrismaNextSpec = {
+  kind: "npm",
+  spec: PRISMA_NEXT_DEFAULT_VERSION,
+};
+
+export function parsePrismaNextVersionSpec(input: string | undefined): ResolvedPrismaNextSpec {
+  if (input === undefined) {
+    return DEFAULT_PRISMA_NEXT_SPEC;
+  }
+
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return DEFAULT_PRISMA_NEXT_SPEC;
+  }
+
+  if (trimmed.startsWith(PKG_PR_NEW_PREFIX)) {
+    const ref = trimmed.slice(PKG_PR_NEW_PREFIX.length).trim();
+    if (ref.length === 0) {
+      throw new Error(
+        `Invalid --prisma-next-version value: '${input}'. Expected 'pkg-pr-new:<sha|branch|pr-number>'.`,
+      );
+    }
+
+    return { kind: "pkg-pr-new", ref };
+  }
+
+  return { kind: "npm", spec: trimmed };
+}
 
 export type AvailableDependency = keyof typeof dependencyVersionMap;
 
@@ -24,13 +59,27 @@ export function isPrismaNextPackage(packageName: string): boolean {
   return packageName === "prisma-next" || packageName.startsWith("@prisma-next/");
 }
 
-export function getPrismaNextPackageSpecifier(packageName: string): string {
-  return `${packageName}@${PRISMA_NEXT_PACKAGE_VERSION}`;
+export function getPrismaNextPackageSpecifier(
+  packageName: string,
+  spec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
+): string {
+  if (spec.kind === "pkg-pr-new") {
+    return `${PKG_PR_NEW_BASE_URL}/${packageName}@${spec.ref}`;
+  }
+
+  return `${packageName}@${spec.spec}`;
 }
 
-export function getDependencyVersion(packageName: string): string | undefined {
+export function getDependencyVersion(
+  packageName: string,
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
+): string | undefined {
   if (isPrismaNextPackage(packageName)) {
-    return PRISMA_NEXT_PACKAGE_VERSION;
+    if (prismaNextSpec.kind === "pkg-pr-new") {
+      return `${PKG_PR_NEW_BASE_URL}/${packageName}@${prismaNextSpec.ref}`;
+    }
+
+    return prismaNextSpec.spec;
   }
 
   return dependencyVersionMap[packageName as AvailableDependency];

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -2,7 +2,12 @@ import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
-import { getDependencyVersion, getCreateTemplateDependencies } from "../constants/dependencies";
+import {
+  DEFAULT_PRISMA_NEXT_SPEC,
+  getCreateTemplateDependencies,
+  getDependencyVersion,
+  type ResolvedPrismaNextSpec,
+} from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
 import { getDenoPrismaSpecifier, getInstallArgs } from "../utils/package-manager";
@@ -114,6 +119,7 @@ export async function addPackageDependency(opts: {
   scripts?: Record<string, string>;
   scriptMode?: "if-missing";
   projectDir: string;
+  prismaNextSpec?: ResolvedPrismaNextSpec;
 }): Promise<void> {
   const {
     dependencies = [],
@@ -122,6 +128,7 @@ export async function addPackageDependency(opts: {
     scripts = {},
     scriptMode,
     projectDir,
+    prismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
   } = opts;
 
   const pkgJsonPath = path.join(projectDir, "package.json");
@@ -138,7 +145,7 @@ export async function addPackageDependency(opts: {
   if (!pkgJson.scripts) pkgJson.scripts = {};
 
   for (const pkgName of unique(dependencies)) {
-    const version = getDependencyVersion(pkgName);
+    const version = getDependencyVersion(pkgName, prismaNextSpec);
     if (version) {
       pkgJson.dependencies[pkgName] = version;
     } else {
@@ -147,7 +154,7 @@ export async function addPackageDependency(opts: {
   }
 
   for (const pkgName of unique(devDependencies)) {
-    const version = getDependencyVersion(pkgName);
+    const version = getDependencyVersion(pkgName, prismaNextSpec);
     if (version) {
       pkgJson.devDependencies[pkgName] = version;
     } else {
@@ -186,6 +193,7 @@ export async function writePrismaDependencies(
   packageManager: PackageManager,
   authoring: AuthoringStyle,
   projectDir = process.cwd(),
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
 ): Promise<void> {
   const dependencies: string[] = [getDbPackages(provider, packageManager), "dotenv"];
   const devDependencies: string[] = ["prisma-next", "@prisma-next/cli", "@types/node"];
@@ -202,6 +210,7 @@ export async function writePrismaDependencies(
     devDependencies,
     scripts: prismaScriptMap,
     projectDir,
+    prismaNextSpec,
   });
 }
 
@@ -209,8 +218,14 @@ export async function writeCreateTemplateDependencies(opts: {
   template: CreateTemplate;
   packageManager: PackageManager;
   projectDir?: string;
+  prismaNextSpec?: ResolvedPrismaNextSpec;
 }): Promise<void> {
-  const { template, packageManager, projectDir = process.cwd() } = opts;
+  const {
+    template,
+    packageManager,
+    projectDir = process.cwd(),
+    prismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
+  } = opts;
   const targets = getCreateTemplateDependencies(template, packageManager);
 
   for (const dependencyTarget of targets) {
@@ -221,6 +236,7 @@ export async function writeCreateTemplateDependencies(opts: {
       devDependencies: dependencyTarget.devDependencies,
       customDependencies: dependencyTarget.customDependencies,
       projectDir: targetDirectory,
+      prismaNextSpec,
     });
   }
 }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -9,7 +9,13 @@ import {
   PRISMA_POSTGRES_TEMPORARY_NOTICE,
   provisionPrismaPostgres,
 } from "./prisma-postgres";
-import { getDependencyVersion, getPrismaNextPackageSpecifier } from "../constants/dependencies";
+import {
+  DEFAULT_PRISMA_NEXT_SPEC,
+  getDependencyVersion,
+  getPrismaNextPackageSpecifier,
+  parsePrismaNextVersionSpec,
+  type ResolvedPrismaNextSpec,
+} from "../constants/dependencies";
 import {
   AuthoringStyleSchema,
   DatabaseProviderSchema,
@@ -64,6 +70,7 @@ export type PrismaSetupContext = {
   shouldUsePrismaPostgres: boolean;
   packageManager: PackageManager;
   shouldInstall: boolean;
+  prismaNextSpec: ResolvedPrismaNextSpec;
 };
 
 type FinalizePrismaOptions = {
@@ -459,6 +466,14 @@ export async function collectPrismaSetupContext(
   const verbose = input.verbose === true;
   const shouldEmit = input.emit ?? DEFAULT_EMIT;
 
+  let prismaNextSpec: ResolvedPrismaNextSpec;
+  try {
+    prismaNextSpec = parsePrismaNextVersionSpec(input.prismaNextVersion);
+  } catch (error) {
+    cancel(error instanceof Error ? error.message : String(error));
+    return;
+  }
+
   const databaseProvider =
     input.provider ?? (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider());
   if (!databaseProvider) {
@@ -515,6 +530,7 @@ export async function collectPrismaSetupContext(
     shouldUsePrismaPostgres,
     packageManager,
     shouldInstall,
+    prismaNextSpec,
   };
 }
 
@@ -821,6 +837,7 @@ async function writeDependenciesForContext(
       context.packageManager,
       context.authoring,
       projectDir,
+      context.prismaNextSpec,
     );
     return true;
   } catch (error) {
@@ -829,8 +846,10 @@ async function writeDependenciesForContext(
   }
 }
 
-function getPrismaNextCliPackageSpecifier(): string {
-  return getPrismaNextPackageSpecifier("prisma-next");
+function getPrismaNextCliPackageSpecifier(
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
+): string {
+  return getPrismaNextPackageSpecifier("prisma-next", prismaNextSpec);
 }
 
 function getPrismaNextInitTarget(provider: DatabaseProvider): "mongodb" | "postgres" {
@@ -840,16 +859,17 @@ function getPrismaNextInitTarget(provider: DatabaseProvider): "mongodb" | "postg
 function getPrismaNextInitCliArgs(
   packageManager: PackageManager,
   prismaNextArgs: string[],
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
 ): { command: string; args: string[] } {
   if (packageManager === "npm") {
     return {
       command: "npx",
-      args: ["--yes", getPrismaNextCliPackageSpecifier(), "init", ...prismaNextArgs],
+      args: ["--yes", getPrismaNextCliPackageSpecifier(prismaNextSpec), "init", ...prismaNextArgs],
     };
   }
 
   return getPackageExecutionArgs(packageManager, [
-    getPrismaNextCliPackageSpecifier(),
+    getPrismaNextCliPackageSpecifier(prismaNextSpec),
     "init",
     ...prismaNextArgs,
   ]);
@@ -858,8 +878,9 @@ function getPrismaNextInitCliArgs(
 function getPrismaNextInitCliCommand(
   packageManager: PackageManager,
   prismaNextArgs: string[],
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
 ): string {
-  const execution = getPrismaNextInitCliArgs(packageManager, prismaNextArgs);
+  const execution = getPrismaNextInitCliArgs(packageManager, prismaNextArgs, prismaNextSpec);
   return [execution.command, ...execution.args].join(" ");
 }
 
@@ -878,14 +899,22 @@ async function runPrismaNextInitForContext(
     getContractPath(context.authoring),
     "--no-install",
   ];
-  const initCommand = getPrismaNextInitCliCommand(context.packageManager, initArgs);
+  const initCommand = getPrismaNextInitCliCommand(
+    context.packageManager,
+    initArgs,
+    context.prismaNextSpec,
+  );
 
   if (context.verbose) {
     log.step(`Running ${initCommand}`);
   }
 
   try {
-    const initExecution = getPrismaNextInitCliArgs(context.packageManager, initArgs);
+    const initExecution = getPrismaNextInitCliArgs(
+      context.packageManager,
+      initArgs,
+      context.prismaNextSpec,
+    );
     await execa(initExecution.command, initExecution.args, {
       cwd: projectDir,
       stdio: context.verbose ? "inherit" : "pipe",

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -1,7 +1,43 @@
 import type { CreatePromptContext } from "../commands/create";
+import {
+  DEFAULT_PRISMA_NEXT_SPEC,
+  PRISMA_NEXT_DEFAULT_VERSION,
+  type ResolvedPrismaNextSpec,
+} from "../constants/dependencies";
 import type { CreateCommandInput } from "../types";
 
 import { trackCliTelemetry } from "./client";
+
+export type PrismaNextVersionKind = "default" | "npm-tag" | "npm-version" | "pkg-pr-new";
+
+function classifyPrismaNextSpec(spec: ResolvedPrismaNextSpec | undefined): PrismaNextVersionKind {
+  if (!spec || spec === DEFAULT_PRISMA_NEXT_SPEC) {
+    return "default";
+  }
+
+  if (spec.kind === "pkg-pr-new") {
+    return "pkg-pr-new";
+  }
+
+  if (spec.spec === PRISMA_NEXT_DEFAULT_VERSION) {
+    return "default";
+  }
+
+  // npm dist-tags are sequences of lowercase letters / digits / hyphens that
+  // don't start with a digit; semver releases always start with a digit. This
+  // is intentionally a coarse classifier — npm itself accepts anything as a
+  // tag, but tags collected over the wire are useful as a low-cardinality
+  // signal for the onboarding audit.
+  return /^[0-9]/.test(spec.spec) ? "npm-version" : "npm-tag";
+}
+
+function getPrismaNextVersionSpecString(spec: ResolvedPrismaNextSpec | undefined): string | null {
+  if (!spec) {
+    return null;
+  }
+
+  return spec.kind === "pkg-pr-new" ? `pkg-pr-new:${spec.ref}` : spec.spec;
+}
 
 export const CREATE_PRISMA_NEXT_COMPLETED_EVENT = "cli:create_prisma_next_command_completed";
 export const CREATE_PRISMA_NEXT_FAILED_EVENT = "cli:create_prisma_next_command_failed";
@@ -29,6 +65,8 @@ function getBaseCreateProperties(
   input: CreateCommandInput,
   context?: CreatePromptContext,
 ): Record<string, boolean | number | string | string[] | null> {
+  const resolvedPrismaNextSpec = context?.prismaSetupContext.prismaNextSpec;
+
   return {
     command: "create",
     "uses-defaults": input.yes === true,
@@ -43,6 +81,9 @@ function getBaseCreateProperties(
     "uses-prisma-postgres":
       context?.prismaSetupContext.shouldUsePrismaPostgres ?? input.prismaPostgres ?? null,
     "target-directory-state": context ? getTargetDirectoryState(context) : null,
+    "prisma-next-version-kind": classifyPrismaNextSpec(resolvedPrismaNextSpec),
+    "prisma-next-version-spec":
+      getPrismaNextVersionSpecString(resolvedPrismaNextSpec) ?? input.prismaNextVersion ?? null,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,14 @@ export const PrismaSetupOptionsSchema = z.object({
   databaseUrl: DatabaseUrlSchema.optional().describe("DATABASE_URL value"),
   install: z.boolean().optional().describe("Install dependencies with selected package manager"),
   emit: z.boolean().optional().describe("Emit Prisma Next contract artifacts after scaffolding"),
+  prismaNextVersion: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Prisma Next version, npm dist-tag, or 'pkg-pr-new:<sha|branch|pr>' (default: latest)",
+    ),
 });
 
 export const PrismaSetupCommandInputSchema = CommonCommandOptionsSchema.extend(

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_PRISMA_NEXT_SPEC,
+  getDependencyVersion,
+  getPrismaNextPackageSpecifier,
+  isPrismaNextPackage,
+  parsePrismaNextVersionSpec,
+  PRISMA_NEXT_DEFAULT_VERSION,
+} from "../src/constants/dependencies";
+
+describe("parsePrismaNextVersionSpec", () => {
+  test("defaults to the npm `latest` dist-tag when input is omitted", () => {
+    expect(parsePrismaNextVersionSpec(undefined)).toEqual(DEFAULT_PRISMA_NEXT_SPEC);
+    expect(DEFAULT_PRISMA_NEXT_SPEC).toEqual({ kind: "npm", spec: PRISMA_NEXT_DEFAULT_VERSION });
+  });
+
+  test("treats blank input as the default", () => {
+    expect(parsePrismaNextVersionSpec("")).toEqual(DEFAULT_PRISMA_NEXT_SPEC);
+    expect(parsePrismaNextVersionSpec("   ")).toEqual(DEFAULT_PRISMA_NEXT_SPEC);
+  });
+
+  test("passes through published versions verbatim", () => {
+    expect(parsePrismaNextVersionSpec("0.10.0")).toEqual({ kind: "npm", spec: "0.10.0" });
+    expect(parsePrismaNextVersionSpec("0.11.0-dev.9")).toEqual({
+      kind: "npm",
+      spec: "0.11.0-dev.9",
+    });
+  });
+
+  test("passes through npm dist-tags verbatim", () => {
+    expect(parsePrismaNextVersionSpec("dev")).toEqual({ kind: "npm", spec: "dev" });
+    expect(parsePrismaNextVersionSpec("next")).toEqual({ kind: "npm", spec: "next" });
+    expect(parsePrismaNextVersionSpec("latest")).toEqual({ kind: "npm", spec: "latest" });
+  });
+
+  test("extracts a pkg.pr.new ref from the pkg-pr-new: prefix", () => {
+    expect(parsePrismaNextVersionSpec("pkg-pr-new:bad6795")).toEqual({
+      kind: "pkg-pr-new",
+      ref: "bad6795",
+    });
+    expect(parsePrismaNextVersionSpec("pkg-pr-new:aman/some-branch")).toEqual({
+      kind: "pkg-pr-new",
+      ref: "aman/some-branch",
+    });
+    expect(parsePrismaNextVersionSpec("pkg-pr-new:581")).toEqual({
+      kind: "pkg-pr-new",
+      ref: "581",
+    });
+  });
+
+  test("rejects an empty pkg-pr-new ref", () => {
+    expect(() => parsePrismaNextVersionSpec("pkg-pr-new:")).toThrow(/pkg-pr-new:/);
+    expect(() => parsePrismaNextVersionSpec("pkg-pr-new:   ")).toThrow(/pkg-pr-new:/);
+  });
+});
+
+describe("isPrismaNextPackage", () => {
+  test("matches prisma-next and @prisma-next/* scoped packages", () => {
+    expect(isPrismaNextPackage("prisma-next")).toBe(true);
+    expect(isPrismaNextPackage("@prisma-next/cli")).toBe(true);
+    expect(isPrismaNextPackage("@prisma-next/vite-plugin-contract-emit")).toBe(true);
+  });
+
+  test("ignores everything else", () => {
+    expect(isPrismaNextPackage("prisma")).toBe(false);
+    expect(isPrismaNextPackage("@prisma/client")).toBe(false);
+    expect(isPrismaNextPackage("dotenv")).toBe(false);
+  });
+});
+
+describe("getPrismaNextPackageSpecifier", () => {
+  test("emits name@version for npm specs (default and explicit)", () => {
+    expect(getPrismaNextPackageSpecifier("prisma-next")).toBe("prisma-next@latest");
+    expect(getPrismaNextPackageSpecifier("@prisma-next/cli", { kind: "npm", spec: "0.10.0" })).toBe(
+      "@prisma-next/cli@0.10.0",
+    );
+    expect(getPrismaNextPackageSpecifier("@prisma-next/cli", { kind: "npm", spec: "dev" })).toBe(
+      "@prisma-next/cli@dev",
+    );
+  });
+
+  test("emits a pkg.pr.new URL specifier for pkg-pr-new specs", () => {
+    expect(
+      getPrismaNextPackageSpecifier("prisma-next", { kind: "pkg-pr-new", ref: "bad6795" }),
+    ).toBe("https://pkg.pr.new/prisma/prisma-next/prisma-next@bad6795");
+    expect(
+      getPrismaNextPackageSpecifier("@prisma-next/cli", { kind: "pkg-pr-new", ref: "581" }),
+    ).toBe("https://pkg.pr.new/prisma/prisma-next/@prisma-next/cli@581");
+  });
+});
+
+describe("getDependencyVersion", () => {
+  test("returns the npm spec verbatim for @prisma-next/* packages", () => {
+    expect(getDependencyVersion("prisma-next")).toBe("latest");
+    expect(getDependencyVersion("@prisma-next/cli", { kind: "npm", spec: "0.10.0" })).toBe(
+      "0.10.0",
+    );
+  });
+
+  test("returns the full pkg.pr.new URL when the spec is pkg-pr-new", () => {
+    expect(getDependencyVersion("prisma-next", { kind: "pkg-pr-new", ref: "bad6795" })).toBe(
+      "https://pkg.pr.new/prisma/prisma-next/prisma-next@bad6795",
+    );
+    expect(
+      getDependencyVersion("@prisma-next/cli", { kind: "pkg-pr-new", ref: "aman/some-branch" }),
+    ).toBe("https://pkg.pr.new/prisma/prisma-next/@prisma-next/cli@aman/some-branch");
+  });
+
+  test("ignores the Prisma Next spec for unrelated packages and uses dependencyVersionMap", () => {
+    expect(getDependencyVersion("dotenv", { kind: "pkg-pr-new", ref: "ignored" })).toBe("^17.4.2");
+    expect(getDependencyVersion("tsx", { kind: "npm", spec: "0.10.0" })).toBe("^4.21.0");
+    expect(getDependencyVersion("not-a-known-package")).toBeUndefined();
+  });
+});

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -3,10 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import {
-  dependencyVersionMap,
-  PRISMA_NEXT_DEFAULT_VERSION,
-} from "../src/constants/dependencies";
+import { dependencyVersionMap, PRISMA_NEXT_DEFAULT_VERSION } from "../src/constants/dependencies";
 import { scaffoldCreateTemplate } from "../src/templates/render-create-template";
 import { writeCreateTemplateDependencies, writePrismaDependencies } from "../src/tasks/install";
 import { getDenoPrismaSpecifier, getInstallArgs } from "../src/utils/package-manager";
@@ -89,6 +86,62 @@ describe("writePrismaDependencies", () => {
           "migration:plan": "bun prisma-next migration plan",
           migrate: "bun prisma-next migrate",
         });
+      },
+    );
+  });
+
+  test("pins every Prisma Next package to a non-default spec when one is provided", async () => {
+    await withPackageJson(
+      {
+        name: "app",
+        dependencies: {},
+        devDependencies: {},
+      },
+      async (projectDir) => {
+        await writePrismaDependencies("postgres", "bun", "psl", projectDir, {
+          kind: "npm",
+          spec: "0.10.0",
+        });
+
+        const packageJson = await readPackageJson(projectDir);
+        const allDependencies = {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+        };
+
+        for (const [packageName, version] of Object.entries(allDependencies)) {
+          if (packageName === "prisma-next" || packageName.startsWith("@prisma-next/")) {
+            expect(version).toBe("0.10.0");
+          }
+        }
+      },
+    );
+  });
+
+  test("writes pkg.pr.new URL specifiers for every Prisma Next dependency", async () => {
+    await withPackageJson(
+      {
+        name: "app",
+        dependencies: {},
+        devDependencies: {},
+      },
+      async (projectDir) => {
+        await writePrismaDependencies("postgres", "bun", "psl", projectDir, {
+          kind: "pkg-pr-new",
+          ref: "bad6795",
+        });
+
+        const packageJson = await readPackageJson(projectDir);
+        const allDependencies = {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+        };
+
+        for (const [packageName, version] of Object.entries(allDependencies)) {
+          if (packageName === "prisma-next" || packageName.startsWith("@prisma-next/")) {
+            expect(version).toBe(`https://pkg.pr.new/prisma/prisma-next/${packageName}@bad6795`);
+          }
+        }
       },
     );
   });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { dependencyVersionMap, PRISMA_NEXT_PACKAGE_VERSION } from "../src/constants/dependencies";
+import {
+  dependencyVersionMap,
+  PRISMA_NEXT_DEFAULT_VERSION,
+} from "../src/constants/dependencies";
 import { scaffoldCreateTemplate } from "../src/templates/render-create-template";
 import { writeCreateTemplateDependencies, writePrismaDependencies } from "../src/tasks/install";
 import { getDenoPrismaSpecifier, getInstallArgs } from "../src/utils/package-manager";
@@ -40,7 +43,7 @@ function expectPrismaNextPackagesUseLatest(packageJson: PackageJson): void {
 
   for (const [packageName, version] of Object.entries(dependencies)) {
     if (packageName === "prisma-next" || packageName.startsWith("@prisma-next/")) {
-      expect(version).toBe(PRISMA_NEXT_PACKAGE_VERSION);
+      expect(version).toBe(PRISMA_NEXT_DEFAULT_VERSION);
     }
   }
 }
@@ -67,17 +70,17 @@ describe("writePrismaDependencies", () => {
         expectPrismaNextPackagesUseLatest(packageJson);
 
         expect(packageJson.dependencies).toMatchObject({
-          "@prisma-next/mongo": PRISMA_NEXT_PACKAGE_VERSION,
+          "@prisma-next/mongo": PRISMA_NEXT_DEFAULT_VERSION,
           dotenv: dependencyVersionMap.dotenv,
           hono: "^4.12.2",
         });
         expect(packageJson.devDependencies).toMatchObject({
-          "@prisma-next/cli": PRISMA_NEXT_PACKAGE_VERSION,
-          "@prisma-next/mongo-contract-ts": PRISMA_NEXT_PACKAGE_VERSION,
-          "@prisma-next/mongo-orm": PRISMA_NEXT_PACKAGE_VERSION,
-          "@prisma-next/target-mongo": PRISMA_NEXT_PACKAGE_VERSION,
+          "@prisma-next/cli": PRISMA_NEXT_DEFAULT_VERSION,
+          "@prisma-next/mongo-contract-ts": PRISMA_NEXT_DEFAULT_VERSION,
+          "@prisma-next/mongo-orm": PRISMA_NEXT_DEFAULT_VERSION,
+          "@prisma-next/target-mongo": PRISMA_NEXT_DEFAULT_VERSION,
           "@types/node": dependencyVersionMap["@types/node"],
-          "prisma-next": PRISMA_NEXT_PACKAGE_VERSION,
+          "prisma-next": PRISMA_NEXT_DEFAULT_VERSION,
           typescript: "^5.8.3",
         });
         expect(packageJson.scripts).toMatchObject({
@@ -134,7 +137,7 @@ describe("writeCreateTemplateDependencies", () => {
         const packageJson = await readPackageJson(projectDir);
 
         expect(packageJson.devDependencies).toMatchObject({
-          "@prisma-next/vite-plugin-contract-emit": PRISMA_NEXT_PACKAGE_VERSION,
+          "@prisma-next/vite-plugin-contract-emit": PRISMA_NEXT_DEFAULT_VERSION,
           vite: "^7.3.3",
         });
       },
@@ -274,7 +277,7 @@ describe("getInstallArgs", () => {
   });
 
   test("uses Deno-compatible npm specifiers for Deno installs", () => {
-    expect(PRISMA_NEXT_PACKAGE_VERSION).toBe("latest");
+    expect(PRISMA_NEXT_DEFAULT_VERSION).toBe("latest");
     expect(getDenoPrismaSpecifier()).toBe("npm:prisma-next");
     expect(getInstallArgs("deno")).toEqual({
       command: "deno",

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { CreatePromptContext } from "../src/commands/create";
+import {
+  DEFAULT_PRISMA_NEXT_SPEC,
+  type ResolvedPrismaNextSpec,
+} from "../src/constants/dependencies";
 import type { CreateCommandInput } from "../src/types";
 
 const trackCliTelemetry = mock(async () => {});
@@ -21,27 +25,34 @@ const createInput = {
   name: "app",
 } satisfies CreateCommandInput;
 
-const createContext = {
-  targetDirectory: "/tmp/app",
-  targetPathState: {
-    exists: false,
-    isDirectory: true,
-    isEmptyDirectory: true,
-  },
-  force: false,
-  template: "hono",
-  projectPackageName: "app",
-  prismaSetupContext: {
-    projectDir: "/tmp/app",
-    verbose: false,
-    shouldEmit: true,
-    databaseProvider: "mongo",
-    authoring: "psl",
-    shouldUsePrismaPostgres: false,
-    packageManager: "bun",
-    shouldInstall: true,
-  },
-} satisfies CreatePromptContext;
+function makeCreateContext(
+  prismaNextSpec: ResolvedPrismaNextSpec = DEFAULT_PRISMA_NEXT_SPEC,
+): CreatePromptContext {
+  return {
+    targetDirectory: "/tmp/app",
+    targetPathState: {
+      exists: false,
+      isDirectory: true,
+      isEmptyDirectory: true,
+    },
+    force: false,
+    template: "hono",
+    projectPackageName: "app",
+    prismaSetupContext: {
+      projectDir: "/tmp/app",
+      verbose: false,
+      shouldEmit: true,
+      databaseProvider: "mongo",
+      authoring: "psl",
+      shouldUsePrismaPostgres: false,
+      packageManager: "bun",
+      shouldInstall: true,
+      prismaNextSpec,
+    },
+  };
+}
+
+const createContext = makeCreateContext();
 
 beforeEach(() => {
   trackCliTelemetry.mockClear();
@@ -62,6 +73,56 @@ describe("create telemetry", () => {
         template: "hono",
         "database-provider": "mongo",
         "duration-ms": 123,
+        "prisma-next-version-kind": "default",
+        "prisma-next-version-spec": "latest",
+      }),
+    );
+  });
+
+  test("classifies a published Prisma Next version as npm-version", async () => {
+    await trackCreateCompleted({
+      input: { ...createInput, prismaNextVersion: "0.10.0" },
+      context: makeCreateContext({ kind: "npm", spec: "0.10.0" }),
+      durationMs: 1,
+    });
+
+    expect(trackCliTelemetry).toHaveBeenCalledWith(
+      CREATE_PRISMA_NEXT_COMPLETED_EVENT,
+      expect.objectContaining({
+        "prisma-next-version-kind": "npm-version",
+        "prisma-next-version-spec": "0.10.0",
+      }),
+    );
+  });
+
+  test("classifies a non-default dist-tag as npm-tag", async () => {
+    await trackCreateCompleted({
+      input: { ...createInput, prismaNextVersion: "dev" },
+      context: makeCreateContext({ kind: "npm", spec: "dev" }),
+      durationMs: 1,
+    });
+
+    expect(trackCliTelemetry).toHaveBeenCalledWith(
+      CREATE_PRISMA_NEXT_COMPLETED_EVENT,
+      expect.objectContaining({
+        "prisma-next-version-kind": "npm-tag",
+        "prisma-next-version-spec": "dev",
+      }),
+    );
+  });
+
+  test("classifies a pkg-pr-new spec and round-trips the ref in the spec field", async () => {
+    await trackCreateCompleted({
+      input: { ...createInput, prismaNextVersion: "pkg-pr-new:bad6795" },
+      context: makeCreateContext({ kind: "pkg-pr-new", ref: "bad6795" }),
+      durationMs: 1,
+    });
+
+    expect(trackCliTelemetry).toHaveBeenCalledWith(
+      CREATE_PRISMA_NEXT_COMPLETED_EVENT,
+      expect.objectContaining({
+        "prisma-next-version-kind": "pkg-pr-new",
+        "prisma-next-version-spec": "pkg-pr-new:bad6795",
       }),
     );
   });
@@ -82,6 +143,22 @@ describe("create telemetry", () => {
         "duration-ms": 456,
         "error-code": "ERR_TEST",
         "failure-stage": "prisma_setup",
+      }),
+    );
+  });
+
+  test("falls back to the raw input spec when no context is available on failure", async () => {
+    await trackCreateFailed({
+      input: { ...createInput, prismaNextVersion: "0.11.0-dev.9" },
+      durationMs: 1,
+      stage: "validate_input",
+    });
+
+    expect(trackCliTelemetry).toHaveBeenCalledWith(
+      CREATE_PRISMA_NEXT_FAILED_EVENT,
+      expect.objectContaining({
+        "prisma-next-version-kind": "default",
+        "prisma-next-version-spec": "0.11.0-dev.9",
       }),
     );
   });


### PR DESCRIPTION
After this PR, you can scaffold against an exact Prisma Next version through the canonical entry point:

```bash
create-prisma --name my-app --template hono --prisma-next-version 0.10.0
# every @prisma-next/* dep in package.json pinned to 0.10.0
# `prisma-next init` invoked as `npx --yes prisma-next@0.10.0 init …`
# agent skills resolved from prisma/prisma-next/skills#v0.10.0
```

Closes [TML-2692](https://linear.app/prisma-company/issue/TML-2692).

## Why

`create-prisma@next` hard-codes the Prisma Next dependency spec to `"latest"`. The moment a new Prisma Next version ships, the previous one becomes unreachable through the canonical scaffold path, which means we cannot reproduce user-filed issues against the exact version they were filed on, smoke-test release candidates before they get the `latest` tag, or dogfood open PRs end-to-end. The onboarding audit needs all three.

## What `<spec>` accepts

The simplest case is **a published version**, used for regression and bisect work:

```bash
create-prisma --prisma-next-version 0.10.0
create-prisma --prisma-next-version 0.11.0-dev.9
```

The next is **an npm dist-tag**, used to smoke-test release candidates before they get the `latest` tag:

```bash
create-prisma --prisma-next-version dev   # or `next`, `canary`, …
```

These two cases work uniformly across every supported package manager (npm, pnpm, yarn, bun, deno) and across the existing skill-install path: `prisma-next init` already derives the skills ref from the installed CLI's `package.json#version`, so installing `@prisma-next/cli@0.10.0` automatically pulls `prisma/prisma-next/skills#v0.10.0`.

The third case is **a pkg.pr.new ref**, used to dogfood open PRs:

```bash
create-prisma --prisma-next-version pkg-pr-new:bad6795
# rewrites every @prisma-next/* install to
# https://pkg.pr.new/prisma/prisma-next/<package>@bad6795
```

This case is partial in this PR — see *Scope* below.

Omitting the flag preserves today's behaviour exactly.

## What changed under the hood

The Prisma Next version is no longer a module-level constant. It's a `ResolvedPrismaNextSpec` produced once at startup by `parsePrismaNextVersionSpec(input.prismaNextVersion)` and threaded through `PrismaSetupContext`, the dep-writing helpers, and the `prisma-next init` invocation. The two helpers that previously hard-coded `\"latest\"` now take the resolved spec and emit either `name@<spec>` or the pkg.pr.new URL form — package managers accept URL specifiers in both install argv and `package.json`, so the URL flows through unchanged.

Telemetry on the create command gains `prisma-next-version-kind` (`default | npm-tag | npm-version | pkg-pr-new`) and the verbatim `prisma-next-version-spec`, so the audit can see which escape hatch users reach for.

## Scope of this PR

**Cases 1 and 2 (version pin, dist-tag) ship end-to-end across every package manager.** Acceptance criteria from TML-2692 met: pinned scaffold has every `@prisma-next/*` and `prisma-next` dep at the requested version, the `init` invocation uses the same version, skills resolve from the matching tag.

**Case 3 (pkg.pr.new) ships partially.** The URL form is emitted everywhere it should be, including `package.json` deps for every package manager. The `npx --yes <URL> init` path works end-to-end on npm. Two follow-ups are needed to make case 3 fully usable:

- **[TML-2694](https://linear.app/prisma-company/issue/TML-2694)** — `prisma-next init` needs a `PRISMA_NEXT_SKILLS_REF` env-var override so the skills ref can be derived from a SHA rather than a `v<version>` git tag (which doesn't exist for pkg.pr.new tarballs).
- **[TML-2695](https://linear.app/prisma-company/issue/TML-2695)** — `bunx <URL>`, `pnpm dlx <URL>`, `yarn dlx <URL>`, and `deno run npm:<URL>` don't accept URL specifiers the way `npx` does. Non-npm package managers need a two-step (install-then-local-bin) shape for the `init` invocation when the spec is pkg.pr.new.

Both are flat tickets in `[PN] Onboarding Audit`, related to TML-2692.

## Test plan

`bun run test:unit` covers the spec parser, the threading from the new flag down to `package.json` writes (including the pkg.pr.new URL form for every Prisma Next dep), and the telemetry classifier across all four kinds (31 tests, including a regression test that the default path still writes `\"latest\"`). Smoke-tested against the built CLI for the default path, `--prisma-next-version 0.10.0` with `--package-manager bun`, and `--prisma-next-version pkg-pr-new:<ref>` with `--package-manager npm`.

## Alternatives considered

- **Keep `PRISMA_NEXT_PACKAGE_VERSION` as a module-level mutable singleton that the CLI entry sets once.** Smaller diff than the threaded approach, but `create-prisma` also exports a programmatic `create()` API; a mutable singleton becomes racy if anyone ever calls it twice in the same process with different specs. Explicit threading keeps the helpers pure and the version a property of a request, not of the process.
- **Ship all three cases in this PR by resolving pkg.pr.new refs to SHAs at scaffold time and shipping the `bunx`/`dlx`/`deno` workarounds inline.** Doable, but the SHA resolution introduces a network dependency at scaffold time, and the workaround for non-npm runtimes is non-trivial. The ticket explicitly classed case 3 as stretch and called out filing the prisma-next-side change as a separate follow-up; doing the same on the create-prisma side keeps this PR small and unblocks cases 1+2 immediately.
- **Validate the spec string against a semver grammar before passing it through.** Rejected because dist-tags (`dev`, `next`, …) and prereleases (`0.11.0-dev.9`) must round-trip unchanged; npm itself doesn't validate tag syntax, and over-validating in `create-prisma` would lock us out of tags Prisma Next may introduce later.