### PR TITLE
Move the scaffold to the current release line: CLI rc.11, Composer 0.15.0, ORM rc.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Unit tests
+        run: bun run test:unit
+
       - name: Build
         run: bun run build
         env:
@@ -130,7 +133,7 @@ jobs:
               `- Run with npm: \`npx create-prisma@${process.env.DIST_TAG}\``,
               `- Run with Yarn: \`yarn dlx create-prisma@${process.env.DIST_TAG}\``,
               `- Run with pnpm: \`pnpm dlx create-prisma@${process.env.DIST_TAG}\``,
-              `- Run with Deno: \`deno run -A npm:create-prisma@${process.env.DIST_TAG}\``,
+              `- Run with Deno: \`deno run -A --minimum-dependency-age=0 npm:create-prisma@${process.env.DIST_TAG}\``,
               `- Workflow run: ${process.env.RUN_URL}`,
             ].join("\n");
 
@@ -179,7 +182,7 @@ jobs:
           echo "- Run with npm: \`npx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Run with Yarn: \`yarn dlx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Run with pnpm: \`pnpm dlx create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Run with Deno: \`deno run -A npm:create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run with Deno: \`deno run -A --minimum-dependency-age=0 npm:create-prisma@${{ steps.preview.outputs.dist_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   release:
     name: Release to npm
@@ -264,6 +267,10 @@ jobs:
       - name: Typecheck
         if: steps.check-version.outputs.exists == 'false'
         run: bun run typecheck
+
+      - name: Unit tests
+        if: steps.check-version.outputs.exists == 'false'
+        run: bun run test:unit
 
       - name: Build
         if: steps.check-version.outputs.exists == 'false'

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ PostgreSQL and MongoDB are supported with PSL or TypeScript contract authoring. 
 Deno is supported for local minimal PostgreSQL apps:
 
 ```bash
-deno run -A npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
+deno run -A --minimum-dependency-age=0 npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
 ```
 
-Prisma Compute does not support Deno deployments yet.
+Deno 2.9 blocks packages published within the previous 24 hours by default. The explicit
+dependency-age flag ensures a newly published `create-prisma` release is selected instead of an
+older cached version. Prisma Compute does not support Deno deployments yet.
 
 ## Options
 

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,30 +3,33 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/composer": "0.14.0",
-  "@prisma/composer-prisma-cloud": "0.14.0",
-  "@prisma/orm-mongo": "8.0.0-rc.6",
+  "@prisma/composer": "0.15.0",
+  "@prisma/composer-prisma-cloud": "0.15.0",
+  "@prisma/orm-mongo": "8.0.0-rc.8",
   // Must match @prisma/composer-prisma-cloud's exact peerDependency.
-  "@prisma/orm-postgres": "8.0.0-rc.4",
+  "@prisma/orm-postgres": "8.0.0-rc.8",
   "@sveltejs/adapter-node": "^5.3.2",
   "@types/node": "^25.6.2",
   alchemy: "2.0.0-beta.74",
   arktype: "^2.2.3",
   dotenv: "^17.4.2",
   esbuild: "^0.28.1",
-  effect: "4.0.0-rc.111",
+  effect: "4.0.0-rc.112",
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
-  prisma: "8.0.0-rc.9",
+  prisma: "8.0.0-rc.11",
   tsx: "^4.21.0",
   typescript: "^5.9.3",
 } as const;
 
 // Pinned, not `prisma@next`: the scaffold's own invocations must not float
