### PR TITLE
Scaffold the baseline migration and move pins to current releases

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,9 +3,10 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/composer": "0.12.0",
-  "@prisma/composer-prisma-cloud": "0.12.0",
-  "@prisma/orm-mongo": "8.0.0-rc.4",
+  "@prisma/composer": "0.14.0",
+  "@prisma/composer-prisma-cloud": "0.14.0",
+  "@prisma/orm-mongo": "8.0.0-rc.6",
+  // Must match @prisma/composer-prisma-cloud's exact peerDependency.
   "@prisma/orm-postgres": "8.0.0-rc.4",
   "@sveltejs/adapter-node": "^5.3.2",
   "@types/node": "^25.6.2",

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -18,12 +18,15 @@ export const dependencyVersionMap = {
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
-  prisma: "next",
+  prisma: "8.0.0-rc.9",
   tsx: "^4.21.0",
   typescript: "^5.9.3",
 } as const;
 
-export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@next";
+// Pinned, not `prisma@next`: the scaffold's own invocations must not float
+// with the dist-tag (rc.10 removed `orm init --skip-skills` and rejected its
+// own scaffolded schema at `contract emit`, breaking every create).
+export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.9";
 // The consolidated CLI currently imports Node-only credential storage when Deno starts it.
 // Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
 export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -316,6 +316,29 @@ async function emitContract(context: PrismaSetupContext, projectDir: string): Pr
   });
 }
 
+// Composer deploys are replay-only: they apply committed migrations and never
+// create schema. The scaffold authors the baseline (empty → the emitted
+// contract) so the project's first deploy always has a migration path.
+async function planBaselineMigration(
+  context: PrismaSetupContext,
+  projectDir: string,
+): Promise<void> {
+  if (context.databaseProvider !== "postgres") return;
+  const invocation = getPrismaCliInvocation(context.packageManager, [
+    "migration",
+    "plan",
+    "--name",
+    "init",
+  ]);
+  if (context.verbose) {
+    log.step([invocation.command, ...invocation.args].join(" "));
+  }
+  await execa(invocation.command, invocation.args, {
+    cwd: projectDir,
+    stdio: context.verbose ? "inherit" : "pipe",
+  });
+}
+
 function formatNextSteps(steps: NextStep[]): string {
   return steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
 }
