### PR TITLE
Revert "Scaffold the baseline migration and move pins to current releases" (#65)

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,10 +3,9 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/composer": "0.14.0",
-  "@prisma/composer-prisma-cloud": "0.14.0",
-  "@prisma/orm-mongo": "8.0.0-rc.6",
-  // Must match @prisma/composer-prisma-cloud's exact peerDependency.
+  "@prisma/composer": "0.12.0",
+  "@prisma/composer-prisma-cloud": "0.12.0",
+  "@prisma/orm-mongo": "8.0.0-rc.4",
   "@prisma/orm-postgres": "8.0.0-rc.4",
   "@sveltejs/adapter-node": "^5.3.2",
   "@types/node": "^25.6.2",
@@ -18,15 +17,12 @@ export const dependencyVersionMap = {
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
-  prisma: "8.0.0-rc.9",
+  prisma: "next",
   tsx: "^4.21.0",
   typescript: "^5.9.3",
 } as const;
 
-// Pinned, not `prisma@next`: the scaffold's own invocations must not float
-// with the dist-tag (rc.10 removed `orm init --skip-skills` and rejected its
-// own scaffolded schema at `contract emit`, breaking every create).
-export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.9";
+export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@next";
 // The consolidated CLI currently imports Node-only credential storage when Deno starts it.
 // Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
 export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -305,33 +305,15 @@ async function ensureComposerTypeScriptOptions(projectDir: string): Promise<void
   await fs.writeFile(tsconfigPath, updated, "utf8");
 }
 
-async function runPrismaCli(
-  context: PrismaSetupContext,
-  projectDir: string,
-  args: string[],
-): Promise<void> {
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
+async function emitContract(context: PrismaSetupContext, projectDir: string): Promise<void> {
+  const invocation = getPrismaCliInvocation(context.packageManager, ["contract", "emit"]);
   if (context.verbose) {
     log.step([invocation.command, ...invocation.args].join(" "));
   }
   await execa(invocation.command, invocation.args, {
     cwd: projectDir,
     stdio: context.verbose ? "inherit" : "pipe",
-    env: { ...process.env, CI: "1" },
   });
-}
-
-async function emitContract(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  await runPrismaCli(context, projectDir, ["contract", "emit"]);
-}
-
-// Composer deploys are replay-only: they apply committed migrations and never
-// create schema, so the scaffold authors the baseline itself.
-async function planBaselineMigration(
-  context: PrismaSetupContext,
-  projectDir: string,
-): Promise<void> {
-  await runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]);
 }
 
 function formatNextSteps(steps: NextStep[]): string {
@@ -453,11 +435,6 @@ export async function executePrismaSetupContext(
 
     progress?.message("Generating Prisma 8 contract artifacts...");
     await emitContract(context, projectDir);
-
-    if (context.databaseProvider === "postgres") {
-      progress?.message("Authoring the baseline migration...");
-      await planBaselineMigration(context, projectDir);
-    }
 
     if (options.initializeGit) {
       progress?.message("Initializing Git repository...");

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -5,10 +5,9 @@ import { dependencyVersionMap, getDependencyVersion } from "../src/constants/dep
 describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
     expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.4");
-    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.6");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.14.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.14.0");
-    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.9");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.12.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.12.0");
+    expect(getDependencyVersion("prisma")).toBe("next");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");
   });

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -219,16 +219,13 @@ describe("create-prisma e2e", () => {
 
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
-      // The scaffold commits the baseline migration — replay-only deploys
-      // need an authored path from empty to the contract.
-      expect(await pathExists(path.join(projectDir, "migrations/app"))).toBe(true);
       expect(
         await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
       expect(
         await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
-      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.9");
+      expect(packageJson.devDependencies.prisma).toBe("next");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
       expect(packageJson.overrides.effect).toBe("4.0.0-rc.111");


### PR DESCRIPTION
Reverts #65 in full at Will's direction: the baseline-migration scaffold step, the dependency bumps, and the prisma CLI pin at 8.0.0-rc.9 are all removed; the scaffolder is back on `prisma@next` with the pre-#65 dependency set. Note 0.9.4 already shipped with #65 included, so this needs a follow-up release to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)