### PR TITLE
feat: support Deno projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Create a Prisma 8 app with Prisma Composer built in.
 Use your package manager:
 
 ```bash
-npx create-prisma@next my-app
-pnpm dlx create-prisma@next my-app
-yarn dlx create-prisma@next my-app
-bunx create-prisma@next my-app
+npx create-prisma@latest my-app
+pnpm dlx create-prisma@latest my-app
+yarn dlx create-prisma@latest my-app
+bunx create-prisma@latest my-app
 ```
 
 The CLI initializes Prisma 8 with `prisma@next`, installs dependencies, emits the contract, and generates a deployable Composer app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
@@ -41,13 +41,21 @@ workspace. Choosing another workspace also updates the Prisma CLI's active works
 
 PostgreSQL and MongoDB are supported with PSL or TypeScript contract authoring. npm, pnpm, Yarn, and Bun are supported.
 
+Deno is supported for local minimal PostgreSQL apps:
+
+```bash
+deno run -A npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
+```
+
+Prisma Compute does not support Deno deployments yet.
+
 ## Options
 
 - positional project name or `--name`
 - `--template`
 - `--provider postgres|postgresql|mongo|mongodb`
 - `--authoring psl|typescript`
-- `--package-manager npm|pnpm|yarn|bun`
+- `--package-manager npm|pnpm|yarn|bun|deno`
 - `--deploy` / `--no-deploy`
 - `--workspace <id-or-name>`
 - `--yes`

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -291,6 +291,7 @@ async function collectCreateContext(
 
   const prismaSetupContext = await collectPrismaSetupContext(input, {
     projectDir: targetDirectory,
+    template,
   });
   if (!prismaSetupContext) {
     return;

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -12,6 +12,7 @@ export const dependencyVersionMap = {
   "@types/node": "^25.6.2",
   alchemy: "2.0.0-beta.67",
   arktype: "^2.2.3",
+  dotenv: "^17.4.2",
   esbuild: "^0.28.1",
   effect: "4.0.0-beta.103",
   mongodb: "^7.1.0",
@@ -22,6 +23,9 @@ export const dependencyVersionMap = {
 } as const;
 
 export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@next";
+// The consolidated CLI currently imports Node-only credential storage when Deno starts it.
+// Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
+export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";
 
 export type AvailableDependency = keyof typeof dependencyVersionMap;
 

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   getCreateTemplateDependencies,
   getDependencyVersion,
+  PRISMA_DENO_CLI_PACKAGE,
   PRISMA_PLATFORM_CLI_PACKAGE,
 } from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
@@ -16,6 +17,27 @@ import {
 } from "../utils/package-manager";
 
 function getPrismaScriptMap(packageManager: PackageManager): Record<string, string> {
+  if (packageManager === "deno") {
+    const prismaCommand = (needsDatabase: boolean, ...args: string[]) =>
+      [
+        "deno run -A",
+        ...(needsDatabase ? ["--env-file=.env"] : []),
+        `npm:${PRISMA_DENO_CLI_PACKAGE}`,
+        ...args,
+      ].join(" ");
+
+    return {
+      "contract:emit": prismaCommand(false, "contract", "emit"),
+      "db:init": prismaCommand(true, "db", "init"),
+      "db:update": prismaCommand(true, "db", "update"),
+      "db:verify": prismaCommand(true, "db", "verify"),
+      "migration:plan": prismaCommand(true, "migration", "plan"),
+      migrate: prismaCommand(true, "migrate"),
+      "migration:status": prismaCommand(true, "migration", "status"),
+      "migration:show": prismaCommand(true, "migration", "show"),
+    };
+  }
+
   const prismaCommand = (...args: string[]) =>
     getPackageExecutionCommand(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
 
@@ -32,6 +54,10 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
 }
 
 export function getComposerScriptMap(packageManager: PackageManager): Record<string, string> {
+  if (packageManager === "deno") {
+    return {};
+  }
+
   const composerCommand = (subcommand: string, extraArgs: string[] = []) =>
     getPackageExecutionCommand(packageManager, [
       PRISMA_PLATFORM_CLI_PACKAGE,
@@ -131,10 +157,14 @@ export async function writePrismaDependencies(
 ): Promise<void> {
   const dependencies = [getDbPackages(provider)];
   if (provider === "mongo") dependencies.push("arktype", "mongodb");
+  if (packageManager === "deno") dependencies.push("dotenv");
+
+  const devDependencies =
+    packageManager === "deno" ? ["@types/node"] : ["@prisma/cli-engine", "@types/node"];
 
   await addPackageDependency({
     dependencies,
-    devDependencies: ["@prisma/cli-engine", "@types/node"],
+    devDependencies,
     scripts: getPrismaScriptMap(packageManager),
     projectDir,
   });
@@ -146,6 +176,10 @@ export async function writeCreateTemplateDependencies(opts: {
   projectDir?: string;
 }): Promise<void> {
   const { template, packageManager, projectDir = process.cwd() } = opts;
+
+  if (packageManager === "deno") {
+    return;
+  }
 
   for (const target of getCreateTemplateDependencies(template, packageManager)) {
     await addPackageDependency({

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -3,12 +3,13 @@ import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
-import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
+import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import { scaffoldCreateSharedTemplates } from "../templates/render-create-template";
 import {
   AuthoringStyleSchema,
   DatabaseProviderSchema,
   PackageManagerSchema,
+  packageManagers,
   type AuthoringStyle,
   type CreateTemplate,
   type DatabaseProvider,
@@ -91,6 +92,7 @@ function getPackageManagerHint(option: PackageManager, detected: PackageManager)
     pnpm: "Fast, disk-efficient package manager",
     yarn: "Yarn package manager",
     bun: "Fast runtime and package manager",
+    deno: "Deno runtime (minimal PostgreSQL apps)",
   } satisfies Record<PackageManager, string>;
   return option === detected ? `Detected; ${hints[option]}` : hints[option];
 }
@@ -101,7 +103,7 @@ async function promptForPackageManager(
   const packageManager = await select({
     message: "Choose package manager",
     initialValue: detected,
-    options: (["npm", "pnpm", "yarn", "bun"] as const).map((value) => ({
+    options: packageManagers.map((value) => ({
       value,
       label: value,
       hint: getPackageManagerHint(value, detected),
@@ -128,7 +130,7 @@ async function promptForDeployment(): Promise<boolean | undefined> {
 
 export async function collectPrismaSetupContext(
   input: PrismaSetupCommandInput,
-  options: { projectDir?: string } = {},
+  options: { projectDir?: string; template?: CreateTemplate } = {},
 ): Promise<PrismaSetupContext | undefined> {
   const projectDir = path.resolve(options.projectDir ?? process.cwd());
   const useDefaults = input.yes === true;
@@ -147,7 +149,20 @@ export async function collectPrismaSetupContext(
     (useDefaults ? detectedPackageManager : await promptForPackageManager(detectedPackageManager));
   if (!packageManager) return;
 
-  const shouldDeploy = input.deploy ?? (useDefaults ? false : await promptForDeployment());
+  if (packageManager === "deno" && databaseProvider !== "postgres") {
+    throw new Error("Deno support currently requires PostgreSQL.");
+  }
+  if (packageManager === "deno" && options.template && options.template !== "minimal") {
+    throw new Error("Deno support currently requires the minimal template.");
+  }
+  if (packageManager === "deno" && input.deploy === true) {
+    throw new Error("Prisma Compute does not support Deno deployments yet. Use --no-deploy.");
+  }
+
+  const shouldDeploy =
+    packageManager === "deno"
+      ? false
+      : (input.deploy ?? (useDefaults ? false : await promptForDeployment()));
   if (shouldDeploy === undefined) return;
 
   return {
@@ -179,24 +194,41 @@ function getInitTarget(provider: DatabaseProvider): "postgres" | "mongodb" {
 }
 
 function getPrismaCliInvocation(packageManager: PackageManager, args: string[]) {
-  return getPackageExecutionArgs(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
+  const packageName =
+    packageManager === "deno" ? PRISMA_DENO_CLI_PACKAGE : PRISMA_PLATFORM_CLI_PACKAGE;
+  return getPackageExecutionArgs(packageManager, [packageName, ...args]);
 }
 
 async function runPrismaInit(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  const args = [
-    "orm",
-    "init",
-    "--yes",
-    "--no-interactive",
-    "--target",
-    getInitTarget(context.databaseProvider),
-    "--authoring",
-    context.authoring,
-    "--schema-path",
-    getContractPath(context.authoring),
-    "--skip-install",
-    "--skip-skills",
-  ];
+  const args =
+    context.packageManager === "deno"
+      ? [
+          "init",
+          "--yes",
+          "--no-interactive",
+          "--target",
+          getInitTarget(context.databaseProvider),
+          "--authoring",
+          context.authoring,
+          "--schema-path",
+          getContractPath(context.authoring),
+          "--no-install",
+          "--no-skill",
+        ]
+      : [
+          "orm",
+          "init",
+          "--yes",
+          "--no-interactive",
+          "--target",
+          getInitTarget(context.databaseProvider),
+          "--authoring",
+          context.authoring,
+          "--schema-path",
+          getContractPath(context.authoring),
+          "--skip-install",
+          "--skip-skills",
+        ];
   const invocation = getPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);
   await execa(invocation.command, invocation.args, {
@@ -204,6 +236,7 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
     stdio: context.verbose ? "inherit" : "pipe",
     env: { ...process.env, CI: "1" },
   });
+  if (context.packageManager === "deno") await fs.remove(path.join(projectDir, "prisma-next.md"));
 }
 
 async function ensureGitignoreEntry(projectDir: string, entry: string): Promise<void> {
@@ -312,9 +345,18 @@ function buildNextSteps(context: PrismaSetupContext, options: PrismaSetupRunOpti
   }
   if (options.includeDevNextStep) {
     nextSteps.push({
-      command: getRunScriptCommand(context.packageManager, "dev:composer"),
-      description: "Build and start the app with Prisma Composer locally.",
+      command: getRunScriptCommand(
+        context.packageManager,
+        context.packageManager === "deno" ? "dev" : "dev:composer",
+      ),
+      description:
+        context.packageManager === "deno"
+          ? "Start the Deno app after setting DATABASE_URL in .env."
+          : "Build and start the app with Prisma Composer locally.",
     });
+  }
+  if (context.packageManager === "deno") {
+    return nextSteps;
   }
   nextSteps.push({
     command: getRunScriptCommand(context.packageManager, "deploy"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const databaseProviders = ["postgres", "mongo"] as const;
 export const databaseProviderInputs = ["postgres", "postgresql", "mongo", "mongodb"] as const;
 
-export const packageManagers = ["npm", "pnpm", "yarn", "bun"] as const;
+export const packageManagers = ["npm", "pnpm", "yarn", "bun", "deno"] as const;
 export const authoringStyles = ["psl", "typescript"] as const;
 export const createTemplates = [
   "minimal",

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -135,7 +135,7 @@ export function getPackageManagerManifestValue(
 
 export function getInstallCommand(packageManager: PackageManager): string {
   if (packageManager === "deno") {
-    return "deno install --allow-scripts";
+    return "deno install";
   }
 
   return `${packageManager} install`;
@@ -200,7 +200,7 @@ export function getInstallArgs(packageManager: PackageManager): CommandAndArgs {
   if (packageManager === "deno") {
     return {
       command: "deno",
-      args: ["install", "--allow-scripts"],
+      args: ["install"],
     };
   }
 

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -34,6 +34,10 @@ function parseUserAgent(userAgent: string | undefined): PackageManager | null {
     return "bun";
   }
 
+  if (userAgent?.startsWith("deno")) {
+    return "deno";
+  }
+
   if (userAgent?.startsWith("npm")) {
     return "npm";
   }
@@ -61,6 +65,16 @@ async function detectFromPackageJson(projectDir: string): Promise<PackageManager
   return parsePackageManagerField(packageJson.packageManager);
 }
 
+async function detectFromDenoConfig(projectDir: string): Promise<PackageManager | null> {
+  for (const configFile of ["deno.json", "deno.jsonc"]) {
+    if (await fs.pathExists(path.join(projectDir, configFile))) {
+      return "deno";
+    }
+  }
+
+  return null;
+}
+
 async function detectFromLockfile(projectDir: string): Promise<PackageManager | null> {
   const lockfileChecks: Array<{ manager: PackageManager; lockfile: string }> = [
     { manager: "pnpm", lockfile: "pnpm-lock.yaml" },
@@ -69,6 +83,7 @@ async function detectFromLockfile(projectDir: string): Promise<PackageManager | 
     { manager: "bun", lockfile: "bun.lock" },
     { manager: "npm", lockfile: "package-lock.json" },
     { manager: "npm", lockfile: "npm-shrinkwrap.json" },
+    { manager: "deno", lockfile: "deno.lock" },
   ];
 
   for (const check of lockfileChecks) {
@@ -91,6 +106,11 @@ export async function detectPackageManager(projectDir = process.cwd()): Promise<
     return fromLockfile;
   }
 
+  const fromDenoConfig = await detectFromDenoConfig(projectDir);
+  if (fromDenoConfig) {
+    return fromDenoConfig;
+  }
+
   const fromUserAgent = parseUserAgent(process.env.npm_config_user_agent);
   if (fromUserAgent) {
     return fromUserAgent;
@@ -106,15 +126,25 @@ export function getPackageManagerManifestValue(
     return undefined;
   }
 
+  if (packageManager === "deno") {
+    return undefined;
+  }
+
   return packageManagerManifestValues[packageManager];
 }
 
 export function getInstallCommand(packageManager: PackageManager): string {
+  if (packageManager === "deno") {
+    return "deno install --allow-scripts";
+  }
+
   return `${packageManager} install`;
 }
 
 export function getRunScriptCommand(packageManager: PackageManager, scriptName: string): string {
   switch (packageManager) {
+    case "deno":
+      return `deno task ${scriptName}`;
     case "bun":
       return `bun run ${scriptName}`;
     case "pnpm":
@@ -133,6 +163,17 @@ export function getRuntimeScriptCommand(
   options: RuntimeScriptOptions,
 ): string {
   const { sourceEntrypoint, builtEntrypoint } = options;
+
+  if (packageManager === "deno") {
+    switch (kind) {
+      case "dev":
+        return `deno run -A --env-file=.env --watch ${sourceEntrypoint}`;
+      case "build":
+        return `deno check ${sourceEntrypoint}`;
+      case "start":
+        return `deno run -A --env-file=.env ${sourceEntrypoint}`;
+    }
+  }
 
   if (packageManager === "bun") {
     switch (kind) {
@@ -156,6 +197,13 @@ export function getRuntimeScriptCommand(
 }
 
 export function getInstallArgs(packageManager: PackageManager): CommandAndArgs {
+  if (packageManager === "deno") {
+    return {
+      command: "deno",
+      args: ["install", "--allow-scripts"],
+    };
+  }
+
   return {
     command: packageManager,
     args: ["install"],
@@ -167,6 +215,13 @@ export function getPackageExecutionArgs(
   commandArgs: string[],
 ): CommandAndArgs {
   switch (packageManager) {
+    case "deno": {
+      const [packageName, ...args] = commandArgs;
+      if (!packageName) {
+        throw new Error("Package execution requires a package name.");
+      }
+      return { command: "deno", args: ["run", "-A", `npm:${packageName}`, ...args] };
+    }
     case "pnpm":
       return { command: "pnpm", args: ["dlx", ...commandArgs] };
     case "yarn":
@@ -193,6 +248,8 @@ export function getLocalPackageBinaryArgs(
   binaryArgs: string[],
 ): CommandAndArgs {
   switch (packageManager) {
+    case "deno":
+      return { command: "deno", args: ["run", "-A", `npm:${binaryName}`, ...binaryArgs] };
     case "pnpm":
       return { command: "pnpm", args: ["exec", binaryName, ...binaryArgs] };
     case "yarn":
@@ -222,6 +279,10 @@ export function getPrismaCliArgs(
     return getPackageExecutionArgs(packageManager, ["--bun", "prisma", ...prismaArgs]);
   }
 
+  if (packageManager === "deno") {
+    return getPackageExecutionArgs(packageManager, ["prisma-next", ...prismaArgs]);
+  }
+
   return getPackageExecutionArgs(packageManager, ["prisma", ...prismaArgs]);
 }
 
@@ -230,6 +291,8 @@ export function getRunScriptArgs(
   scriptName: string,
 ): CommandAndArgs {
   switch (packageManager) {
+    case "deno":
+      return { command: "deno", args: ["task", scriptName] };
     case "bun":
       return { command: "bun", args: ["run", scriptName] };
     case "pnpm":

--- a/templates/create/_shared/README.md.hbs
+++ b/templates/create/_shared/README.md.hbs
@@ -1,5 +1,37 @@
 # {{projectName}}
 
+{{#if (eq packageManager "deno")}}
+A minimal Prisma 8 app for Deno and PostgreSQL.
+
+## Run locally
+
+Copy `.env.example` to `.env`, set `DATABASE_URL`, then initialize the database:
+
+```bash
+deno task db:init
+```
+
+Start the app:
+
+```bash
+deno task dev
+```
+
+The starter users are inserted idempotently from `src/prisma/seed.ts` on the first database query.
+
+## Prisma
+
+- Contract: `src/prisma/contract{{#if (eq authoring "typescript")}}.ts{{else}}.prisma{{/if}}`
+- Prisma config: `prisma-next.config.ts`
+
+After changing the contract, run:
+
+```bash
+deno task contract:emit
+```
+
+Prisma Compute does not support Deno deployments yet.
+{{else}}
 A minimal {{template}} app with Prisma 8 and Prisma Composer.
 
 ## Run locally
@@ -37,3 +69,4 @@ After changing the contract, run:
 ```
 
 To use the framework's development server directly, run `{{runScriptCommand packageManager "dev"}}`. This direct mode requires `DATABASE_URL`.
+{{/if}}

--- a/templates/create/_shared/deno.json.hbs
+++ b/templates/create/_shared/deno.json.hbs
@@ -1,0 +1,5 @@
+{{#if (eq packageManager "deno")}}
+{
+  "nodeModulesDir": "auto"
+}
+{{/if}}

--- a/templates/create/_shared/module.ts.hbs
+++ b/templates/create/_shared/module.ts.hbs
@@ -1,3 +1,4 @@
+{{#unless (eq packageManager "deno")}}
 import { module } from "@prisma/composer";
 {{#if (eq provider "postgres")}}
 import { pnPostgres } from "@prisma/composer-prisma-cloud/prisma-next";
@@ -26,3 +27,4 @@ export default module("{{projectName}}", ({ provision }) => {
   });
 {{/if}}
 });
+{{/unless}}

--- a/templates/create/_shared/prisma-composer.config.ts.hbs
+++ b/templates/create/_shared/prisma-composer.config.ts.hbs
@@ -1,3 +1,4 @@
+{{#unless (eq packageManager "deno")}}
 import { defineConfig } from "@prisma/composer/config";
 import { nodeBuild } from "@prisma/composer/node/control";
 {{#if (eq template "next")}}
@@ -9,3 +10,4 @@ export default defineConfig({
   extensions: [prismaCloud(), nodeBuild(){{#if (eq template "next")}}, nextjsBuild(){{/if}}],
   state: prismaState(),
 });
+{{/unless}}

--- a/templates/create/_shared/prisma.config.ts.hbs
+++ b/templates/create/_shared/prisma.config.ts.hbs
@@ -1,3 +1,4 @@
+{{#unless (eq packageManager "deno")}}
 import { definePrismaConfig } from "@prisma/cli-engine";
 import { defineConfig as ormConfig } from "@prisma/orm-{{#if (eq provider "postgres")}}postgres{{else}}mongo{{/if}}/config";
 
@@ -15,3 +16,4 @@ export default definePrismaConfig({
     configPath: "./prisma-composer.config.ts",
   },
 });
+{{/unless}}

--- a/templates/create/_shared/service.ts.hbs
+++ b/templates/create/_shared/service.ts.hbs
@@ -1,3 +1,4 @@
+{{#unless (eq packageManager "deno")}}
 {{#if (eq template "next")}}
 import nextjs from "@prisma/composer/nextjs";
 {{else}}
@@ -40,3 +41,4 @@ export default compute({
   build: node({ module: import.meta.url, entry: "./dist/server.mjs" }),
 {{/if}}
 });
+{{/unless}}

--- a/templates/create/_shared/src/prisma/composer.ts.hbs
+++ b/templates/create/_shared/src/prisma/composer.ts.hbs
@@ -1,3 +1,4 @@
+{{#unless (eq packageManager "deno")}}
 {{#if (eq provider "postgres")}}
 import { pnContract } from "@prisma/composer-prisma-cloud/prisma-next";
 
@@ -6,3 +7,4 @@ import contractJson from "./{{#if (eq authoring "typescript")}}generated/{{/if}}
 
 export const appContract = pnContract<Contract>(contractJson);
 {{/if}}
+{{/unless}}

--- a/templates/create/_shared/src/prisma/db.ts.hbs
+++ b/templates/create/_shared/src/prisma/db.ts.hbs
@@ -1,6 +1,17 @@
 {{#if (eq provider "postgres")}}
 import postgres from "@prisma/orm-postgres/runtime";
 
+{{#if (eq packageManager "deno")}}
+import type { Contract } from "./{{#if (eq authoring "typescript")}}generated/{{/if}}contract.d.ts";
+import contractJson from "./{{#if (eq authoring "typescript")}}generated/{{/if}}contract.json" with { type: "json" };
+
+const databaseUrl = Deno.env.get("DATABASE_URL");
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is not set. Add it to .env before starting the app.");
+}
+
+export const db = postgres<Contract>({ contractJson, url: databaseUrl });
+{{else}}
 import service from "../../service.ts";
 import type { Contract } from "./{{#if (eq authoring "typescript")}}generated/{{/if}}contract.d.ts";
 import contractJson from "./{{#if (eq authoring "typescript")}}generated/{{/if}}contract.json" with { type: "json" };
@@ -18,6 +29,7 @@ export const db =
   (process.env.DATABASE_URL
     ? postgres<Contract>({ contractJson, url: process.env.DATABASE_URL })
     : postgres<Contract>({ contractJson }));
+{{/if}}
 {{else}}
 import mongo from "@prisma/orm-mongo/runtime";
 

--- a/templates/create/minimal/package.json.hbs
+++ b/templates/create/minimal/package.json.hbs
@@ -6,9 +6,15 @@
   {{/if}}
   "type": "module",
   "scripts": {
+    {{#if (eq packageManager "deno")}}
+    "dev": "{{runtimeScript packageManager "dev" "src/index.ts" "dist/server.mjs"}}",
+    "build": "{{runtimeScript packageManager "build" "src/index.ts" "dist/server.mjs"}}",
+    "start": "{{runtimeScript packageManager "start" "src/index.ts" "dist/server.mjs"}}"
+    {{else}}
     "dev": "tsx watch src/index.ts",
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/server.mjs",
     "start": "node dist/server.mjs"
+    {{/if}}
   },
   "dependencies": {},
   "devDependencies": {}

--- a/templates/create/minimal/src/index.ts.hbs
+++ b/templates/create/minimal/src/index.ts.hbs
@@ -1,8 +1,8 @@
 import { createServer } from "node:http";
 
-import { listUsers } from "./prisma/users";
+import { listUsers } from "./prisma/users{{#if (eq packageManager "deno")}}.ts{{/if}}";
 
-const port = Number(process.env.PORT ?? 3000);
+const port = Number({{#if (eq packageManager "deno")}}Deno.env.get("PORT"){{else}}process.env.PORT{{/if}} ?? 3000);
 
 createServer(async (_request, response) => {
   try {

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -137,6 +137,45 @@ describe("create-prisma e2e", () => {
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);
   });
 
+  test("rejects unsupported Deno combinations with a non-zero exit code", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-deno-reject-e2e-"));
+    tempRoots.push(rootDir);
+
+    const child = Bun.spawn({
+      cmd: [
+        process.execPath,
+        path.join(import.meta.dir, "../../src/cli.ts"),
+        "create",
+        "unsupported-deno-app",
+        "--template",
+        "next",
+        "--provider",
+        "postgres",
+        "--authoring",
+        "psl",
+        "--package-manager",
+        "deno",
+        "--no-deploy",
+        "--yes",
+      ],
+      cwd: rootDir,
+      env: { ...Bun.env, CI: "1", CREATE_PRISMA_DISABLE_TELEMETRY: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    expect(exitCode).toBe(1);
+    expect(`${stdout}\n${stderr}`).toContain(
+      "Deno support currently requires the minimal template",
+    );
+    expect(await pathExists(path.join(rootDir, "unsupported-deno-app"))).toBe(false);
+  });
+
   test(
     "generates, builds, and runs a Composer-backed Prisma Postgres app",
     async () => {
@@ -220,6 +259,54 @@ describe("create-prisma e2e", () => {
 
       await runCommand(projectDir, ["bun", "run", "build"]);
       await runCommand(projectDir, ["bunx", "tsc", "--noEmit"]);
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "generates and checks a minimal Deno Prisma Postgres app",
+    async () => {
+      const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-deno-e2e-"));
+      tempRoots.push(rootDir);
+      const previousCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        await runCreateCommand({
+          name: "deno-app",
+          template: "minimal",
+          provider: "postgres",
+          authoring: "psl",
+          packageManager: "deno",
+          deploy: false,
+          yes: true,
+        });
+      } finally {
+        process.chdir(previousCwd);
+      }
+
+      const projectDir = path.join(rootDir, "deno-app");
+      const packageJson = JSON.parse(
+        await readFile(path.join(projectDir, "package.json"), "utf8"),
+      ) as Record<string, any>;
+      const configSource = await readFile(path.join(projectDir, "prisma-next.config.ts"), "utf8");
+      const dbSource = await readFile(path.join(projectDir, "src/prisma/db.ts"), "utf8");
+
+      expect(await pathExists(path.join(projectDir, "deno.json"))).toBe(true);
+      expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
+      expect(await pathExists(path.join(projectDir, "src/prisma/contract.d.ts"))).toBe(true);
+      expect(await pathExists(path.join(projectDir, "prisma-next.md"))).toBe(false);
+      expect(await pathExists(path.join(projectDir, "module.ts"))).toBe(false);
+      expect(await pathExists(path.join(projectDir, "service.ts"))).toBe(false);
+      expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(false);
+      expect(configSource).toContain("dotenv/config");
+      expect(dbSource).toContain('Deno.env.get("DATABASE_URL")');
+      expect(packageJson.scripts).toMatchObject({
+        build: "deno check src/index.ts",
+        dev: "deno run -A --env-file=.env --watch src/index.ts",
+      });
+      expect(packageJson.scripts.deploy).toBeUndefined();
+
+      await runCommand(projectDir, ["deno", "task", "build"]);
     },
     TEST_TIMEOUT,
   );

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -3,7 +3,11 @@ import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { dependencyVersionMap, PRISMA_PLATFORM_CLI_PACKAGE } from "../src/constants/dependencies";
+import {
+  dependencyVersionMap,
+  PRISMA_DENO_CLI_PACKAGE,
+  PRISMA_PLATFORM_CLI_PACKAGE,
+} from "../src/constants/dependencies";
 import { scaffoldCreateTemplate } from "../src/templates/render-create-template";
 import {
   getComposerScriptMap,
@@ -75,6 +79,26 @@ describe("writePrismaDependencies", () => {
       expect(packageJson.scripts?.["db:seed"]).toBeUndefined();
     });
   });
+
+  test("writes Deno-native Prisma scripts without Composer dependencies", async () => {
+    await withPackageJson(async (projectDir) => {
+      await writePrismaDependencies("postgres", "deno", "psl", projectDir);
+      const packageJson = await readPackageJson(projectDir);
+
+      expect(packageJson.dependencies).toMatchObject({
+        "@prisma/orm-postgres": dependencyVersionMap["@prisma/orm-postgres"],
+        dotenv: dependencyVersionMap.dotenv,
+      });
+      expect(packageJson.devDependencies).toMatchObject({
+        "@types/node": dependencyVersionMap["@types/node"],
+      });
+      expect(packageJson.devDependencies?.["@prisma/cli-engine"]).toBeUndefined();
+      expect(packageJson.scripts).toMatchObject({
+        "contract:emit": `deno run -A npm:${PRISMA_DENO_CLI_PACKAGE} contract emit`,
+        "db:init": `deno run -A --env-file=.env npm:${PRISMA_DENO_CLI_PACKAGE} db init`,
+      });
+    });
+  });
 });
 
 describe("Composer package-manager commands", () => {
@@ -91,13 +115,14 @@ describe("Composer package-manager commands", () => {
     expect(getComposerScriptMap("bun")["composer:deploy"]).toBe(
       `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} composer deploy module.ts`,
     );
+    expect(getComposerScriptMap("deno")).toEqual({});
   });
 
   test("keeps installs package-manager native", () => {
     for (const packageManager of packageManagers) {
       expect(getInstallArgs(packageManager)).toEqual({
         command: packageManager,
-        args: ["install"],
+        args: packageManager === "deno" ? ["install", "--allow-scripts"] : ["install"],
       });
     }
   });
@@ -109,6 +134,10 @@ describe("generated templates", () => {
       for (const provider of databaseProviders) {
         for (const authoring of authoringStyles) {
           for (const packageManager of packageManagers) {
+            if (packageManager === "deno" && (template !== "minimal" || provider !== "postgres")) {
+              continue;
+            }
+
             const projectDir = await mkdtemp(path.join(tmpdir(), "create-prisma-matrix-"));
             try {
               await scaffoldCreateTemplate({
@@ -122,8 +151,6 @@ describe("generated templates", () => {
               await writeCreateTemplateDependencies({ template, packageManager, projectDir });
 
               const packageJson = await readPackageJson(projectDir);
-              const moduleSource = await readFile(path.join(projectDir, "module.ts"), "utf8");
-              const serviceSource = await readFile(path.join(projectDir, "service.ts"), "utf8");
               const dbSource = await readFile(path.join(projectDir, "src/prisma/db.ts"), "utf8");
               const seedSource = await readFile(
                 path.join(projectDir, "src/prisma/seed.ts"),
@@ -133,11 +160,36 @@ describe("generated templates", () => {
                 path.join(projectDir, "src/prisma/users.ts"),
                 "utf8",
               );
+              const tsconfig = await readFile(path.join(projectDir, "tsconfig.json"), "utf8");
+
+              if (packageManager === "deno") {
+                expect(await pathExists(path.join(projectDir, "deno.json"))).toBe(true);
+                expect(await pathExists(path.join(projectDir, "module.ts"))).toBe(false);
+                expect(await pathExists(path.join(projectDir, "service.ts"))).toBe(false);
+                expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(false);
+                expect(await pathExists(path.join(projectDir, "prisma-composer.config.ts"))).toBe(
+                  false,
+                );
+                expect(packageJson.dependencies?.["@prisma/composer"]).toBeUndefined();
+                expect(packageJson.scripts).toMatchObject({
+                  build: "deno check src/index.ts",
+                  dev: "deno run -A --env-file=.env --watch src/index.ts",
+                  start: "deno run -A --env-file=.env src/index.ts",
+                });
+                expect(packageJson.scripts?.deploy).toBeUndefined();
+                expect(dbSource).toContain('Deno.env.get("DATABASE_URL")');
+                expect(dbSource).not.toContain('import service from "../../service.ts"');
+                expect(seedSource).toContain("await connectDatabase()");
+                expect(usersSource).toContain("await seed()");
+                continue;
+              }
+
+              const moduleSource = await readFile(path.join(projectDir, "module.ts"), "utf8");
+              const serviceSource = await readFile(path.join(projectDir, "service.ts"), "utf8");
               const prismaConfig = await readFile(
                 path.join(projectDir, "prisma.config.ts"),
                 "utf8",
               );
-              const tsconfig = await readFile(path.join(projectDir, "tsconfig.json"), "utf8");
 
               expect(packageJson.scripts?.deploy).toBeDefined();
               expect(packageJson.dependencies).toHaveProperty("@prisma/composer");

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -122,7 +122,7 @@ describe("Composer package-manager commands", () => {
     for (const packageManager of packageManagers) {
       expect(getInstallArgs(packageManager)).toEqual({
         command: packageManager,
-        args: packageManager === "deno" ? ["install", "--allow-scripts"] : ["install"],
+        args: ["install"],
       });
     }
   });

--- a/tests/setup-prisma.test.ts
+++ b/tests/setup-prisma.test.ts
@@ -84,4 +84,42 @@ describe("collectPrismaSetupContext", () => {
       expect(context?.databaseProvider).toBe("mongo");
     });
   });
+
+  test("supports Deno for local minimal PostgreSQL apps", async () => {
+    await withTempProject(async (projectDir) => {
+      const context = await collectPrismaSetupContext(
+        { yes: true, packageManager: "deno", provider: "postgres" },
+        { projectDir, template: "minimal" },
+      );
+
+      expect(context).toMatchObject({
+        databaseProvider: "postgres",
+        packageManager: "deno",
+        shouldDeploy: false,
+      });
+    });
+  });
+
+  test("rejects Deno for unsupported providers, templates, and deployments", async () => {
+    await withTempProject(async (projectDir) => {
+      await expect(
+        collectPrismaSetupContext(
+          { yes: true, packageManager: "deno", provider: "mongo" },
+          { projectDir, template: "minimal" },
+        ),
+      ).rejects.toThrow("Deno support currently requires PostgreSQL.");
+      await expect(
+        collectPrismaSetupContext(
+          { yes: true, packageManager: "deno", provider: "postgres" },
+          { projectDir, template: "next" },
+        ),
+      ).rejects.toThrow("Deno support currently requires the minimal template.");
+      await expect(
+        collectPrismaSetupContext(
+          { yes: true, packageManager: "deno", provider: "postgres", deploy: true },
+          { projectDir, template: "minimal" },
+        ),
+      ).rejects.toThrow("Prisma Compute does not support Deno deployments yet. Use --no-deploy.");
+    });
+  });
 });


### PR DESCRIPTION
## What this adds

- accepts deno as a package manager
- generates a native minimal Deno server for PostgreSQL
- installs dependencies with Deno and emits Deno task scripts for contract and database commands
- uses Deno environment access and explicit TypeScript import extensions
- omits Composer and Compute files, dependencies, and deployment steps
- rejects MongoDB, framework templates, and Compute deployment with actionable non-zero errors

## Scope

Deno support is intentionally limited to local minimal PostgreSQL apps. Prisma Compute does not support Deno deployments.

The consolidated prisma@next CLI currently crashes under Deno while importing @prisma/credentials-store through xdg-app-paths. Until that upstream path is compatible, this uses the existing Prisma 8 ORM-only prisma-next entrypoint for init and ORM commands. No Composer or authentication command goes through that path.

## Verification

- bun run typecheck
- bun run check
- bun run test:unit
- bun run build
- Deno E2E: scaffold, install, contract emit, and deno task build
- built create-prisma CLI executed under Deno successfully
- live Prisma Postgres verification: db:init succeeded, the generated Deno server returned HTTP 200, and Alice, Bob, and Carol were seeded on the first query

The full local E2E run also exercised the existing Bun templates; its Composer-dev test was blocked by stale local Prisma emulator port state, while the new Deno E2E passed.