@@ -435,6 +458,9 @@ export async function executePrismaSetupContext(
 
     progress?.message("Generating Prisma 8 contract artifacts...");
     await emitContract(context, projectDir);
+
+    progress?.message("Authoring the baseline migration...");
+    await planBaselineMigration(context, projectDir);
 
     if (options.initializeGit) {
       progress?.message("Initializing Git repository...");

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -305,38 +305,33 @@ async function ensureComposerTypeScriptOptions(projectDir: string): Promise<void
   await fs.writeFile(tsconfigPath, updated, "utf8");
 }
 
-async function emitContract(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  const invocation = getPrismaCliInvocation(context.packageManager, ["contract", "emit"]);
+async function runPrismaCli(
+  context: PrismaSetupContext,
+  projectDir: string,
+  args: string[],
+): Promise<void> {
+  const invocation = getPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) {
     log.step([invocation.command, ...invocation.args].join(" "));
   }
   await execa(invocation.command, invocation.args, {
     cwd: projectDir,
     stdio: context.verbose ? "inherit" : "pipe",
+    env: { ...process.env, CI: "1" },
   });
 }
 
+async function emitContract(context: PrismaSetupContext, projectDir: string): Promise<void> {
+  await runPrismaCli(context, projectDir, ["contract", "emit"]);
+}
+
 // Composer deploys are replay-only: they apply committed migrations and never
-// create schema. The scaffold authors the baseline (empty → the emitted
-// contract) so the project's first deploy always has a migration path.
+// create schema, so the scaffold authors the baseline itself.
 async function planBaselineMigration(
   context: PrismaSetupContext,
   projectDir: string,
 ): Promise<void> {
-  if (context.databaseProvider !== "postgres") return;
-  const invocation = getPrismaCliInvocation(context.packageManager, [
-    "migration",
-    "plan",
-    "--name",
-    "init",
-  ]);
-  if (context.verbose) {
-    log.step([invocation.command, ...invocation.args].join(" "));
-  }
-  await execa(invocation.command, invocation.args, {
-    cwd: projectDir,
-    stdio: context.verbose ? "inherit" : "pipe",
-  });
+  await runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]);
 }
 
 function formatNextSteps(steps: NextStep[]): string {
@@ -459,8 +454,10 @@ export async function executePrismaSetupContext(
     progress?.message("Generating Prisma 8 contract artifacts...");
     await emitContract(context, projectDir);
 
-    progress?.message("Authoring the baseline migration...");
-    await planBaselineMigration(context, projectDir);
+    if (context.databaseProvider === "postgres") {
+      progress?.message("Authoring the baseline migration...");
+      await planBaselineMigration(context, projectDir);
+    }
 
     if (options.initializeGit) {
       progress?.message("Initializing Git repository...");

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -8,7 +8,7 @@ describe("Prisma 8 dependency versions", () => {
     expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.6");
     expect(getDependencyVersion("@prisma/composer")).toBe("0.14.0");
     expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.14.0");
-    expect(getDependencyVersion("prisma")).toBe("next");
+    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.9");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");
   });

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -5,8 +5,9 @@ import { dependencyVersionMap, getDependencyVersion } from "../src/constants/dep
 describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
     expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.4");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.12.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.12.0");
+    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.6");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.14.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.14.0");
     expect(getDependencyVersion("prisma")).toBe("next");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -219,6 +219,9 @@ describe("create-prisma e2e", () => {
 
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
+      // The scaffold commits the baseline migration — replay-only deploys
+      // need an authored path from empty to the contract.
+      expect(await pathExists(path.join(projectDir, "migrations/app"))).toBe(true);
       expect(
         await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
       ).toBe(true);

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -228,7 +228,7 @@ describe("create-prisma e2e", () => {
       expect(
         await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
-      expect(packageJson.devDependencies.prisma).toBe("next");
+      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.9");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
       expect(packageJson.overrides.effect).toBe("4.0.0-rc.111");


### PR DESCRIPTION
Composer deploys are becoming replay-only (prisma/composer#259): the pipeline applies committed migrations and never creates schema. This PR makes sure a fresh scaffold always has a migration path on its first deploy, and moves the template pins to current releases.

## What changed

- After `contract emit`, the postgres scaffold runs `prisma migration plan --name init`, so every new project ships with its baseline migration (empty → the emitted contract) committed in the initial commit. Mongo templates are unchanged — they don't go through the Composer migration step.
- Pins: `@prisma/composer` and `@prisma/composer-prisma-cloud` move to 0.14.0, `@prisma/orm-mongo` to 8.0.0-rc.6. `@prisma/orm-postgres` stays at 8.0.0-rc.4 because `@prisma/composer-prisma-cloud@0.14.0` declares it as an exact-version peer dependency.
- The postgres e2e asserts `migrations/app` exists after scaffolding.

## Verification

- `bun run typecheck`, `bun run check`, `bun run test:unit`: clean, 32 pass.
- The "generates, builds, and runs a Composer-backed Prisma Postgres app" e2e passes locally: the scaffold authors the baseline, builds, typechecks, and serves the seeded users through `composer dev`.

## Sequencing

Land this before or with the composer release that removes deploy-time schema synthesis, so new users never see the missing-path refusal on a fresh scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Amendments after review

- **The platform CLI is now pinned at `prisma@8.0.0-rc.9`** (both the scaffold's own invocations and the scaffolded project's devDependency) instead of floating on `prisma@next`. While this PR was open, `next` moved to 8.0.0-rc.10, which removed `orm init --skip-skills` and rejects its own scaffolded schema at `contract emit` — every `create-prisma` run broke with no change in this repo. Pinning makes scaffolding change only when this package deliberately moves the pin. The postgres e2e passes against the pin.
- One `runPrismaCli` helper replaces three near-identical execa blocks and carries `CI=1` on every scaffold-time CLI invocation; the postgres-only guard for the baseline step moved to the call site so mongo scaffolds don't display a step that never runs.

Known gap, tracked: no test replays a scaffolded baseline against the pinned composer replay engine (`@prisma/orm-postgres` 8.0.0-rc.4) — every e2e passes `--no-deploy`. An e2e that runs the pinned control client's migrate against the scaffolded `migrations/` + `contract.json` would catch on-disk format drift between the authoring CLI and the replay engine.
