### PR TITLE
feat: sync agent skills through Prisma CLI

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,21 +3,21 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/cli-engine": "0.2.0",
-  "@prisma/composer": "0.10.0",
-  "@prisma/composer-prisma-cloud": "0.10.0",
+  "@prisma/composer": "0.12.0",
+  "@prisma/composer-prisma-cloud": "0.12.0",
   "@prisma/orm-mongo": "8.0.0-rc.4",
   "@prisma/orm-postgres": "8.0.0-rc.4",
   "@sveltejs/adapter-node": "^5.3.2",
   "@types/node": "^25.6.2",
-  alchemy: "2.0.0-beta.67",
+  alchemy: "2.0.0-beta.74",
   arktype: "^2.2.3",
   dotenv: "^17.4.2",
   esbuild: "^0.28.1",
-  effect: "4.0.0-beta.103",
+  effect: "4.0.0-rc.111",
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
+  prisma: "next",
   tsx: "^4.21.0",
   typescript: "^5.9.3",
 } as const;
@@ -51,7 +51,7 @@ export function getCreateTemplateDependencies(
   _packageManager: PackageManager,
 ): CreateTemplateDependencyTarget[] {
   const dependencies = ["@prisma/composer", "@prisma/composer-prisma-cloud", "alchemy"];
-  const devDependencies = ["@prisma/cli-engine"];
+  const devDependencies: string[] = [];
 
   if (usesEsbuild(template)) {
     devDependencies.push("esbuild");

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -6,15 +6,10 @@ import {
   getCreateTemplateDependencies,
   getDependencyVersion,
   PRISMA_DENO_CLI_PACKAGE,
-  PRISMA_PLATFORM_CLI_PACKAGE,
 } from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
-import {
-  getInstallArgs,
-  getPackageExecutionCommand,
-  getRunScriptCommand,
-} from "../utils/package-manager";
+import { getInstallArgs, getRunScriptCommand } from "../utils/package-manager";
 
 function getPrismaScriptMap(packageManager: PackageManager): Record<string, string> {
   if (packageManager === "deno") {
@@ -38,8 +33,7 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
     };
   }
 
-  const prismaCommand = (...args: string[]) =>
-    getPackageExecutionCommand(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
+  const prismaCommand = (...args: string[]) => ["prisma", ...args].join(" ");
 
   return {
     "contract:emit": prismaCommand("contract", "emit"),
@@ -50,6 +44,7 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
     migrate: prismaCommand("db", "migrate"),
     "migration:status": prismaCommand("migration", "status"),
     "migration:show": prismaCommand("migration", "show"),
+    "skills:sync": `${prismaCommand("skills", "sync")} || exit 0`,
   };
 }
 
@@ -59,11 +54,7 @@ export function getComposerScriptMap(packageManager: PackageManager): Record<str
   }
 
   const composerCommand = (subcommand: "dev" | "deploy") =>
-    getPackageExecutionCommand(packageManager, [
-      PRISMA_PLATFORM_CLI_PACKAGE,
-      subcommand,
-      "module.ts",
-    ]);
+    ["prisma", subcommand, "module.ts"].join(" ");
 
   return {
     "composer:dev": composerCommand("dev"),
@@ -156,8 +147,7 @@ export async function writePrismaDependencies(
   if (provider === "mongo") dependencies.push("arktype", "mongodb");
   if (packageManager === "deno") dependencies.push("dotenv");
 
-  const devDependencies =
-    packageManager === "deno" ? ["@types/node"] : ["@prisma/cli-engine", "@types/node"];
+  const devDependencies = packageManager === "deno" ? ["@types/node"] : ["@types/node", "prisma"];
 
   await addPackageDependency({
     dependencies,

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -239,6 +239,25 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
   if (context.packageManager === "deno") await fs.remove(path.join(projectDir, "prisma-next.md"));
 }
 
+async function initializeAgentSkills(
+  context: PrismaSetupContext,
+  projectDir: string,
+): Promise<void> {
+  if (context.packageManager === "deno") return;
+
+  const invocation = getPrismaCliInvocation(context.packageManager, [
+    "init",
+    "--yes",
+    "--no-interactive",
+  ]);
+  if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);
+  await execa(invocation.command, invocation.args, {
+    cwd: projectDir,
+    stdio: context.verbose ? "inherit" : "pipe",
+    env: { ...process.env, CI: "1" },
+  });
+}
+
 async function ensureGitignoreEntry(projectDir: string, entry: string): Promise<void> {
   const gitignorePath = path.join(projectDir, ".gitignore");
   const existing = (await fs.pathExists(gitignorePath))
@@ -403,6 +422,9 @@ export async function executePrismaSetupContext(
     await installProjectDependencies(context.packageManager, projectDir, {
       verbose: context.verbose,
     });
+
+    progress?.message("Installing Prisma agent skills...");
+    await initializeAgentSkills(context, projectDir);
 
     progress?.message("Generating Prisma 8 contract artifacts...");
     await emitContract(context, projectDir);

--- a/templates/create/_shared/pnpm-workspace.yaml.hbs
+++ b/templates/create/_shared/pnpm-workspace.yaml.hbs
@@ -12,5 +12,5 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - "@prisma/*"
 overrides:
-  effect: "4.0.0-beta.103"
+  effect: "4.0.0-rc.111"
 {{/if}}

--- a/templates/create/_shared/prisma.config.ts.hbs
+++ b/templates/create/_shared/prisma.config.ts.hbs
@@ -1,8 +1,11 @@
 {{#unless (eq packageManager "deno")}}
-import { definePrismaConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "prisma/config";
 import { defineConfig as ormConfig } from "@prisma/orm-{{#if (eq provider "postgres")}}postgres{{else}}mongo{{/if}}/config";
 
 export default definePrismaConfig({
+  skills: {
+    agents: ["claude", "cursor", "agents", "devin"],
+  },
   orm: ormConfig({
     contract: "./src/prisma/contract{{#if (eq authoring "typescript")}}.ts{{else}}.prisma{{/if}}",
 {{#if (eq authoring "typescript")}}

--- a/templates/create/nuxt/package.json.hbs
+++ b/templates/create/nuxt/package.json.hbs
@@ -11,7 +11,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
+    "postinstall": "nuxt prepare && {{runScriptCommand packageManager "skills:sync"}}",
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -5,9 +5,11 @@ import { dependencyVersionMap, getDependencyVersion } from "../src/constants/dep
 describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
     expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.4");
-    expect(getDependencyVersion("@prisma/cli-engine")).toBe("0.2.0");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.10.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.10.0");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.12.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.12.0");
+    expect(getDependencyVersion("prisma")).toBe("next");
+    expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
+    expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");
   });
 
   test("returns undefined for dependencies missing from the version map", () => {

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -36,6 +36,19 @@ async function runCommand(projectDir: string, args: string[]) {
   return `${stdout}\n${stderr}`;
 }
 
+function findAppEndpoint(output: string): string | undefined {
+  for (const line of output.split(/\r?\n/)) {
+    try {
+      const frame = JSON.parse(line) as { kind?: unknown; name?: unknown; url?: unknown };
+      if (frame.kind === "endpoint" && frame.name === "app" && typeof frame.url === "string") {
+        return frame.url;
+      }
+    } catch {
+      // Build output and package-manager prefixes are not JSON protocol frames.
+    }
+  }
+}
+
 async function verifyComposerDev(projectDir: string) {
   const process = Bun.spawn({
     cmd: ["bun", "run", "dev:composer"],
@@ -72,10 +85,10 @@ async function verifyComposerDev(projectDir: string) {
           result: nextResult,
         }));
       }
-      const match = output.match(/app:\s+(http:\/\/localhost:\d+)/);
-      if (!match?.[1]) continue;
+      const appUrl = findAppEndpoint(output);
+      if (!appUrl) continue;
 
-      const response = await fetch(match[1]);
+      const response = await fetch(appUrl);
       expect(response.status).toBe(200);
       const body = (await response.json()) as { users: Array<{ name: string }> };
       expect(body.users.map((user) => user.name)).toEqual(["Alice", "Bob", "Carol"]);
@@ -206,8 +219,16 @@ describe("create-prisma e2e", () => {
 
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
+      expect(
+        await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
+      ).toBe(true);
+      expect(
+        await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
+      ).toBe(true);
+      expect(packageJson.devDependencies.prisma).toBe("next");
+      expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
-      expect(packageJson.overrides.effect).toBe("4.0.0-beta.103");
+      expect(packageJson.overrides.effect).toBe("4.0.0-rc.111");
       expect(moduleSource).toContain("pnPostgres({");
       expect(dbSource).toContain("service.load().database.client");
 

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -3,11 +3,7 @@ import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import {
-  dependencyVersionMap,
-  PRISMA_DENO_CLI_PACKAGE,
-  PRISMA_PLATFORM_CLI_PACKAGE,
-} from "../src/constants/dependencies";
+import { dependencyVersionMap, PRISMA_DENO_CLI_PACKAGE } from "../src/constants/dependencies";
 import { scaffoldCreateTemplate } from "../src/templates/render-create-template";
 import {
   getComposerScriptMap,
@@ -15,7 +11,7 @@ import {
   writePrismaDependencies,
 } from "../src/tasks/install";
 import { authoringStyles, createTemplates, databaseProviders, packageManagers } from "../src/types";
-import { getInstallArgs } from "../src/utils/package-manager";
+import { getInstallArgs, getRunScriptCommand } from "../src/utils/package-manager";
 
 type PackageJson = {
   dependencies?: Record<string, string>;
@@ -57,11 +53,12 @@ describe("writePrismaDependencies", () => {
       });
       expect(packageJson.dependencies?.dotenv).toBeUndefined();
       expect(packageJson.devDependencies).toMatchObject({
-        "@prisma/cli-engine": dependencyVersionMap["@prisma/cli-engine"],
+        prisma: dependencyVersionMap.prisma,
       });
       expect(packageJson.scripts).toMatchObject({
-        "contract:emit": `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} contract emit`,
-        migrate: `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} db migrate`,
+        "contract:emit": "prisma contract emit",
+        migrate: "prisma db migrate",
+        "skills:sync": "prisma skills sync || exit 0",
       });
       expect(packageJson.scripts?.["db:seed"]).toBeUndefined();
     });
@@ -94,6 +91,7 @@ describe("writePrismaDependencies", () => {
         "@types/node": dependencyVersionMap["@types/node"],
       });
       expect(packageJson.devDependencies?.["@prisma/cli-engine"]).toBeUndefined();
+      expect(packageJson.devDependencies?.prisma).toBeUndefined();
       expect(packageJson.scripts).toMatchObject({
         "contract:emit": `deno run -A npm:${PRISMA_DENO_CLI_PACKAGE} contract emit`,
         "db:init": `deno run -A --env-file=.env npm:${PRISMA_DENO_CLI_PACKAGE} db init`,
@@ -104,21 +102,12 @@ describe("writePrismaDependencies", () => {
 
 describe("Composer package-manager commands", () => {
   test("uses each selected package manager for Prisma CLI execution", () => {
-    expect(getComposerScriptMap("npm")["composer:deploy"]).toBe(
-      `npx --yes ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
-    );
-    expect(getComposerScriptMap("pnpm")["composer:deploy"]).toBe(
-      `pnpm dlx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
-    );
-    expect(getComposerScriptMap("yarn")["composer:deploy"]).toBe(
-      `yarn dlx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
-    );
-    expect(getComposerScriptMap("bun")["composer:deploy"]).toBe(
-      `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} deploy module.ts`,
-    );
-    expect(getComposerScriptMap("bun")["composer:dev"]).toBe(
-      `bunx ${PRISMA_PLATFORM_CLI_PACKAGE} dev module.ts`,
-    );
+    for (const packageManager of ["npm", "pnpm", "yarn", "bun"] as const) {
+      expect(getComposerScriptMap(packageManager)["composer:deploy"]).toBe(
+        "prisma deploy module.ts",
+      );
+      expect(getComposerScriptMap(packageManager)["composer:dev"]).toBe("prisma dev module.ts");
+    }
     expect(getComposerScriptMap("bun")["composer:destroy"]).toBeUndefined();
     expect(getComposerScriptMap("deno")).toEqual({});
   });
@@ -200,6 +189,8 @@ describe("generated templates", () => {
               expect(packageJson.dependencies).toHaveProperty("@prisma/composer");
               expect(packageJson.dependencies).toHaveProperty("alchemy");
               expect(prismaConfig).toContain("orm: ormConfig({");
+              expect(prismaConfig).toContain('import { definePrismaConfig } from "prisma/config"');
+              expect(prismaConfig).toContain('agents: ["claude", "cursor", "agents", "devin"]');
               expect(prismaConfig).toContain('configPath: "./prisma-composer.config.ts"');
               expect(tsconfig).toContain('"node"');
               expect(serviceSource).toContain("compute({");
@@ -231,6 +222,11 @@ describe("generated templates", () => {
               if (template === "svelte") {
                 const viteConfig = await readFile(path.join(projectDir, "vite.config.ts"), "utf8");
                 expect(viteConfig).toContain("noExternal: true");
+              }
+              if (template === "nuxt") {
+                expect(packageJson.scripts?.postinstall).toBe(
+                  `nuxt prepare && ${getRunScriptCommand(packageManager, "skills:sync")}`,
+                );
               }
               if (provider === "postgres") {
                 expect(moduleSource).toContain("pnPostgres({");
@@ -290,14 +286,14 @@ describe("generated templates", () => {
                     "minimumReleaseAgeExclude:",
                     '  - "@prisma/*"',
                     "overrides:",
-                    '  effect: "4.0.0-beta.103"',
+                    '  effect: "4.0.0-rc.111"',
                     "",
                   ].join("\n"),
                 );
               } else if (packageManager === "yarn") {
-                expect(packageJson.resolutions?.effect).toBe("4.0.0-beta.103");
+                expect(packageJson.resolutions?.effect).toBe("4.0.0-rc.111");
               } else {
-                expect(packageJson.overrides?.effect).toBe("4.0.0-beta.103");
+                expect(packageJson.overrides?.effect).toBe("4.0.0-rc.111");
               }
             } finally {
               await rm(projectDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- install `prisma@next` in generated Node projects and use its local `prisma` binary for ORM and Composer scripts
- configure the supported agent targets in `prisma.config.ts`, then run `prisma init` after dependency installation so the CLI syncs skills from installed Prisma packages
- keep skills current with the CLI-managed postinstall hook; preserve Nuxt's required `nuxt prepare` step before syncing
- align the generated stack with the skills-bearing Composer 0.12 release and its Alchemy/Effect versions
- consume the consolidated CLI's structured endpoint frame in the Composer dev E2E test

This keeps the old ORM skills installer disabled (`--skip-skills` / `--no-skill`), so generated projects no longer source skills from `prisma/skills`. Deno remains on its existing ORM-only path until the consolidated CLI can start under Deno.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:e2e`
- scaffolded and production-built a Nuxt app; verified its CLI-managed `prisma-composer` skill and chained postinstall
- Composer local dev returned seeded users through the generated app
- Deno minimal scaffold/build still passes