-// with the dist-tag (rc.10 removed `orm init --skip-skills` and rejected its
-// own scaffolded schema at `contract emit`, breaking every create).
-export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.9";
+// with the dist-tag — the rc line ships breaking changes between releases
+// (rc.10 broke every create). The pin must move in lockstep with the pins
+// above: the CLI bundles its own copies of @prisma/composer-cli and
+// @prisma/orm-toolchain, and those must match the @prisma/composer* and
+// @prisma/orm-* versions this map installs into the project.
+export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.11";
 // The consolidated CLI currently imports Node-only credential storage when Deno starts it.
 // Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
 export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -30,9 +30,11 @@ export const dependencyVersionMap = {
 // @prisma/orm-toolchain, and those must match the @prisma/composer* and
 // @prisma/orm-* versions this map installs into the project.
 export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.11";
-// The consolidated CLI currently imports Node-only credential storage when Deno starts it.
-// Keep Deno on Prisma 8's ORM-only CLI entrypoint until that upstream path is Deno-compatible.
-export const PRISMA_DENO_CLI_PACKAGE = "prisma-next";
+// Deno runs the same pinned consolidated CLI. The former `prisma-next`
+// fallback is dead: under Deno the bare `npm:prisma-next` specifier resolves
+// to the highest non-prerelease version (0.12.0, frozen), which cannot emit
+// against the ORM releases pinned above.
+export const PRISMA_DENO_CLI_PACKAGE = PRISMA_PLATFORM_CLI_PACKAGE;
 
 export type AvailableDependency = keyof typeof dependencyVersionMap;
 

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -27,7 +27,7 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
       "db:update": prismaCommand(true, "db", "update"),
       "db:verify": prismaCommand(true, "db", "verify"),
       "migration:plan": prismaCommand(true, "migration", "plan"),
-      migrate: prismaCommand(true, "migrate"),
+      migrate: prismaCommand(true, "db", "migrate"),
       "migration:status": prismaCommand(true, "migration", "status"),
       "migration:show": prismaCommand(true, "migration", "show"),
     };
