### PR TITLE
fix: harden generated app installs and deploys

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,9 @@
 import { createCreatePrismaCli } from "./index";
 
-createCreatePrismaCli().run();
+await createCreatePrismaCli().run({
+  formatError: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+});
+
+if (process.exitCode && process.exitCode !== 0) {
+  process.exit(process.exitCode);
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -223,24 +223,16 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
     failureStage = "unknown";
     const executionResult = await executeCreateContext(context);
     if (!executionResult.ok) {
-      if (executionResult.error) {
-        cancel(
-          `Create command failed: ${
-            executionResult.error instanceof Error
-              ? executionResult.error.message
-              : String(executionResult.error)
-          }`,
-        );
-      }
-
-      await trackCreateFailed({
-        input,
-        context,
-        durationMs: Date.now() - startedAt,
-        error: executionResult.error,
-        stage: executionResult.stage,
-      });
-      return;
+      failureStage = executionResult.stage;
+      const error =
+        executionResult.error instanceof Error
+          ? executionResult.error
+          : new Error(
+              executionResult.error === undefined
+                ? `Create command failed during ${executionResult.stage}`
+                : String(executionResult.error),
+            );
+      throw error;
     }
 
     await trackCreateCompleted({
@@ -249,14 +241,20 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
       durationMs: Date.now() - startedAt,
     });
   } catch (error) {
-    cancel(`Create command failed: ${error instanceof Error ? error.message : String(error)}`);
-    await trackCreateFailed({
-      input,
-      context,
-      durationMs: Date.now() - startedAt,
-      error,
-      stage: failureStage,
-    });
+    const commandError = error instanceof Error ? error : new Error(String(error));
+    cancel(`Create command failed: ${commandError.message}`);
+    try {
+      await trackCreateFailed({
+        input,
+        context,
+        durationMs: Date.now() - startedAt,
+        error: commandError,
+        stage: failureStage,
+      });
+    } catch {
+      // Telemetry is best-effort and must not hide the original command error.
+    }
+    throw commandError;
   }
 }
 

