### PR TITLE
fix: include Prisma Compute skill in addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Prisma Compute deployment is currently supported for:
 - Prisma IDE extension install
 
 These can be selected interactively or enabled with flags.
+When Prisma Compute deploy is selected, the skills add-on recommends the `prisma-compute` skill too.
 
 ## Deploy to Prisma Compute
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -342,6 +342,7 @@ async function collectCreateContext(
     useDefaults,
     provider: prismaSetupContext.databaseProvider,
     shouldUsePrismaPostgres: prismaSetupContext.shouldUsePrismaPostgres,
+    shouldUseComputeDeploy: Boolean(computeDeployContext),
   });
   if (addonSetupContext === undefined) {
     return;

--- a/src/tasks/setup-addons.ts
+++ b/src/tasks/setup-addons.ts
@@ -113,11 +113,13 @@ type SkillOption = {
 };
 
 function getAvailablePrismaSkills(provider: DatabaseProvider): PrismaSkillName[] {
+  const skills: PrismaSkillName[] = [...SHARED_PRISMA_SKILLS, "prisma-compute"];
+
   if (provider === "postgresql") {
-    return [...SHARED_PRISMA_SKILLS, "prisma-postgres"];
+    return [...skills, "prisma-postgres"];
   }
 
-  return [...SHARED_PRISMA_SKILLS];
+  return skills;
 }
 
 function getSkillOptions(provider: DatabaseProvider): SkillOption[] {
@@ -132,6 +134,11 @@ function getSkillOptions(provider: DatabaseProvider): SkillOption[] {
       value: "prisma-client-api",
       label: "prisma-client-api",
       hint: "Prisma Client query patterns",
+    },
+    "prisma-compute": {
+      value: "prisma-compute",
+      label: "prisma-compute",
+      hint: "Prisma Compute deploy and hosting workflows",
     },
     "prisma-database-setup": {
       value: "prisma-database-setup",
@@ -198,11 +205,16 @@ function uniqueValues<T>(values: T[]): T[] {
 function getRecommendedPrismaSkills(
   provider: DatabaseProvider,
   shouldUsePrismaPostgres: boolean,
+  shouldUseComputeDeploy: boolean,
 ): PrismaSkillName[] {
-  const skills = [...getAvailablePrismaSkills(provider)];
+  const skills = [...SHARED_PRISMA_SKILLS];
 
-  if (!shouldUsePrismaPostgres) {
-    return skills.filter((skill) => skill !== "prisma-postgres");
+  if (provider === "postgresql" && shouldUsePrismaPostgres) {
+    skills.push("prisma-postgres");
+  }
+
+  if (shouldUseComputeDeploy) {
+    skills.push("prisma-compute");
   }
 
   return uniqueValues(skills);
@@ -324,6 +336,7 @@ export async function collectCreateAddonSetupContext(
     useDefaults: boolean;
     provider: DatabaseProvider;
     shouldUsePrismaPostgres: boolean;
+    shouldUseComputeDeploy: boolean;
   },
 ): Promise<CreateAddonSetupContext | null | undefined> {
   const hasExplicitAddonSelection =
@@ -359,6 +372,7 @@ export async function collectCreateAddonSetupContext(
   const recommendedSkills = getRecommendedPrismaSkills(
     options.provider,
     options.shouldUsePrismaPostgres,
+    options.shouldUseComputeDeploy,
   );
   const skills = !addons.includes("skills")
     ? []

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export const extensionTargets = ["vscode", "cursor", "windsurf"] as const;
 export const prismaSkillNames = [
   "prisma-cli",
   "prisma-client-api",
+  "prisma-compute",
   "prisma-database-setup",
   "prisma-upgrade-v7",
   "prisma-postgres",


### PR DESCRIPTION
## Summary
- add prisma-compute to the supported Prisma skill list
- show prisma-compute in the skills add-on selector
- recommend prisma-compute automatically when Prisma Compute deploy is selected

## Verification
- bun run typecheck
- bun run build
- bunx oxlint src --deny-warnings
- git diff --check
- smoke checked add-on recommendation logic for deploy vs non-deploy flows