### PR TITLE
chore(release): 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.9.3

This PR bumps `create-prisma` to `0.9.3` after #63.

When this PR merges, GitHub Actions publishes to npm using trusted publishing.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test:unit` (32 passed)
