### PR TITLE
fix: repair astro dev, turborepo runtime paths, and prisma postgres migration retry

### DIFF
--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -77,7 +77,7 @@ const DEFAULT_PRISMA_POSTGRES = true;
 const DEFAULT_INSTALL = true;
 const DEFAULT_GENERATE = true;
 const DEFAULT_MIGRATE_AND_SEED = true;
-const PRISMA_POSTGRES_MIGRATION_DELAY_MS = 2000;
+const PRISMA_POSTGRES_MIGRATION_RETRY_DELAYS_MS = [1000, 2000, 4000];
 
 const requiredPrismaFileGroups = [
   ["prisma/schema.prisma", "packages/db/prisma/schema.prisma"],
@@ -851,15 +851,21 @@ async function migrateAndSeedIfRequested(
   migrateSpinner.start("Creating and applying initial migration...");
   let didMigrate = false;
   try {
-    if (context.shouldUsePrismaPostgres) {
-      // Newly provisioned Prisma Postgres databases can briefly reject the first migration.
-      // TODO(2026-04-26): replace this grace period with an explicit readiness probe.
-      await new Promise((resolve) => setTimeout(resolve, PRISMA_POSTGRES_MIGRATION_DELAY_MS));
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await execa(migrateInvocation.command, migrateInvocation.args, {
+          cwd: prismaProjectDir,
+          stdio: context.verbose ? "inherit" : "pipe",
+        });
+        break;
+      } catch (error) {
+        const retryDelayMs = PRISMA_POSTGRES_MIGRATION_RETRY_DELAYS_MS[attempt];
+        if (!context.shouldUsePrismaPostgres || retryDelayMs === undefined) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
     }
-    await execa(migrateInvocation.command, migrateInvocation.args, {
-      cwd: prismaProjectDir,
-      stdio: context.verbose ? "inherit" : "pipe",
-    });
     migrateSpinner.stop("Initial migration applied.");
     didMigrate = true;
   } catch (error) {

--- a/templates/create/astro/astro.config.mjs.hbs
+++ b/templates/create/astro/astro.config.mjs.hbs
@@ -2,20 +2,23 @@
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 
+// Workaround for cookie CJS imports on Prisma Compute's Bun runtime; build-only because noExternal breaks `astro dev`.
+/** @type {import("astro").AstroIntegration} */
+const bundleSsrDependenciesOnBuild = {
+  name: "bundle-ssr-dependencies-on-build",
+  hooks: {
+    "astro:config:setup": ({ command, updateConfig }) => {
+      if (command === "build") {
+        updateConfig({ vite: { ssr: { noExternal: true } } });
+      }
+    },
+  },
+};
+
 // https://astro.build/config
 export default defineConfig({
   output: "server",
   adapter: node({ mode: "standalone" }),
   server: { host: true },
-  vite: {
-    ssr: {
-      // Bundle SSR dependencies into the server entry. Astro's standalone
-      // build emits `import { parse, serialize } from "cookie"`, and the Bun
-      // runtime on Prisma Compute cannot resolve those named exports from
-      // cookie's CommonJS build at runtime (SyntaxError: Export named 'parse'
-      // not found). Bundling resolves the imports at build time. Remove once
-      // the Bun/cookie CJS named-export interop is fixed upstream.
-      noExternal: true,
-    },
-  },
+  integrations: [bundleSsrDependenciesOnBuild],
 });

--- a/templates/create/next/package.json.hbs
+++ b/templates/create/next/package.json.hbs
@@ -13,7 +13,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "next": "16.2.9",
+    "next": "16.2.10",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },
@@ -22,7 +22,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.5.0",
-    "eslint-config-next": "16.2.9",
+    "eslint-config-next": "16.2.10",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }

--- a/templates/create/turborepo/apps/api/package.json.hbs
+++ b/templates/create/turborepo/apps/api/package.json.hbs
@@ -11,7 +11,7 @@
     {{else}}
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/src/index.js",
+    "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit"
     {{/if}}
   },

