### PR TITLE
fix: make Composer deployment progress actionable

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
     "test": "bun run test:unit && bun run test:e2e",
-    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/install.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry.test.ts",
+    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/initialize-git.test.ts ./tests/install.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry.test.ts",
     "test:e2e": "bun test --timeout 180000 ./tests/e2e/create-prisma.e2e.test.ts",
     "check": "bun run format:check && bun run lint",
     "lint": "oxlint . --deny-warnings",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -382,6 +382,7 @@ async function executeCreateContext(
       template: context.template,
       createdProjectPath: context.targetDirectory,
       includeDevNextStep: true,
+      initializeGit: !context.targetPathState.exists || context.targetPathState.isEmptyDirectory,
       progressSpinner: createSpinner,
     });
 

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -72,13 +72,17 @@ export type ComposerDeployResult = {
   };
 };
 
-function redactSecrets(message: string): string {
+export function redactSecrets(message: string): string {
   return message
-    .replace(/\b((?:prisma\+)?postgres(?:ql)?:\/\/)[^\s'"]+/gi, "$1<redacted>")
     .replace(
-      /\b([A-Z0-9_]*(?:DATABASE_URL|TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z0-9_]*=)[^\s]+/g,
+      /\b((?:(?:prisma\+)?postgres(?:ql)?|mongodb(?:\+srv)?):\/\/)[^\s'"]+/gi,
       "$1<redacted>",
-    );
+    )
+    .replace(
+      /\b([A-Z0-9_]*(?:MONGODB_(?:URL|URI)|DATABASE_URL|TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s]+)/gi,
+      "$1<redacted>",
+    )
+    .replace(/(\bAuthorization\s*:\s*Bearer\s+)[^\s'"]+/gi, "$1<redacted>");
 }
 
 function getErrorMessage(error: unknown): string {

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -370,7 +370,11 @@ async function getProjectDetails(options: {
   }
 }
 
-export async function deployWithComposer(options: {
+/**
+ * Performs the optional one-shot deployment at the end of a create-prisma scaffold.
+ * Generated projects use their own `deploy` script for every subsequent deployment.
+ */
+export async function deployNewProjectWithComposer(options: {
   appName: string;
   packageManager: PackageManager;
   projectDir: string;

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -1,5 +1,6 @@
-import { cancel, isCancel, log, select, spinner } from "@clack/prompts";
+import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts";
 import { execa } from "execa";
+import { createInterface } from "node:readline";
 
 import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import type { PackageManager } from "../types";
@@ -42,6 +43,13 @@ type WorkspaceUseResult = {
 type ProjectShowResult = {
   workspace: PrismaWorkspace;
   project: { id: string; name: string } | null;
+};
+
+type ProjectListResult = {
+  items: Array<{
+    id: string;
+    name: string;
+  }>;
 };
 
 type ComposerDeployCommandResult = {
@@ -123,22 +131,28 @@ async function runPrismaJsonCommand<Result>(options: {
   packageManager: PackageManager;
   projectDir: string;
   args: string[];
-  forwardStderr?: boolean;
+  onStderrLine?: (line: string) => void;
 }): Promise<Result> {
   const invocation = getPrismaCliArgs(options.packageManager, [
     ...options.args,
     "--json",
     "--no-interactive",
   ]);
-  const result = await execa(invocation.command, invocation.args, {
+  const subprocess = execa(invocation.command, invocation.args, {
     cwd: options.projectDir,
     env: process.env,
     reject: false,
   });
-
-  if (options.forwardStderr && result.stderr) {
-    process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
-  }
+  const stderrLines =
+    options.onStderrLine && subprocess.stderr
+      ? (async () => {
+          const lines = createInterface({ input: subprocess.stderr });
+          for await (const line of lines) {
+            if (line.trim()) options.onStderrLine?.(line);
+          }
+        })()
+      : Promise.resolve();
+  const [result] = await Promise.all([subprocess, stderrLines]);
 
   let envelope: PrismaCliEnvelope<Result>;
   try {
@@ -157,6 +171,36 @@ async function runPrismaJsonCommand<Result>(options: {
     );
   }
   return envelope.result;
+}
+
+export function findProjectNameCollisions(
+  projects: ProjectListResult["items"],
+  appName: string,
+): ProjectListResult["items"] {
+  return projects.filter((project) => project.name === appName);
+}
+
+async function ensureProjectNameAvailable(options: {
+  appName: string;
+  packageManager: PackageManager;
+  projectDir: string;
+  workspace: PrismaWorkspace;
+}): Promise<void> {
+  const result = await runPrismaJsonCommand<ProjectListResult>({
+    packageManager: options.packageManager,
+    projectDir: options.projectDir,
+    args: ["project", "list"],
+  });
+  const collisions = findProjectNameCollisions(result.items, options.appName);
+  if (collisions.length === 0) return;
+
+  const projectIds = collisions.map((project) => project.id).join(", ");
+  throw new Error(
+    `A Prisma project named "${options.appName}" already exists in workspace ${workspaceLabel(
+      options.workspace,
+    )} (${options.workspace.id}). Choose a different project name or delete the existing project ` +
+      `(${projectIds}) in Prisma Console, then retry.`,
+  );
 }
 
 async function ensureAuthentication(
@@ -335,6 +379,7 @@ export async function deployWithComposer(options: {
   workspace?: string;
 }): Promise<ComposerDeployResult | undefined> {
   const progress = options.verbose ? undefined : spinner();
+  let deploymentLog: ReturnType<typeof taskLog> | undefined;
   let progressRunning = false;
   const showProgress = (message: string) => {
     if (!progress) return;
@@ -373,6 +418,15 @@ export async function deployWithComposer(options: {
     });
     if (!selectedWorkspace) return;
 
+    showProgress("Checking Prisma project name...");
+    if (options.verbose) log.step("Checking Prisma project name.");
+    await ensureProjectNameAvailable({
+      appName: options.appName,
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      workspace: selectedWorkspace,
+    });
+
     showProgress("Building for deployment...");
     if (options.verbose) log.step("Building for deployment.");
     const build = getRunScriptArgs(options.packageManager, "build");
@@ -382,26 +436,48 @@ export async function deployWithComposer(options: {
       stdio: options.verbose ? "inherit" : "pipe",
     });
 
-    showProgress("Deploying to Prisma...");
-    if (options.verbose) log.step("Deploying to Prisma.");
+    clearProgress();
+    const deployCommand = getPackageExecutionCommand(options.packageManager, [
+      PRISMA_PLATFORM_CLI_PACKAGE,
+      "deploy",
+      "module.ts",
+    ]);
+    if (options.verbose) {
+      log.step(`Deploying to Prisma with ${deployCommand}.`);
+    } else {
+      deploymentLog = taskLog({ title: "Deploying to Prisma...", limit: 10 });
+      deploymentLog.message(`$ ${deployCommand}`);
+    }
     const deployment = parseComposerDeployResult(
       await runPrismaJsonCommand<ComposerDeployCommandResult>({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
         args: ["deploy", "module.ts"],
-        forwardStderr: options.verbose,
+        onStderrLine: (line) => {
+          const redactedLine = redactSecrets(line);
+          if (options.verbose) {
+            process.stderr.write(`${redactedLine}\n`);
+          } else {
+            deploymentLog?.message(redactedLine);
+          }
+        },
       }),
     );
     const appName = deployment?.appName ?? options.appName;
 
-    showProgress("Loading deployment details...");
+    if (options.verbose) {
+      log.step("Loading deployment details.");
+    } else {
+      deploymentLog?.message("Loading deployment details...");
+    }
     const details = await getProjectDetails({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       appName,
     });
 
-    progress?.stop("Deployed to Prisma.");
+    deploymentLog?.success("Deployed to Prisma.");
+    deploymentLog = undefined;
     progressRunning = false;
     if (options.verbose) log.success("Deployed to Prisma.");
     const workspace = details?.workspace ?? selectedWorkspace;
@@ -412,7 +488,12 @@ export async function deployWithComposer(options: {
       project: details?.project ?? { name: appName },
     };
   } catch (error) {
-    progress?.error("Deployment failed.");
+    if (deploymentLog) {
+      deploymentLog.error("Deployment failed.");
+      deploymentLog = undefined;
+    } else {
+      progress?.error("Deployment failed.");
+    }
     progressRunning = false;
     log.error(`Deploy failed: ${getErrorMessage(error)}`);
     return;

--- a/src/tasks/initialize-git.ts
+++ b/src/tasks/initialize-git.ts
@@ -1,0 +1,53 @@
+import { execa } from "execa";
+import fs from "fs-extra";
+import path from "node:path";
+
+export type GitInitializationResult =
+  | { status: "initialized" }
+  | { status: "already-in-repository" }
+  | { status: "skipped"; reason: string };
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && "stderr" in error) {
+    const stderr = String((error as { stderr?: string }).stderr ?? "").trim();
+    if (stderr) return stderr;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Initializes a standalone scaffold as a Git repository and records its generated files.
+ * Projects created inside an existing repository remain part of that repository.
+ */
+export async function initializeGitRepository(
+  projectDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<GitInitializationResult> {
+  try {
+    const existing = await execa("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd: projectDir,
+      env,
+      reject: false,
+    });
+    if (existing.exitCode === 0 && existing.stdout.trim() === "true") {
+      return { status: "already-in-repository" };
+    }
+  } catch (error) {
+    return { status: "skipped", reason: errorMessage(error) };
+  }
+
+  let initialized = false;
+  try {
+    await execa("git", ["init"], { cwd: projectDir, env });
+    initialized = true;
+    await execa("git", ["add", "--all"], { cwd: projectDir, env });
+    await execa("git", ["commit", "--no-verify", "-m", "Initial commit from create-prisma"], {
+      cwd: projectDir,
+      env,
+    });
+    return { status: "initialized" };
+  } catch (error) {
+    if (initialized) await fs.remove(path.join(projectDir, ".git"));
+    return { status: "skipped", reason: errorMessage(error) };
+  }
+}

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -22,7 +22,7 @@ import {
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
-import { deployWithComposer, type ComposerDeployResult } from "./deploy-with-composer";
+import { deployNewProjectWithComposer, type ComposerDeployResult } from "./deploy-with-composer";
 import { installProjectDependencies, writePrismaDependencies } from "./install";
 
 const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
@@ -437,7 +437,7 @@ export async function executePrismaSetupContext(
 
   let deployment: ComposerDeployResult | undefined;
   if (context.shouldDeploy) {
-    deployment = await deployWithComposer({
+    deployment = await deployNewProjectWithComposer({
       appName: projectName,
       packageManager: context.packageManager,
       projectDir,

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -23,6 +23,7 @@ import {
   getRunScriptCommand,
 } from "../utils/package-manager";
 import { deployNewProjectWithComposer, type ComposerDeployResult } from "./deploy-with-composer";
+import { initializeGitRepository, type GitInitializationResult } from "./initialize-git";
 import { installProjectDependencies, writePrismaDependencies } from "./install";
 
 const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
@@ -40,6 +41,7 @@ type PrismaSetupRunOptions = {
   template?: CreateTemplate;
   createdProjectPath?: string;
   includeDevNextStep?: boolean;
+  initializeGit?: boolean;
   progressSpinner?: ReturnType<typeof spinner>;
 };
 
@@ -393,6 +395,7 @@ export async function executePrismaSetupContext(
   const template = options.template ?? "minimal";
   const progress = context.verbose ? undefined : (options.progressSpinner ?? spinner());
   const ownsProgress = progress !== undefined && !options.progressSpinner;
+  let gitInitialization: GitInitializationResult | undefined;
   if (ownsProgress) progress.start("Creating Prisma 8 project...");
 
   try {
@@ -415,6 +418,10 @@ export async function executePrismaSetupContext(
     );
     await ensureComposerTypeScriptOptions(projectDir);
     if (context.databaseProvider === "mongo") await ensureMongoEnvironment(projectDir);
+    if (context.packageManager !== "deno") {
+      await ensureGitignoreEntry(projectDir, "/.alchemy");
+      await ensureGitignoreEntry(projectDir, "/.prisma-composer");
+    }
 
     progress?.message(
       `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
@@ -428,7 +435,17 @@ export async function executePrismaSetupContext(
 
     progress?.message("Generating Prisma 8 contract artifacts...");
     await emitContract(context, projectDir);
+
+    if (options.initializeGit) {
+      progress?.message("Initializing Git repository...");
+      gitInitialization = await initializeGitRepository(projectDir);
+    }
     progress?.stop("Prisma 8 project ready.");
+    if (gitInitialization?.status === "initialized" && context.verbose) {
+      log.success("Initialized Git repository with an initial commit.");
+    } else if (gitInitialization?.status === "skipped") {
+      log.warn(`Could not initialize Git repository: ${gitInitialization.reason}`);
+    }
   } catch (error) {
     progress?.error("Could not create Prisma 8 project.");
     cancel(getCommandErrorMessage(error));

--- a/tests/deploy-with-composer.test.ts
+++ b/tests/deploy-with-composer.test.ts
@@ -5,7 +5,34 @@ import {
   getConsoleProjectUrl,
   parseComposerDeployResult,
   parsePrismaCliEnvelope,
+  redactSecrets,
 } from "../src/tasks/deploy-with-composer";
+
+describe("redactSecrets", () => {
+  test("redacts supported database URLs", () => {
+    expect(
+      redactSecrets(
+        "postgresql://user:pass@host/db mongodb://user:pass@host/db mongodb+srv://user:pass@host/db",
+      ),
+    ).toBe("postgresql://<redacted> mongodb://<redacted> mongodb+srv://<redacted>");
+  });
+
+  test("redacts mixed-case assignments and quoted values", () => {
+    expect(
+      redactSecrets(
+        "database_url = \"postgresql://user:pass@host/db\" MongoDb_Uri='mongodb://secret' Api_Token=token-value",
+      ),
+    ).toBe("database_url = <redacted> MongoDb_Uri=<redacted> Api_Token=<redacted>");
+  });
+
+  test("redacts bearer credentials without hiding public app URLs", () => {
+    expect(
+      redactSecrets(
+        "Authorization: Bearer header.payload.signature App: https://example.prisma.build",
+      ),
+    ).toBe("Authorization: Bearer <redacted> App: https://example.prisma.build");
+  });
+});
 
 describe("findProjectNameCollisions", () => {
   test("returns every exact project-name match", () => {

--- a/tests/deploy-with-composer.test.ts
+++ b/tests/deploy-with-composer.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  findProjectNameCollisions,
   getConsoleProjectUrl,
   parseComposerDeployResult,
   parsePrismaCliEnvelope,
 } from "../src/tasks/deploy-with-composer";
+
+describe("findProjectNameCollisions", () => {
+  test("returns every exact project-name match", () => {
+    expect(
+      findProjectNameCollisions(
+        [
+          { id: "proj_first", name: "my-app" },
+          { id: "proj_other", name: "my-app-api" },
+          { id: "proj_second", name: "my-app" },
+        ],
+        "my-app",
+      ),
+    ).toEqual([
+      { id: "proj_first", name: "my-app" },
+      { id: "proj_second", name: "my-app" },
+    ]);
+  });
+
+  test("does not treat a differently-cased name as the same project", () => {
+    expect(findProjectNameCollisions([{ id: "proj_upper", name: "My-App" }], "my-app")).toEqual([]);
+  });
+});
 
 describe("getConsoleProjectUrl", () => {
   test("converts Management API resource ids to Console route ids", () => {

--- a/tests/initialize-git.test.ts
+++ b/tests/initialize-git.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { execa } from "execa";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { initializeGitRepository } from "../src/tasks/initialize-git";
+
+const gitIdentity = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "create-prisma test",
+  GIT_AUTHOR_EMAIL: "create-prisma@example.test",
+  GIT_COMMITTER_NAME: "create-prisma test",
+  GIT_COMMITTER_EMAIL: "create-prisma@example.test",
+};
+
+async function withTempDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(path.join(tmpdir(), "create-prisma-git-"));
+  try {
+    return await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("initializeGitRepository", () => {
+  test("creates an initial commit containing the generated project", async () => {
+    await withTempDirectory(async (projectDir) => {
+      await writeFile(path.join(projectDir, "package.json"), '{"name":"app"}\n');
+
+      const result = await initializeGitRepository(projectDir, gitIdentity);
+
+      expect(result).toEqual({ status: "initialized" });
+      expect(
+        (
+          await execa("git", ["log", "-1", "--pretty=%s"], {
+            cwd: projectDir,
+            env: gitIdentity,
+          })
+        ).stdout,
+      ).toBe("Initial commit from create-prisma");
+      expect(
+        (
+          await execa("git", ["status", "--porcelain"], {
+            cwd: projectDir,
+            env: gitIdentity,
+          })
+        ).stdout,
+      ).toBe("");
+    });
+  });
+
+  test("does not create a nested repository inside an existing checkout", async () => {
+    await withTempDirectory(async (repositoryDir) => {
+      await execa("git", ["init"], { cwd: repositoryDir, env: gitIdentity });
+      await writeFile(path.join(repositoryDir, "README.md"), "# repository\n");
+      await execa("git", ["add", "--all"], { cwd: repositoryDir, env: gitIdentity });
+      await execa("git", ["commit", "--no-verify", "-m", "Existing commit"], {
+        cwd: repositoryDir,
+        env: gitIdentity,
+      });
+      const projectDir = path.join(repositoryDir, "apps", "new-app");
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, "package.json"), '{"name":"new-app"}\n');
+
+      const result = await initializeGitRepository(projectDir, gitIdentity);
+
+      expect(result).toEqual({ status: "already-in-repository" });
+      expect(await fsExists(path.join(projectDir, ".git"))).toBe(false);
+    });
+  });
+});
+
+async function fsExists(filePath: string): Promise<boolean> {
+  return await Bun.file(filePath).exists();
+}


### PR DESCRIPTION
## Summary

- fail the first-time `create-prisma` deployment before building when the selected workspace already contains an exact project-name match
- use the consolidated CLI's structured `project list --json` result for collision detection
- stream delegated Composer diagnostics through Clack 1.7's native `taskLog`
- retain only the latest 10 redacted lines while deploying, clear them on success, and preserve them on failure
- redact PostgreSQL, MongoDB/SRV, secret-assignment, and bearer credentials from streamed logs
- keep complete streaming output under `--verbose`
- initialize new standalone scaffolds as Git repositories with an `Initial commit from create-prisma`
- keep projects created inside an existing checkout in that checkout instead of creating a nested repository
- ignore Composer's generated `/.alchemy` and `/.prisma-composer` state before the initial commit

Normal `prisma deploy` behavior is unchanged: repeat deployments can continue reusing a Composer-owned project.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run test:unit` (32 passed)
- `bun run test:e2e` (5 passed)
- `bun run build`
- live collision check against an existing `my-app-sas` project: rejected before build
- live fresh Bun/TypeScript/PostgreSQL deployment: succeeded, rolling log cleared, deployed route returned seeded users
- live Git-backed preview deployment: streamed resource progress without the missing-Git warning, succeeded, returned seeded users, and left `git status` clean
- Git initialization tests verify the initial commit and avoidance of nested repositories