@@ -147,7 +147,7 @@ export async function writePrismaDependencies(
   if (provider === "mongo") dependencies.push("arktype", "mongodb");
   if (packageManager === "deno") dependencies.push("dotenv");
 
-  const devDependencies = packageManager === "deno" ? ["@types/node"] : ["@types/node", "prisma"];
+  const devDependencies = ["@types/node", "prisma"];
 
   await addPackageDependency({
     dependencies,

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -202,34 +202,19 @@ function getPrismaCliInvocation(packageManager: PackageManager, args: string[]) 
 }
 
 async function runPrismaInit(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  const args =
-    context.packageManager === "deno"
-      ? [
-          "init",
-          "--yes",
-          "--no-interactive",
-          "--target",
-          getInitTarget(context.databaseProvider),
-          "--authoring",
-          context.authoring,
-          "--schema-path",
-          getContractPath(context.authoring),
-          "--no-install",
-          "--no-skill",
-        ]
-      : [
-          "orm",
-          "init",
-          "--yes",
-          "--no-interactive",
-          "--target",
-          getInitTarget(context.databaseProvider),
-          "--authoring",
-          context.authoring,
-          "--schema-path",
-          getContractPath(context.authoring),
-          "--skip-install",
-        ];
+  const args = [
+    "orm",
+    "init",
+    "--yes",
+    "--no-interactive",
+    "--target",
+    getInitTarget(context.databaseProvider),
+    "--authoring",
+    context.authoring,
+    "--schema-path",
+    getContractPath(context.authoring),
+    "--skip-install",
+  ];
   const invocation = getPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);
   await execa(invocation.command, invocation.args, {

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -229,7 +229,6 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
           "--schema-path",
           getContractPath(context.authoring),
           "--skip-install",
-          "--skip-skills",
         ];
   const invocation = getPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -14,6 +14,10 @@ type RuntimeScriptOptions = {
   builtEntrypoint?: string;
 };
 
+// Deno 2.9 rejects packages published within the previous 24 hours by default.
+// Scaffolding must be able to resolve the freshly published, explicitly pinned Prisma release.
+const DENO_ALLOW_FRESH_DEPENDENCIES = "--minimum-dependency-age=0";
+
 const packageManagerManifestValues = {
   npm: "npm@10.9.0",
   pnpm: "pnpm@11.21.0",
@@ -200,7 +204,7 @@ export function getInstallArgs(packageManager: PackageManager): CommandAndArgs {
   if (packageManager === "deno") {
     return {
       command: "deno",
-      args: ["install"],
+      args: ["install", DENO_ALLOW_FRESH_DEPENDENCIES],
     };
   }
 
@@ -220,7 +224,10 @@ export function getPackageExecutionArgs(
       if (!packageName) {
         throw new Error("Package execution requires a package name.");
       }
-      return { command: "deno", args: ["run", "-A", `npm:${packageName}`, ...args] };
+      return {
+        command: "deno",
+        args: ["run", "-A", DENO_ALLOW_FRESH_DEPENDENCIES, `npm:${packageName}`, ...args],
+      };
     }
     case "pnpm":
       return { command: "pnpm", args: ["dlx", ...commandArgs] };
@@ -249,7 +256,10 @@ export function getLocalPackageBinaryArgs(
 ): CommandAndArgs {
   switch (packageManager) {
     case "deno":
-      return { command: "deno", args: ["run", "-A", `npm:${binaryName}`, ...binaryArgs] };
+      return {
+        command: "deno",
+        args: ["run", "-A", DENO_ALLOW_FRESH_DEPENDENCIES, `npm:${binaryName}`, ...binaryArgs],
+      };
     case "pnpm":
       return { command: "pnpm", args: ["exec", binaryName, ...binaryArgs] };
     case "yarn":
@@ -271,21 +281,6 @@ export function getLocalPackageBinaryCommand(
   return [execution.command, ...execution.args].join(" ");
 }
 
-export function getPrismaCliArgs(
-  packageManager: PackageManager,
-  prismaArgs: string[],
-): CommandAndArgs {
-  if (packageManager === "bun") {
-    return getPackageExecutionArgs(packageManager, ["--bun", "prisma", ...prismaArgs]);
-  }
-
-  if (packageManager === "deno") {
-    return getPackageExecutionArgs(packageManager, ["prisma-next", ...prismaArgs]);
-  }
-
-  return getPackageExecutionArgs(packageManager, ["prisma", ...prismaArgs]);
-}
-
 export function getRunScriptArgs(
   packageManager: PackageManager,
   scriptName: string,
@@ -303,9 +298,4 @@ export function getRunScriptArgs(
     default:
       return { command: "npm", args: ["run", scriptName] };
   }
-}
-
-export function getPrismaCliCommand(packageManager: PackageManager, prismaArgs: string[]): string {
-  const execution = getPrismaCliArgs(packageManager, prismaArgs);
-  return [execution.command, ...execution.args].join(" ");
 }

--- a/templates/create/_shared/README.md.hbs
+++ b/templates/create/_shared/README.md.hbs
@@ -22,7 +22,7 @@ The starter users are inserted idempotently from `src/prisma/seed.ts` on the fir
 ## Prisma
 
 - Contract: `src/prisma/contract{{#if (eq authoring "typescript")}}.ts{{else}}.prisma{{/if}}`
-- Prisma config: `prisma-next.config.ts`
+- Prisma config: `prisma.config.ts`
 
 After changing the contract, run:
 

--- a/templates/create/_shared/pnpm-workspace.yaml.hbs
+++ b/templates/create/_shared/pnpm-workspace.yaml.hbs
@@ -12,5 +12,5 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - "@prisma/*"
 overrides:
-  effect: "4.0.0-rc.111"
+  effect: "4.0.0-rc.112"
 {{/if}}

--- a/templates/create/_shared/prisma.config.ts.hbs
+++ b/templates/create/_shared/prisma.config.ts.hbs
@@ -1,4 +1,20 @@
-{{#unless (eq packageManager "deno")}}
+{{#if (eq packageManager "deno")}}
+import "dotenv/config";
+import { definePrismaConfig } from "prisma/config";
+import { defineConfig as ormConfig } from "@prisma/orm-{{#if (eq provider "postgres")}}postgres{{else}}mongo{{/if}}/config";
+
+export default definePrismaConfig({
+  orm: ormConfig({
+    contract: "./src/prisma/contract{{#if (eq authoring "typescript")}}.ts{{else}}.prisma{{/if}}",
+{{#if (eq authoring "typescript")}}
+    output: "./src/prisma/generated",
+{{/if}}
+    db: {
+      connection: process.env.{{#if (eq provider "postgres")}}DATABASE_URL{{else}}MONGODB_URL{{/if}}!,
+    },
+  }),
+});
+{{else}}
 import { definePrismaConfig } from "prisma/config";
 import { defineConfig as ormConfig } from "@prisma/orm-{{#if (eq provider "postgres")}}postgres{{else}}mongo{{/if}}/config";
 
@@ -19,4 +35,4 @@ export default definePrismaConfig({
     configPath: "./prisma-composer.config.ts",
   },
 });
-{{/unless}}
+{{/if}}

--- a/templates/create/_shared/src/prisma/users.ts.hbs
+++ b/templates/create/_shared/src/prisma/users.ts.hbs
@@ -8,19 +8,19 @@ export async function listUsers(limit = 10) {
 {{#if (eq provider "mongo")}}
   const users = [];
 
-  for await (const user of db.orm.users.select("_id", "email", "username", "name").take(limit).all()) {
+  for await (const user of db.orm.users.select("_id", "email", "username", "name").limit(limit).all()) {
     users.push({
       id: String(user._id),
       email: user.email,
       username: user.username ?? null,
       name: user.name ?? null,
-      createdAt: null as Date | null,
+      createdAt: null as string | null,
     });
   }
 
   return users;
 {{else}}
-  const users = await db.orm.public.User.select("id", "email", "username", "name", "createdAt").take(limit).all();
+  const users = await db.orm.public.User.select("id", "email", "username", "name", "createdAt").limit(limit).all();
 
   return users.map((user) => ({
     id: String(user.id),

--- a/templates/create/astro/src/pages/index.astro.hbs
+++ b/templates/create/astro/src/pages/index.astro.hbs
@@ -54,8 +54,8 @@ const users = await listUsers(10).catch(() => undefined);
                   <p>{user.username ? `@${user.username}` : user.email}</p>
                 </div>
                 {user.createdAt ? (
-                  <time datetime={user.createdAt.toISOString()}>
-                    {formatter.format(user.createdAt)}
+                  <time datetime={user.createdAt}>
+                    {formatter.format(new Date(user.createdAt))}
                   </time>
                 ) : (
                   <span class="muted">No timestamp</span>

--- a/templates/create/next/src/app/page.tsx.hbs
+++ b/templates/create/next/src/app/page.tsx.hbs
@@ -43,8 +43,8 @@ export default async function Home() {
                   <p>{user.username ? `@${user.username}` : user.email}</p>
                 </div>
                 {user.createdAt ? (
-                  <time dateTime={user.createdAt.toISOString()}>
-                    {formatter.format(user.createdAt)}
+                  <time dateTime={user.createdAt}>
+                    {formatter.format(new Date(user.createdAt))}
                   </time>
                 ) : (
                   <span className="empty">No timestamp</span>

--- a/templates/create/nuxt/server/api/users.get.ts.hbs
+++ b/templates/create/nuxt/server/api/users.get.ts.hbs
@@ -5,7 +5,7 @@ export default defineEventHandler(async () => {
     .then((rows) =>
       rows.map((user) => ({
         ...user,
-        createdAt: user.createdAt?.toISOString() ?? null,
+        createdAt: user.createdAt ?? null,
       }))
     )
     .catch((error) => {

--- a/templates/create/svelte/src/routes/+page.server.ts.hbs
+++ b/templates/create/svelte/src/routes/+page.server.ts.hbs
@@ -7,7 +7,7 @@ export const load: PageServerLoad = async () => {
     .then((rows) =>
       rows.map((user) => ({
         ...user,
-        createdAt: user.createdAt?.toISOString() ?? null,
+        createdAt: user.createdAt ?? null,
       }))
     )
     .catch(() => undefined);

--- a/templates/create/tanstack-start/src/routes/index.tsx.hbs
+++ b/templates/create/tanstack-start/src/routes/index.tsx.hbs
@@ -8,7 +8,7 @@ const listUsers = createServerFn({ method: "GET" }).handler(async () => {
     .then((rows) =>
       rows.map((user) => ({
         ...user,
-        createdAt: user.createdAt?.toISOString() ?? null,
+        createdAt: user.createdAt ?? null,
       }))
     )
     .catch(() => undefined);

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -4,13 +4,13 @@ import { dependencyVersionMap, getDependencyVersion } from "../src/constants/dep
 
 describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
-    expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.4");
-    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.6");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.14.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.14.0");
-    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.9");
+    expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.8");
+    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.8");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.15.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.15.0");
+    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.11");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
-    expect(getDependencyVersion("effect")).toBe("4.0.0-rc.111");
+    expect(getDependencyVersion("effect")).toBe("4.0.0-rc.112");
   });
 
   test("returns undefined for dependencies missing from the version map", () => {

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -194,11 +194,12 @@ describe("create-prisma e2e", () => {
     async () => {
       const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-next-e2e-"));
       tempRoots.push(rootDir);
+      const appName = `composer-app-${path.basename(rootDir).toLowerCase()}`;
       const previousCwd = process.cwd();
       process.chdir(rootDir);
       try {
         await runCreateCommand({
-          name: "composer-app",
+          name: appName,
           template: "minimal",
           provider: "postgres",
           authoring: "psl",
@@ -210,7 +211,7 @@ describe("create-prisma e2e", () => {
         process.chdir(previousCwd);
       }
 
-      const projectDir = path.join(rootDir, "composer-app");
+      const projectDir = path.join(rootDir, appName);
       const packageJson = JSON.parse(
         await readFile(path.join(projectDir, "package.json"), "utf8"),
       ) as Record<string, any>;

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -312,7 +312,7 @@ describe("create-prisma e2e", () => {
       const packageJson = JSON.parse(
         await readFile(path.join(projectDir, "package.json"), "utf8"),
       ) as Record<string, any>;
-      const configSource = await readFile(path.join(projectDir, "prisma-next.config.ts"), "utf8");
+      const configSource = await readFile(path.join(projectDir, "prisma.config.ts"), "utf8");
       const dbSource = await readFile(path.join(projectDir, "src/prisma/db.ts"), "utf8");
 
       expect(await pathExists(path.join(projectDir, "deno.json"))).toBe(true);
@@ -321,7 +321,7 @@ describe("create-prisma e2e", () => {
       expect(await pathExists(path.join(projectDir, "prisma-next.md"))).toBe(false);
       expect(await pathExists(path.join(projectDir, "module.ts"))).toBe(false);
       expect(await pathExists(path.join(projectDir, "service.ts"))).toBe(false);
-      expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(false);
+      expect(await pathExists(path.join(projectDir, "prisma-next.config.ts"))).toBe(false);
       expect(configSource).toContain("dotenv/config");
       expect(dbSource).toContain('Deno.env.get("DATABASE_URL")');
       expect(packageJson.scripts).toMatchObject({

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -228,10 +228,10 @@ describe("create-prisma e2e", () => {
       expect(
         await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
-      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.9");
+      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.11");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
-      expect(packageJson.overrides.effect).toBe("4.0.0-rc.111");
+      expect(packageJson.overrides.effect).toBe("4.0.0-rc.112");
       expect(moduleSource).toContain("pnPostgres({");
       expect(dbSource).toContain("service.load().database.client");
 

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -11,7 +11,11 @@ import {
   writePrismaDependencies,
 } from "../src/tasks/install";
 import { authoringStyles, createTemplates, databaseProviders, packageManagers } from "../src/types";
-import { getInstallArgs, getRunScriptCommand } from "../src/utils/package-manager";
+import {
+  getInstallArgs,
+  getPackageExecutionArgs,
+  getRunScriptCommand,
+} from "../src/utils/package-manager";
 
 type PackageJson = {
   dependencies?: Record<string, string>;
@@ -89,9 +93,9 @@ describe("writePrismaDependencies", () => {
       });
       expect(packageJson.devDependencies).toMatchObject({
         "@types/node": dependencyVersionMap["@types/node"],
+        prisma: dependencyVersionMap.prisma,
       });
       expect(packageJson.devDependencies?.["@prisma/cli-engine"]).toBeUndefined();
-      expect(packageJson.devDependencies?.prisma).toBeUndefined();
       expect(packageJson.scripts).toMatchObject({
         "contract:emit": `deno run -A npm:${PRISMA_DENO_CLI_PACKAGE} contract emit`,
         "db:init": `deno run -A --env-file=.env npm:${PRISMA_DENO_CLI_PACKAGE} db init`,
@@ -116,9 +120,16 @@ describe("Composer package-manager commands", () => {
     for (const packageManager of packageManagers) {
       expect(getInstallArgs(packageManager)).toEqual({
         command: packageManager,
-        args: ["install"],
+        args: packageManager === "deno" ? ["install", "--minimum-dependency-age=0"] : ["install"],
       });
     }
+  });
+
+  test("allows create-prisma to resolve freshly published packages with Deno", () => {
+    expect(getPackageExecutionArgs("deno", ["prisma@8.0.0-rc.11", "orm", "init"])).toEqual({
+      command: "deno",
+      args: ["run", "-A", "--minimum-dependency-age=0", "npm:prisma@8.0.0-rc.11", "orm", "init"],
+    });
   });
 });
 
@@ -160,7 +171,7 @@ describe("generated templates", () => {
                 expect(await pathExists(path.join(projectDir, "deno.json"))).toBe(true);
                 expect(await pathExists(path.join(projectDir, "module.ts"))).toBe(false);
                 expect(await pathExists(path.join(projectDir, "service.ts"))).toBe(false);
-                expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(false);
+                expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
                 expect(await pathExists(path.join(projectDir, "prisma-composer.config.ts"))).toBe(
                   false,
                 );
@@ -286,14 +297,14 @@ describe("generated templates", () => {
                     "minimumReleaseAgeExclude:",
                     '  - "@prisma/*"',
                     "overrides:",
-                    '  effect: "4.0.0-rc.111"',
+                    `  effect: "${dependencyVersionMap.effect}"`,
                     "",
                   ].join("\n"),
                 );
               } else if (packageManager === "yarn") {
-                expect(packageJson.resolutions?.effect).toBe("4.0.0-rc.111");
+                expect(packageJson.resolutions?.effect).toBe(dependencyVersionMap.effect);
               } else {
-                expect(packageJson.overrides?.effect).toBe("4.0.0-rc.111");
+                expect(packageJson.overrides?.effect).toBe(dependencyVersionMap.effect);
               }
             } finally {
               await rm(projectDir, { recursive: true, force: true });


### PR DESCRIPTION
This PR moves create-prisma off its emergency version pin and onto the current Prisma release line — CLI **8.0.0-rc.11**, Composer **0.15.0**, ORM **8.0.0-rc.8** — and updates the scaffold code that the new line requires. Without those code updates, a project scaffolded on the new versions fails its own typecheck before the user has written a line of code:

```
$ bunx tsc --noEmit
src/prisma/users.ts(8,97): error TS2339: Property 'take' does not exist on type 'Collection<Contract, "User", ...>'.
```

## Why we're pinned, and why we're moving

Version 0.9.4 pinned the whole stack to a snapshot — CLI rc.9, Composer 0.14.0, ORM rc.4 — because CLI rc.10 broke every scaffold (it dropped an `orm init` flag we passed and scaffolded schemas the pinned ORM rejected). The pin was the right hotfix, but it left new projects on a frozen, aging line.

Today the whole stack released in lockstep: ORM rc.8, Composer 0.15.0 (which exact-peer-pins ORM rc.8), and CLI rc.11 (which bundles Composer 0.15.0 and ORM rc.8). These versions form a chain of exact pins, so create-prisma has to move all of them together — a project whose installed ORM differs from the one bundled in the CLI it runs breaks at `contract emit`. That is why the diff moves five versions at once, plus `effect` to 4.0.0-rc.112 (Composer 0.15.0's own pin).

## What the move required

**1. Drop `--skip-skills`.** The ORM removed the flag along with what it controlled: `orm init` no longer installs agent skills at all. Skills setup lives in `prisma init`, which the scaffold already runs as a separate step — so the flag is simply deleted. (Bonus: rc.11's `prisma init` now writes the `postinstall: prisma skills sync || exit 0` hook itself, which our e2e suite always expected.)

**2. Teach the templates the current ORM API.** Two things changed under the scaffolded starter code:
- `.take(n)` was renamed to `.limit(n)` on collections.
- Timestamp columns now come back as ISO strings, not `Date` objects. The next/svelte/astro/nuxt/tanstack starter pages formatted them with `Date` methods (`user.createdAt.toISOString()`); they now treat the value as the string it is.

**3. Move the Deno path onto the same CLI as everyone else.** Deno scaffolds ran a separate package, `prisma-next` — and under Deno, a bare `npm:prisma-next` specifier resolves to the highest *non-prerelease* version. Every 8.x release is a prerelease, so Deno silently got the frozen 0.12.0 CLI, which cannot emit against today's ORM. Deno now runs the same pinned `prisma` CLI as every other package manager: one shared `orm init` invocation, a rendered `prisma.config.ts` (whose `prisma/config` import makes `prisma` a devDependency for Deno too), and current command spellings in the generated scripts.

**What deliberately stays:** the baseline-migration step from #65. Composer 0.15.0 deploys are replay-only — the pipeline replays committed migrations and never creates schema — so a scaffold without a committed baseline fails its very first deploy. The step that plans and commits `migrations/` at scaffold time is now what makes a new project's first deploy succeed.

## Verification

The full e2e suite runs against the published npm registry and passes **5/5**: the Composer-backed test provisions a local Prisma Postgres, replays the scaffolded baseline migration, boots the dev loop, and fetches the seeded users over HTTP; the Deno test emits and builds on the consolidated CLI. Typecheck, lint, build, and unit tests pass. A preview is published under the `pr69` dist-tag: `npm create prisma@pr69`.

## Alternatives considered

- **Float on `prisma@latest` instead of pinning.** Rejected: the rc line ships breaking changes between releases by policy, and floating is exactly what broke every scaffold when rc.10 landed. The pin comment in `dependencies.ts` now records the lockstep rule so the next bump moves everything together.
- **Keep Deno on `prisma-next` with a pinned version.** Rejected: the package is frozen (its repo is archived into prisma/prisma) and will only drift further from the ORM line.
- **Satisfy the Deno config import with an `@prisma/cli-engine` devDependency** (what `orm init`'s generated config imports). Rejected: that adds a second version pin that must track the CLI. Rendering our own config that imports `prisma/config` reuses the `prisma` pin we already carry and matches what every non-Deno scaffold does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up hardening

Deno 2.9 applies a 24-hour minimum dependency age by default. Because preview tags and coordinated Prisma RCs are exercised immediately after publication, the documented Deno invocation and create-prisma’s initial delegated resolution use Deno’s official `--minimum-dependency-age=0` control. This applies only while scaffolding; generated projects do not permanently disable Deno’s dependency-age policy.

The stale unit expectations are updated, the unused `prisma-next` command helper is removed, preview and release publishing now run unit tests before npm publication, and the Composer E2E uses a unique app name so repeated local runs cannot reuse a stale emulator database.