### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.9.0

Publishes Deno support from #57 as `create-prisma@latest` using the trusted publishing workflow.

The previous Prisma 7 implementation remains available as `create-prisma@stable` (`0.7.2`).

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- Published #57 preview verified end to end with Deno and a live Prisma Postgres database.