### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.9.1

Publishes Prisma CLI RC9 command compatibility from #59 as `create-prisma@latest` using trusted publishing.

The previous Prisma 7 implementation remains available as `create-prisma@stable` (`0.7.2`).

## Verification

- actual published #59 preview with official `prisma@next` (`8.0.0-rc.9`)
- all nine Bun templates: scaffold, install, contract emit, production build
- Deno minimal template: scaffold and build
- `bun run check`
- `bun run typecheck`
- `bun run build`