--- a/src/tasks/deploy-to-compute.ts
+++ b/src/tasks/deploy-to-compute.ts
@@ -203,6 +203,11 @@ export async function collectComputeDeployContext(
   },
 ): Promise<ComputeDeployContext | null | undefined> {
   if (!isComputeDeployableTemplate(options.template)) {
+    if (input.deploy === true) {
+      throw createExplicitDeployError(
+        `${options.template} is not supported by prisma app deploy yet`,
+      );
+    }
     return null;
   }
 

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -227,8 +227,16 @@ export async function installProjectDependencies(
 ): Promise<void> {
   const verbose = options.verbose === true;
   const installCommand = getInstallArgs(packageManager);
+  const env =
+    packageManager === "yarn"
+      ? {
+          ...process.env,
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
+        }
+      : undefined;
   await execa(installCommand.command, installCommand.args, {
     cwd: projectDir,
+    env,
     stdio: verbose ? "inherit" : "pipe",
   });
 }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -3,6 +3,7 @@ import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
+import { escapeRegExp } from "../utils/regexp";
 import { installProjectDependencies, writePrismaDependencies } from "./install";
 import {
   getCreateDbCommand,
@@ -374,11 +375,6 @@ function getDefaultDatabaseUrl(provider: DatabaseProvider): string {
       throw new Error(`Unsupported provider: ${String(exhaustiveCheck)}`);
     }
   }
-}
-
-// Escape regex metacharacters before interpolating dynamic values into RegExp.
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function escapeEnvValue(value: string): string {

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -21,7 +21,7 @@ import {
   detectPackageManager,
   getInstallCommand,
   getPrismaCliArgs,
-  getPrismaCliCommand,
+  getRunScriptArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
 
@@ -660,7 +660,7 @@ async function generatePrismaClientForContext(
     };
   }
 
-  const generateCommand = getPrismaCliCommand(context.packageManager, ["generate"]);
+  const generateCommand = getRunScriptCommand(context.packageManager, "db:generate");
   if (context.verbose) {
     log.step(`Running ${generateCommand}`);
   }
@@ -668,7 +668,7 @@ async function generatePrismaClientForContext(
   const generateSpinner = context.verbose ? undefined : spinner();
   generateSpinner?.start("Generating Prisma Client...");
   try {
-    const generateArgs = getPrismaCliArgs(context.packageManager, ["generate"]);
+    const generateArgs = getRunScriptArgs(context.packageManager, "db:generate");
     await execa(generateArgs.command, generateArgs.args, {
       cwd: prismaProjectDir,
       stdio: context.verbose ? "inherit" : "pipe",

--- a/src/templates/render-create-template.ts
+++ b/src/templates/render-create-template.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "node:path";
 
 import type { CreateTemplate, DatabaseProvider, PackageManager, SchemaPreset } from "../types";
+import { escapeRegExp } from "../utils/regexp";
 import { renderTemplateTree, resolveTemplatesDir } from "./shared";
 
 type CreateTemplateContext = {
@@ -40,10 +41,6 @@ const pnpmAllowedBuilds = [
   "sharp",
   "unrs-resolver",
 ] as const;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function renderPnpmAllowBuildLine(packageName: string): string {
   const key = packageName.startsWith("@") ? JSON.stringify(packageName) : packageName;

--- a/src/templates/render-create-template.ts
+++ b/src/templates/render-create-template.ts
@@ -1,3 +1,6 @@
+import fs from "fs-extra";
+import path from "node:path";
+
 import type { CreateTemplate, DatabaseProvider, PackageManager, SchemaPreset } from "../types";
 import { renderTemplateTree, resolveTemplatesDir } from "./shared";
 
@@ -29,6 +32,69 @@ function createTemplateContext(
   };
 }
 
+const pnpmAllowedBuilds = [
+  "@prisma/engines",
+  "@parcel/watcher",
+  "esbuild",
+  "prisma",
+  "sharp",
+  "unrs-resolver",
+] as const;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function renderPnpmAllowBuildLine(packageName: string): string {
+  const key = packageName.startsWith("@") ? JSON.stringify(packageName) : packageName;
+  return `  ${key}: true`;
+}
+
+function renderPnpmAllowBuilds(): string {
+  return ["allowBuilds:", ...pnpmAllowedBuilds.map(renderPnpmAllowBuildLine)].join("\n");
+}
+
+function hasPnpmAllowBuild(content: string, packageName: string): boolean {
+  const key = escapeRegExp(packageName);
+  return new RegExp(`^\\s*["']?${key}["']?\\s*:\\s*true\\s*$`, "m").test(content);
+}
+
+function mergePnpmAllowBuilds(content: string): string {
+  const missingBuilds = pnpmAllowedBuilds.filter(
+    (packageName) => !hasPnpmAllowBuild(content, packageName),
+  );
+  if (missingBuilds.length === 0) {
+    return content;
+  }
+
+  const missingLines = missingBuilds.map(renderPnpmAllowBuildLine);
+  const trimmedContent = content.trimEnd();
+  const lines = trimmedContent.length > 0 ? trimmedContent.split("\n") : [];
+  const allowBuildsIndex = lines.findIndex((line) => /^allowBuilds:\s*$/.test(line));
+  if (allowBuildsIndex === -1) {
+    const allowBuilds = ["allowBuilds:", ...missingLines].join("\n");
+    return trimmedContent.length > 0 ? `${trimmedContent}\n\n${allowBuilds}\n` : `${allowBuilds}\n`;
+  }
+
+  lines.splice(allowBuildsIndex + 1, 0, ...missingLines);
+  return `${lines.join("\n")}\n`;
+}
+
+async function ensurePnpmWorkspaceAllowBuilds(projectDir: string): Promise<void> {
+  const workspacePath = path.join(projectDir, "pnpm-workspace.yaml");
+
+  if (!(await fs.pathExists(workspacePath))) {
+    await fs.writeFile(workspacePath, `${renderPnpmAllowBuilds()}\n`, "utf8");
+    return;
+  }
+
+  const existingContent = await fs.readFile(workspacePath, "utf8");
+  const nextContent = mergePnpmAllowBuilds(existingContent);
+  if (nextContent !== existingContent) {
+    await fs.writeFile(workspacePath, nextContent, "utf8");
+  }
+}
+
 export async function scaffoldCreateTemplate(opts: {
   projectDir: string;
   projectName: string;
@@ -52,4 +118,7 @@ export async function scaffoldCreateTemplate(opts: {
     outputDir: projectDir,
     context,
   });
+  if (packageManager === "pnpm") {
+    await ensurePnpmWorkspaceAllowBuilds(projectDir);
+  }
 }

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -158,18 +158,41 @@ export function getInstallCommand(packageManager: PackageManager): string {
 }
 
 export function getRunScriptCommand(packageManager: PackageManager, scriptName: string): string {
+  const { command, args } = getRunScriptArgs(packageManager, scriptName);
+  return [command, ...args].join(" ");
+}
+
+export function getRunScriptArgs(
+  packageManager: PackageManager,
+  scriptName: string,
+): CommandAndArgs {
   switch (packageManager) {
     case "deno":
-      return `deno task ${scriptName}`;
+      return {
+        command: "deno",
+        args: ["task", scriptName],
+      };
     case "bun":
-      return `bun run ${scriptName}`;
+      return {
+        command: "bun",
+        args: ["run", scriptName],
+      };
     case "pnpm":
-      return `pnpm run ${scriptName}`;
+      return {
+        command: "pnpm",
+        args: ["run", scriptName],
+      };
     case "yarn":
-      return `yarn run ${scriptName}`;
+      return {
+        command: "yarn",
+        args: ["run", scriptName],
+      };
     case "npm":
     default:
-      return `npm run ${scriptName}`;
+      return {
+        command: "npm",
+        args: ["run", scriptName],
+      };
   }
 }
 

--- a/src/utils/regexp.ts
+++ b/src/utils/regexp.ts
@@ -1,0 +1,4 @@
+// Escape regex metacharacters before interpolating dynamic values into RegExp.
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/templates/create/astro/astro.config.mjs.hbs
+++ b/templates/create/astro/astro.config.mjs.hbs
@@ -7,4 +7,15 @@ export default defineConfig({
   output: "server",
   adapter: node({ mode: "standalone" }),
   server: { host: true },
+  vite: {
+    ssr: {
+      // Bundle SSR dependencies into the server entry. Astro's standalone
+      // build emits `import { parse, serialize } from "cookie"`, and the Bun
+      // runtime on Prisma Compute cannot resolve those named exports from
+      // cookie's CommonJS build at runtime (SyntaxError: Export named 'parse'
+      // not found). Bundling resolves the imports at build time. Remove once
+      // the Bun/cookie CJS named-export interop is fixed upstream.
+      noExternal: true,
+    },
+  },
 });

--- a/templates/create/astro/astro.config.mjs.hbs
+++ b/templates/create/astro/astro.config.mjs.hbs
@@ -7,9 +7,4 @@ export default defineConfig({
   output: "server",
   adapter: node({ mode: "standalone" }),
   server: { host: true },
-  vite: {
-    ssr: {
-      noExternal: true,
-    },
-  },
 });

--- a/templates/create/astro/astro.config.mjs.hbs
+++ b/templates/create/astro/astro.config.mjs.hbs
@@ -7,4 +7,9 @@ export default defineConfig({
   output: "server",
   adapter: node({ mode: "standalone" }),
   server: { host: true },
+  vite: {
+    ssr: {
+      noExternal: true,
+    },
+  },
 });

--- a/templates/create/elysia/.yarnrc.yml.hbs
+++ b/templates/create/elysia/.yarnrc.yml.hbs
@@ -1,0 +1,3 @@
+{{#if (eq packageManager "yarn")}}
+nodeLinker: node-modules
+{{/if}}

--- a/templates/create/elysia/package.json.hbs
+++ b/templates/create/elysia/package.json.hbs
@@ -17,6 +17,7 @@
     "openapi-types": "^12.1.3"
   },
   "devDependencies": {
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/templates/create/elysia/tsconfig.json
+++ b/templates/create/elysia/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "rootDir": "."

--- a/templates/create/hono/tsconfig.json
+++ b/templates/create/hono/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "rootDir": "."

--- a/templates/create/nest/tsconfig.json
+++ b/templates/create/nest/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/templates/create/tanstack-start/src/routes/index.tsx.hbs
+++ b/templates/create/tanstack-start/src/routes/index.tsx.hbs
@@ -1,5 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
+{{#if (eq schemaPreset "basic")}}
 import { createServerFn } from "@tanstack/react-start";
+{{/if}}
 {{#if (eq schemaPreset "basic")}}
 import { prisma } from "../lib/prisma.server";
 {{/if}}

--- a/templates/create/tanstack-start/src/routes/index.tsx.hbs
+++ b/templates/create/tanstack-start/src/routes/index.tsx.hbs
@@ -1,8 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 {{#if (eq schemaPreset "basic")}}
 import { createServerFn } from "@tanstack/react-start";
-{{/if}}
-{{#if (eq schemaPreset "basic")}}
 import { prisma } from "../lib/prisma.server";
 {{/if}}
 

--- a/templates/create/tanstack-start/tsconfig.json
+++ b/templates/create/tanstack-start/tsconfig.json
@@ -15,7 +15,7 @@
       "@/*": ["./src/*"]
     },
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "prisma/**/*.ts", "vite.config.ts"]
 }

--- a/templates/create/turborepo/apps/api/tsconfig.json
+++ b/templates/create/turborepo/apps/api/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "rootDir": "."

--- a/templates/create/turborepo/packages/db/package.json.hbs
+++ b/templates/create/turborepo/packages/db/package.json.hbs
@@ -8,9 +8,17 @@
   "scripts": {
     {{#if (eq packageManager "deno")}}
     "build": "deno check src/index.ts",
+    "db:generate": "{{prismaCommand packageManager "generate"}}",
+    "db:push": "{{prismaCommand packageManager "db push"}}",
+    "db:migrate": "{{prismaCommand packageManager "migrate dev"}}",
+    "db:seed": "{{prismaCommand packageManager "db seed"}}",
     "typecheck": "deno check src/index.ts"
     {{else}}
     "build": "tsc",
+    "db:generate": "{{prismaCommand packageManager "generate"}}",
+    "db:push": "{{prismaCommand packageManager "db push"}}",
+    "db:migrate": "{{prismaCommand packageManager "migrate dev"}}",
+    "db:seed": "{{prismaCommand packageManager "db seed"}}",
     "typecheck": "tsc --noEmit"
     {{/if}}
   },

--- a/templates/create/turborepo/packages/db/tsconfig.json
+++ b/templates/create/turborepo/packages/db/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "rootDir": "."


### PR DESCRIPTION
## Summary

- Run generated `db:generate` scripts so framework-specific setup, such as SvelteKit sync, happens before Prisma Client generation.
- Harden generated installs across package managers: Yarn non-immutable installs, Elysia Yarn node-modules config, missing Node typings, package-local turborepo DB scripts, and centralized pnpm `allowBuilds` generation/merging.
- Keep generated Astro SSR builds self-contained for Prisma Compute with `vite.ssr.noExternal: true` until the Compute runtime can safely execute Astro externalized SSR deps without Bun runtime package resolution drift.
- Make explicit unsupported deploy requests fail with a non-zero exit, while keeping failure telemetry best-effort so it cannot mask the original command error.

## Notes

The pnpm workspace file is now generated programmatically only when `packageManager === "pnpm"`:

- single-app pnpm templates get a `pnpm-workspace.yaml` containing `allowBuilds`
- non-pnpm single-app templates do not get a pnpm workspace file
- turborepo keeps its package globs and receives `allowBuilds` only for pnpm
- existing `allowBuilds` blocks are merged with any missing required packages

Astro note: `@prisma/compute-sdk@0.32.0` now traces Astro runtime dependencies, but a real PR-preview deploy without `noExternal` still crashed in Compute under Bun with `Export named 'parse' not found in module '/.bun/install/cache/cookie@2.0.1@@@1/dist/index.js'`. Keeping the generated SSR bundle self-contained is the safer production default for now.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- Focused turborepo + pnpm scaffold check: `packages/db` has package-local `db:*` scripts and `pnpm-workspace.yaml` keeps package globs plus `allowBuilds`.
- Verified published `@prisma/compute-sdk@0.32.0` has Astro `traceDependencies: true`.
- Local Astro/Postgres scaffold without `vite.ssr.noExternal` built and staged successfully with `AstroBuild`, and the staged artifact returned `200 OK` locally.
- Real PR-preview Astro deploy without `vite.ssr.noExternal` reproduced the Compute runtime crash above, so the template keeps `noExternal: true`.
- Manual scaffold matrix: 450/450 passed across templates, providers, package managers, and schema presets.
- Manual Astro post-fix matrix: 50/50 scaffold and 10/10 install/build/typecheck passed.
- Focused render check for pnpm workspace behavior:
  - Astro + Bun: no `pnpm-workspace.yaml`
  - Astro + pnpm: `allowBuilds` generated
  - Turborepo + Bun: package globs only
  - Turborepo + pnpm: package globs plus `allowBuilds`
- Real Prisma Compute smoke deploys for supported templates.