### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "description": "Create Prisma 7 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.6.0

This PR bumps `create-prisma` to `0.6.0`.

When this PR merges, GitHub Actions publishes to npm using trusted publishing.
