### PR TITLE
feat: enable Prisma Compute deploys for the NestJS template

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Prisma Compute deployment is currently supported for:
 
 - `hono`
 - `elysia`
+- `nest`
 - `next`
 - `astro`
 - `nuxt`
@@ -152,7 +153,7 @@ When Prisma Compute deploy is selected, the skills add-on recommends the `prisma
 
 ## Deploy to Prisma Compute
 
-After scaffolding, `create-prisma` can deploy your app to [Prisma Compute](https://www.prisma.io/docs/compute), the serverless hosting for TypeScript apps that runs next to your Prisma Postgres database. It is offered for the templates the Prisma CLI can deploy today: `hono`, `elysia`, `next`, `astro`, `nuxt`, `tanstack-start`, and `turborepo`.
+After scaffolding, `create-prisma` can deploy your app to [Prisma Compute](https://www.prisma.io/docs/compute), the serverless hosting for TypeScript apps that runs next to your Prisma Postgres database. It is offered for the templates the Prisma CLI can deploy today: `hono`, `elysia`, `nest`, `next`, `astro`, `nuxt`, `tanstack-start`, and `turborepo`.
 
 Accept the deploy prompt when it appears, or pass the flag:
 

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -28,6 +28,7 @@ export type CreateTemplateDependencyTarget = {
 const computeConfigTemplates = new Set<CreateTemplate>([
   "hono",
   "elysia",
+  "nest",
   "next",
   "astro",
   "nuxt",

--- a/src/tasks/deploy-to-compute.ts
+++ b/src/tasks/deploy-to-compute.ts
@@ -21,6 +21,7 @@ const DEPLOY_OPTIONS_BY_TEMPLATE: Partial<
 > = {
   hono: {},
   elysia: {},
+  nest: {},
   next: {},
   astro: {},
   nuxt: {},

--- a/src/templates/shared.ts
+++ b/src/templates/shared.ts
@@ -102,6 +102,7 @@ Handlebars.registerHelper(
       sourceEntrypoint,
       builtEntrypoint,
       denoFlags: getOptionalHashStringList(hash, "denoFlags"),
+      emit: hash.emit === true,
     });
   },
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export const CreateScaffoldOptionsSchema = z.object({
 export const COMPUTE_DEPLOYABLE_TEMPLATES: ReadonlySet<CreateTemplate> = new Set<CreateTemplate>([
   "hono",
   "elysia",
+  "nest",
   "next",
   "astro",
   "nuxt",

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -14,6 +14,10 @@ type RuntimeScriptOptions = {
   sourceEntrypoint: string;
   builtEntrypoint?: string;
   denoFlags?: string[];
+  // When true, `build` compiles to `dist` instead of only type-checking.
+  // Templates that deploy a compiled artifact (e.g. NestJS) need this; bun and
+  // deno otherwise run TypeScript directly and skip emit.
+  emit?: boolean;
 };
 
 const packageManagerManifestValues = {
@@ -198,7 +202,7 @@ export function getRuntimeScriptCommand(
   kind: RuntimeScriptKind,
   options: RuntimeScriptOptions,
 ): string {
-  const { sourceEntrypoint, builtEntrypoint, denoFlags = [] } = options;
+  const { sourceEntrypoint, builtEntrypoint, denoFlags = [], emit = false } = options;
 
   if (packageManager === "deno") {
     switch (kind) {
@@ -213,6 +217,9 @@ export function getRuntimeScriptCommand(
           sourceEntrypoint,
         ]);
       case "build":
+        // Deno runs TypeScript directly; there is no node-style compiled
+        // artifact to emit here (the Deno nest variant uses Deno APIs and is
+        // not built for the node-based Compute runtime).
         return `deno check ${sourceEntrypoint}`;
       case "start":
         return joinCommandParts([
@@ -231,7 +238,7 @@ export function getRuntimeScriptCommand(
       case "dev":
         return `bun --watch ${sourceEntrypoint}`;
       case "build":
-        return "tsc --noEmit";
+        return emit ? "tsc" : "tsc --noEmit";
       case "start":
         return `bun ${sourceEntrypoint}`;
     }

--- a/templates/create/nest/package.json.hbs
+++ b/templates/create/nest/package.json.hbs
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "{{runtimeScript packageManager "dev" "src/main.ts" "dist/main.js"}}",
-    "build": "{{runtimeScript packageManager "build" "src/main.ts" "dist/main.js"}}",
+    "build": "{{runtimeScript packageManager "build" "src/main.ts" "dist/main.js" emit=true}}",
     "start": "{{runtimeScript packageManager "start" "src/main.ts" "dist/main.js"}}"
   },
   "dependencies": {

--- a/templates/create/nest/prisma.compute.ts.hbs
+++ b/templates/create/nest/prisma.compute.ts.hbs
@@ -1,0 +1,9 @@
+import { defineComputeConfig } from "@prisma/compute-sdk/config";
+
+export default defineComputeConfig({
+  app: {
+    name: "{{projectName}}",
+    framework: "nestjs",
+    env: ".env",
+  },
+});


### PR DESCRIPTION
## What

Enables `nest` as a Compute-deployable template, now that the SDK has a NestJS build strategy (project-compute #94, shipped in `@prisma/compute-sdk@0.28.0` and the build-runner).

## Changes

- Add `"nest"` to `COMPUTE_DEPLOYABLE_TEMPLATES` (`src/types.ts`).
- Add `templates/create/nest/prisma.compute.ts.hbs` with `framework: "nestjs"` — framework-detected (no `entrypoint`), and no `httpPort` because the SDK's NestJS default (3000) matches the template's listen port (`process.env.PORT ?? 3000`).

Everything else auto-wires off the existing deployable gate: the `compute:deploy` script, the `compute` render flag, and the README's `{{#if compute}}` Compute sections (already present in the nest README) all key off `isComputeDeployableTemplate`.

## Verification

- `tsc --noEmit` clean, `oxfmt --check` + `oxlint --deny-warnings` clean, build succeeds.
- Scaffolded `nest` non-interactively end-to-end: it emits a correct `prisma.compute.ts` (`framework: "nestjs"`, project name, `env: ".env"`), and `compute:deploy` appears only with `--deploy` (as expected).
- The template's tsconfig already has `emitDecoratorMetadata`/`experimentalDecorators` and `outDir: dist`, so the build produces `dist/main.js` — exactly what the SDK's NestJS strategy resolves and traces.