### PR TITLE
chore(release): 0.9.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -208,17 +208,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Extract version from commit message
-        id: version
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           VERSION=$(printf '%s\n' "$COMMIT_MESSAGE" | sed -nE '1s/^chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Releasing version: $VERSION"
 
       - name: Validate version format
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Invalid version format '$VERSION'. Expected x.y.z"
             exit 1
@@ -226,7 +224,6 @@ jobs:
 
       - name: Verify package version matches commit
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           PACKAGE_VERSION=$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version)")
           if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
             echo "Error: package.json version is '$PACKAGE_VERSION' but commit version is '$VERSION'"
@@ -236,7 +233,6 @@ jobs:
       - name: Check if version already exists on npm
         id: check-version
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if npm view create-prisma@$VERSION version >/dev/null 2>&1; then
             echo "Version $VERSION already exists on npm"
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -285,7 +281,6 @@ jobs:
       - name: Create and push git tag
         if: steps.check-version.outputs.exists == 'false'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
             git config --local user.email "github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
@@ -298,7 +293,6 @@ jobs:
       - name: Create GitHub Release
         if: steps.check-version.outputs.exists == 'false'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! gh release view "v$VERSION" >/dev/null 2>&1; then
             bunx changelogithub
           else
@@ -310,7 +304,6 @@ jobs:
       - name: Release summary
         if: steps.check-version.outputs.exists == 'false'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           echo "## Release v$VERSION complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- https://www.npmjs.com/package/create-prisma/v/$VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,8 +209,10 @@ jobs:
 
       - name: Extract version from commit message
         id: version
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          VERSION=$(echo "${{ github.event.head_commit.message }}" | sed -E 's/^chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          VERSION=$(printf '%s\n' "$COMMIT_MESSAGE" | sed -nE '1s/^chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 


### PR DESCRIPTION
## Retry release v0.9.5

The first trusted-publishing run stopped before npm because the workflow interpolated the entire squash commit message into `GITHUB_OUTPUT`; the `Signed-off-by` body line made the output invalid.

This changes version extraction to read the commit message through an environment variable and parse only its first line. It then retries the unchanged `0.9.5` release through trusted publishing.

## Verification

- Reproduced the failing multiline squash message locally
- The updated extractor returns exactly `0.9.5`
- No manual npm publication is used

CodeQL also identified six pre-existing direct step-output interpolations in shell blocks. This PR now propagates the strictly numeric version through `GITHUB_ENV` once and removes all six interpolation sites.