### PR TITLE
fix: pin the compatible Prisma CLI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn dlx create-prisma@latest my-app
 bunx create-prisma@latest my-app
 ```
 
-The CLI initializes Prisma 8 with `prisma@next`, installs dependencies, emits the contract, and generates a deployable Composer app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
+The CLI initializes Prisma 8 with a tested Prisma CLI release, installs dependencies, emits the contract, and generates a deployable Composer app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
 
 The deployment prompt is:
 

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -17,12 +17,12 @@ export const dependencyVersionMap = {
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
-  prisma: "next",
+  prisma: "8.0.0-rc.9",
   tsx: "^4.21.0",
   typescript: "^5.9.3",
 } as const;
 
-export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@next";
+export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.9";
 // The consolidated CLI currently imports Node-only credential storage when Deno starts it.
 // Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
 export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -7,7 +7,7 @@ describe("Prisma 8 dependency versions", () => {
     expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.4");
     expect(getDependencyVersion("@prisma/composer")).toBe("0.12.0");
     expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.12.0");
-    expect(getDependencyVersion("prisma")).toBe("next");
+    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.9");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");
   });

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -225,7 +225,7 @@ describe("create-prisma e2e", () => {
       expect(
         await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
-      expect(packageJson.devDependencies.prisma).toBe("next");
+      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.9");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
       expect(packageJson.overrides.effect).toBe("4.0.0-rc.111");


### PR DESCRIPTION
## Problem

`create-prisma@0.9.3` floats on `prisma@next`. Both the `next` and `latest` tags moved to `8.0.0-rc.10`, breaking every non-Deno scaffold without a create-prisma release:

1. `orm init` rejects the existing `--skip-skills` argument.
2. Removing that argument is not sufficient: RC.10 generates a contract using `field.temporal.createdAtString()`, while the latest Composer cloud package still requires `@prisma/orm-postgres@8.0.0-rc.4`, which does not expose that API. `contract emit` then fails with `CONTRACT.SOURCE_LOAD_FAILED`.

## Fix

Pin both the scaffold-time CLI invocation and the generated project dependency to the last verified compatible release, `prisma@8.0.0-rc.9`. This prevents npm dist-tag movement from breaking published create-prisma versions.

This is intentionally a focused hotfix. The broader baseline migration and dependency updates in #65 can proceed independently.

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test:unit` — 32 passed
- `bun run test:e2e` — 5 passed, including Composer dev + seeded data, Next.js TypeScript build/typecheck, and Deno
- Exact reported path: SvelteKit + TypeScript + Bun scaffolded successfully, `bun run build` passed, and `bun run check` reported 0 errors and 0 warnings