### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "Create Prisma 7 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.7.1

This PR bumps `create-prisma` to `0.7.1`.

When this PR merges, GitHub Actions publishes to npm using trusted publishing.
