### PR TITLE
fix: align with Prisma CLI RC8 commands

### DIFF
--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -309,7 +309,7 @@ async function getProjectDetails(options: {
     const result = await runPrismaJsonCommand<ProjectShowResult>({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
-      args: ["project", "show", "--project", options.appName],
+      args: ["project", "show", options.appName],
     });
     if (!result.project) return;
     return {
@@ -388,7 +388,7 @@ export async function deployWithComposer(options: {
       await runPrismaJsonCommand<ComposerDeployCommandResult>({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
-        args: ["composer", "deploy", "module.ts"],
+        args: ["deploy", "module.ts"],
         forwardStderr: options.verbose,
       }),
     );

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -47,7 +47,7 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
     "db:update": prismaCommand("db", "update"),
     "db:verify": prismaCommand("db", "verify"),
     "migration:plan": prismaCommand("migration", "plan"),
-    migrate: prismaCommand("migrate"),
+    migrate: prismaCommand("db", "migrate"),
     "migration:status": prismaCommand("migration", "status"),
     "migration:show": prismaCommand("migration", "show"),
   };
@@ -58,19 +58,16 @@ export function getComposerScriptMap(packageManager: PackageManager): Record<str
     return {};
   }
 
-  const composerCommand = (subcommand: string, extraArgs: string[] = []) =>
+  const composerCommand = (subcommand: "dev" | "deploy") =>
     getPackageExecutionCommand(packageManager, [
       PRISMA_PLATFORM_CLI_PACKAGE,
-      "composer",
       subcommand,
       "module.ts",
-      ...extraArgs,
     ]);
 
   return {
     "composer:dev": composerCommand("dev"),
     "composer:deploy": composerCommand("deploy"),
-    "composer:destroy": composerCommand("destroy", ["--production"]),
     deploy: `${getRunScriptCommand(packageManager, "build")} && ${getRunScriptCommand(
       packageManager,
       "composer:deploy",

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -61,6 +61,7 @@ describe("writePrismaDependencies", () => {
       });
       expect(packageJson.scripts).toMatchObject({
         "contract:emit": `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} contract emit`,
+        migrate: `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} db migrate`,
       });
       expect(packageJson.scripts?.["db:seed"]).toBeUndefined();
     });
@@ -104,17 +105,21 @@ describe("writePrismaDependencies", () => {
 describe("Composer package-manager commands", () => {
   test("uses each selected package manager for Prisma CLI execution", () => {
     expect(getComposerScriptMap("npm")["composer:deploy"]).toBe(
-      `npx --yes ${PRISMA_PLATFORM_CLI_PACKAGE} composer deploy module.ts`,
+      `npx --yes ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
     );
     expect(getComposerScriptMap("pnpm")["composer:deploy"]).toBe(
-      `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} composer deploy module.ts`,
+      `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
     );
     expect(getComposerScriptMap("yarn")["composer:deploy"]).toBe(
-      `yarn dlx ${PRISMA_PLATFORM_CLI_PACKAGE} composer deploy module.ts`,
+      `yarn dlx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
     );
     expect(getComposerScriptMap("bun")["composer:deploy"]).toBe(
-      `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} composer deploy module.ts`,
+      `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
     );
+    expect(getComposerScriptMap("bun")["composer:dev"]).toBe(
+      `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} dev module.ts`,
+    );
+    expect(getComposerScriptMap("bun")["composer:destroy"]).toBeUndefined();
     expect(getComposerScriptMap("deno")).toEqual({});
   });
 


### PR DESCRIPTION
## What changed

Prisma CLI RC8 changed its command grammar without compatibility aliases. This updates every affected Create Prisma call site:

- `prisma composer dev/deploy` → root `prisma dev/deploy`
- removes the deleted `composer destroy` generated script
- `prisma migrate` → `prisma db migrate`
- `prisma project show --project <name>` → `prisma project show <name>`

The official `prisma@next` entrypoint remains unchanged.

## Upstream dependency

Do not merge or release this until prisma/prisma-cli#221 publishes RC9. The currently published `prisma@next` RC8 wrapper has mismatched product dependency pins and crashes on every command with `Cannot read properties of undefined (reading 'needs')`. Upstream #221 fixes the wrapper and adds conformance coverage for this exact failure.

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test:unit` — 25 passed
- `bun run build`
- verified the RC8 command surface directly through `@prisma/cli@next`
- verified auth whoami/workspace JSON result shapes remain compatible
- generated Bun Composer app invoked root `dev module.ts` and reached both local emulators; the existing machine-wide stale Prisma Dev port registry then blocked database startup (unrelated to this change)