### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.4.2",
+  "version": "0.8.0",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.8.0

Publishes the merged Prisma 8 create flow as `create-prisma@latest` using the trusted publishing workflow.

The previous implementation remains available as `create-prisma@stable` (`0.7.2`).