### PR TITLE
chore(release): 0.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.9.5

Publishes the Prisma CLI rc.11, Composer 0.15.0, ORM rc.8, template compatibility, baseline migration, and Deno support updates merged in #69.

When this PR merges, GitHub Actions publishes `create-prisma@0.9.5` to npm using trusted publishing.

## Verification

- Formatting, lint, typecheck, and build pass
- 33 unit tests pass
- 5/5 E2E tests pass, including Composer dev, Next.js TypeScript, and Deno
- Published `pr69` preview scaffolded and typechecked a Deno app from an empty cache