--- a/templates/create/turborepo/packages/db/src/client.ts.hbs
+++ b/templates/create/turborepo/packages/db/src/client.ts.hbs
@@ -1,6 +1,6 @@
-{{#unless (eq packageManager "deno")}}
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+{{#unless (eq packageManager "deno")}}
 import dotenv from "dotenv";
 {{/unless}}
 import { PrismaClient } from "./generated/prisma/client{{#if (eq packageManager "deno")}}.ts{{/if}}";
@@ -20,14 +20,22 @@ import { {{sqliteAdapterClass packageManager}} } from "{{sqliteAdapterPackage pa
 import { PrismaMssql } from "@prisma/adapter-mssql";
 {{/if}}
 
-{{#unless (eq packageManager "deno")}}
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+{{#unless (eq packageManager "deno")}}
 dotenv.config({ path: path.resolve(moduleDir, "../.env"), quiet: true });
 {{/unless}}
 
 const rawDatabaseUrl = process.env.DATABASE_URL;
 {{#if (eq provider "sqlite")}}
-const databaseUrl = (rawDatabaseUrl ?? "").trim() || "file:./dev.db";
+function resolveSqliteUrl(url: string): string {
+  const filePath = url.replace(/^file:(?:\/\/)?/, "");
+  if (!url.startsWith("file:") || path.isAbsolute(filePath)) {
+    return url;
+  }
+  return `file:${path.resolve(moduleDir, "..", filePath)}`;
+}
+
+const databaseUrl = resolveSqliteUrl((rawDatabaseUrl ?? "").trim() || "file:./dev.db");
 {{else}}
 const databaseUrl = (rawDatabaseUrl ?? "").trim();
 if (!databaseUrl) {

--- a/templates/create/turborepo/turbo.json
+++ b/templates/create/turborepo/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["PORT", "DATABASE_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
End-to-end sweep of all 9 templates (scaffold → install → generate → migrate → seed → build → dev server → prod server, asserting seeded users over HTTP). 7/9 passed; astro and turborepo had real bugs, fixed here. Also bumps the only stale exact pins and replaces the provisioning sleep hack.

## astro: `astro dev` crashed at startup

`vite.ssr.noExternal: true` (the workaround for Prisma Compute's Bun runtime failing on cookie's CJS named exports) forces CJS deps through Vite's ESM module runner in dev → `exports is not defined` in `cookie/dist/index.js`, so the dev server never booted. Moved the setting into an inline integration that applies it only for `astro build`. Verified: dev serves `/api/users` from the seeded DB, the built server output still bundles `cookie` inline (no external import remains in `dist/server`), and `preview` works. Once prisma/project-compute#111 (stable Bun runtime) ships, this workaround can be deleted entirely.

## turborepo: three runtime bugs

1. **Empty database at runtime.** `DATABASE_URL="file:./dev.db"` is relative; the CLI (migrate/seed, cwd `packages/db`) created `packages/db/dev.db`, but `@prisma/adapter-libsql` resolves the path against the *process* cwd — turbo runs the api in `apps/api`, so `GET /users` hit a fresh empty `apps/api/dev.db` and 500'd. `client.ts` now resolves relative `file:` paths against the db package dir. (Underlying CLI/adapter inconsistency is worth an upstream prisma/prisma issue.)
2. **`PORT` silently ignored.** turbo 2.x strict env mode strips undeclared vars, so `PORT=x bun run dev` listened on 3000. Added `globalPassThroughEnv: ["PORT", "DATABASE_URL"]`.
3. **`start` crashed under Node.** `node dist/src/index.js` can't resolve `@repo/db`'s raw-TS export (`ERR_MODULE_NOT_FOUND` on the extensionless `./client` import). `start` now uses `tsx`, same as `dev`.

Verified: root `PORT=8129 bun run dev` serves seeded users on 8129, `start` works, no stray `apps/api/dev.db` is created.

## next: stale exact pins

`next`/`eslint-config-next` 16.2.9 → 16.2.10 (everything else uses caret ranges that already resolve to latest; Prisma is on current 7.8.0). Also clears the eslint peer-dep warnings during install. Re-verified scaffold + build + dev.

## prisma postgres: retry instead of blind sleep

The first `migrate dev` against a freshly provisioned database raced provisioning readiness, papered over with a fixed 2s sleep. Root cause fixed in prisma/create-db#84 (create-db now blocks until the DB answers `SELECT 1`); here the sleep is replaced with bounded retries (1s/2s/4s backoff, Prisma Postgres flow only), which is net faster in the common case and covers older create-db versions. Verified with a live run: provision → migrate → seed all green.

## Testing

- `bun run check` + `typecheck` clean
- All 9 templates re-verified e2e with SQLite (4 delegated to codex CLI, 5 to parallel agents)
- Live Prisma Postgres flow: `--provider postgresql --prisma-postgres` → provisioned, migrated, seeded, exit 0