### PR TITLE
feat: add agent-friendly JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ older cached version. Prisma Compute does not support Deno deployments yet.
 - `--yes`
 - `--force`
 - `--verbose`
+- `--json`
+
+### JSON output for agents and automation
+
+Use `--json` when another program is driving `create-prisma`:
+
+```bash
+bunx create-prisma@latest my-app --template next --package-manager bun --no-deploy --json
+```
+
+JSON mode is non-interactive and uses the same defaults as `--yes`. It writes exactly one compact
+result object to stdout and suppresses all human UI and subprocess output. Successful results include
+the generated project, deployment metadata when `--deploy` is used, next steps, and warnings. Errors
+use the same envelope with `ok: false`, an actionable message, and the stage that failed. `--verbose`
+is intentionally incompatible with `--json` so the machine-readable contract stays deterministic.
 
 This branch intentionally targets Prisma 8 only. It does not generate a Prisma 7 compatibility path.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ Use `--json` when another program is driving `create-prisma`:
 bunx create-prisma@latest my-app --template next --package-manager bun --no-deploy --json
 ```
 
-JSON mode is non-interactive and uses the same defaults as `--yes`. It writes exactly one compact
-result object to stdout and suppresses all human UI and subprocess output. Successful results include
-the generated project, deployment metadata when `--deploy` is used, next steps, and warnings. Errors
-use the same envelope with `ok: false`, an actionable message, and the stage that failed. `--verbose`
-is intentionally incompatible with `--json` so the machine-readable contract stays deterministic.
+JSON mode is non-interactive and deploys by default; pass `--no-deploy` to generate locally only. It
+writes exactly one compact result object to stdout and suppresses all human UI and subprocess output.
+Successful results include the generated project, deployment metadata, next steps, and warnings.
+Errors use the same envelope with `ok: false`, an actionable message, and the stage that failed.
+`--verbose` is intentionally incompatible with `--json` so the machine-readable contract stays
+deterministic.
 
 This branch intentionally targets Prisma 8 only. It does not generate a Prisma 7 compatibility path.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
     "test": "bun run test:unit && bun run test:e2e",
-    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/initialize-git.test.ts ./tests/install.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry.test.ts",
+    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/initialize-git.test.ts ./tests/install.test.ts ./tests/json-output.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry.test.ts",
     "test:e2e": "bun test --timeout 180000 ./tests/e2e/create-prisma.e2e.test.ts",
     "check": "bun run format:check && bun run lint",
     "lint": "oxlint . --deny-warnings",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import { createCreatePrismaCli } from "./index";
+import { createJsonOutputLogger, isJsonOutputRequested } from "./ui/json-output";
 
 createCreatePrismaCli().run({
+  ...(isJsonOutputRequested(process.argv) ? { logger: createJsonOutputLogger() } : {}),
   process: {
     exit(code): never {
       const commandExitCode =

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,7 +1,14 @@
 import { cancel, intro, isCancel, log, select, spinner, text } from "@clack/prompts";
 import fs from "fs-extra";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
+import {
+  CREATE_PRISMA_RESULT_SCHEMA_VERSION,
+  createCommandFailureResult,
+  type CreateCommandResult,
+  type CreateProjectResult,
+} from "../result";
 import {
   trackCreateCompleted,
   trackCreateFailed,
@@ -18,6 +25,8 @@ import {
   type CreateTemplate,
 } from "../types";
 import { getCreatePrismaIntro } from "../ui/branding";
+import { resolveExecutionSettings } from "../ui/output";
+import { getErrorMessage } from "../utils/errors";
 import { getUnsupportedNodeMessage, supportsPrismaNext } from "../utils/node-version";
 
 const DEFAULT_PROJECT_NAME = "my-app";
@@ -39,12 +48,17 @@ export type CreatePromptContext = {
 };
 
 type ExecuteCreateContextResult =
-  | { ok: true }
+  | { ok: true; result: CreateCommandResult }
   | {
       ok: false;
       stage: CreateTelemetryFailureStage;
       error?: unknown;
+      errorReported?: boolean;
     };
+
+type CollectCreateContextResult =
+  | { ok: true; context: CreatePromptContext }
+  | { ok: false; message: string };
 
 function toPackageName(projectName: string): string {
   return (
@@ -77,23 +91,35 @@ function validateProjectName(value: string | undefined): string | undefined {
   return undefined;
 }
 
-async function promptForProjectName(): Promise<string | undefined> {
+function getProjectResult(context: CreatePromptContext): CreateProjectResult {
+  return {
+    name: context.projectPackageName,
+    path: context.targetDirectory,
+    template: context.template,
+    databaseProvider: context.prismaSetupContext.databaseProvider,
+    authoring: context.prismaSetupContext.authoring,
+    packageManager: context.prismaSetupContext.packageManager,
+  };
+}
+
+async function promptForProjectName(output: Writable): Promise<string | undefined> {
   const projectName = await text({
     message: "Project name",
     placeholder: DEFAULT_PROJECT_NAME,
     initialValue: DEFAULT_PROJECT_NAME,
     validate: validateProjectName,
+    output,
   });
 
   if (isCancel(projectName)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return undefined;
   }
 
   return String(projectName).trim();
 }
 
-async function promptForCreateTemplate(): Promise<CreateTemplate | undefined> {
+async function promptForCreateTemplate(output: Writable): Promise<CreateTemplate | undefined> {
   const template = await select({
     message: "Select template",
     initialValue: DEFAULT_TEMPLATE,
@@ -144,10 +170,11 @@ async function promptForCreateTemplate(): Promise<CreateTemplate | undefined> {
         hint: "React app with file routes and server functions",
       },
     ],
+    output,
   });
 
   if (isCancel(template)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return undefined;
   }
 
@@ -180,41 +207,52 @@ async function inspectTargetPath(targetPath: string): Promise<CreateTargetPathSt
   };
 }
 
-export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promise<void> {
+export async function runCreateCommand(
+  rawInput: CreateCommandInput = {},
+): Promise<CreateCommandResult> {
   const startedAt = Date.now();
   let input: CreateCommandInput = {};
   let context: CreatePromptContext | undefined;
   let failureStage: CreateTelemetryFailureStage = "validate_input";
+  const { output } = resolveExecutionSettings(rawInput);
 
   try {
     input = CreateCommandInputSchema.parse(rawInput);
-
+    if (input.json && input.verbose) {
+      throw new Error("--verbose cannot be used with --json because JSON mode is output-only.");
+    }
     if (!supportsPrismaNext()) {
-      cancel(getUnsupportedNodeMessage());
+      const message = getUnsupportedNodeMessage();
+      cancel(message, { output });
       process.exitCode = 1;
-      return;
+      return createCommandFailureResult(failureStage, message);
     }
 
-    intro(getCreatePrismaIntro());
+    intro(getCreatePrismaIntro(), { output });
 
     failureStage = "collect_context";
-    context = await collectCreateContext(input);
-    if (!context) {
-      return;
+    const collected = await collectCreateContext(input);
+    if (!collected.ok) {
+      process.exitCode = 1;
+      const result = createCommandFailureResult(failureStage, collected.message);
+      await trackCreateFailed({
+        input,
+        durationMs: Date.now() - startedAt,
+        stage: failureStage,
+      });
+      return result;
     }
+    context = collected.context;
 
     failureStage = "unknown";
     const executionResult = await executeCreateContext(context);
     if (!executionResult.ok) {
       process.exitCode = 1;
-      if (executionResult.error) {
-        cancel(
-          `Create command failed: ${
-            executionResult.error instanceof Error
-              ? executionResult.error.message
-              : String(executionResult.error)
-          }`,
-        );
+      const message = executionResult.error
+        ? getErrorMessage(executionResult.error)
+        : "Project setup did not complete.";
+      if (executionResult.error && !executionResult.errorReported) {
+        cancel(`Create command failed: ${message}`, { output });
       }
 
       await trackCreateFailed({
@@ -224,7 +262,7 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
         error: executionResult.error,
         stage: executionResult.stage,
       });
-      return;
+      return createCommandFailureResult(executionResult.stage, message, getProjectResult(context));
     }
 
     await trackCreateCompleted({
@@ -232,9 +270,11 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
       context,
       durationMs: Date.now() - startedAt,
     });
+    return executionResult.result;
   } catch (error) {
     process.exitCode = 1;
-    cancel(`Create command failed: ${error instanceof Error ? error.message : String(error)}`);
+    const message = getErrorMessage(error);
+    cancel(`Create command failed: ${message}`, { output });
     await trackCreateFailed({
       input,
       context,
@@ -242,51 +282,54 @@ export async function runCreateCommand(rawInput: CreateCommandInput = {}): Promi
       error,
       stage: failureStage,
     });
+    return createCommandFailureResult(
+      failureStage,
+      message,
+      context ? getProjectResult(context) : undefined,
+    );
   }
 }
 
 async function collectCreateContext(
   input: CreateCommandInput,
-): Promise<CreatePromptContext | undefined> {
+): Promise<CollectCreateContextResult> {
   const force = input.force === true;
-  const useDefaults = input.yes === true;
+  const { output, useDefaults } = resolveExecutionSettings(input);
 
   const projectNameInput =
-    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : await promptForProjectName());
+    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : await promptForProjectName(output));
   if (projectNameInput === undefined) {
-    return;
+    return { ok: false, message: "Operation cancelled." };
   }
 
   const projectName = String(projectNameInput).trim();
   const projectNameValidationError = validateProjectName(projectName);
   if (projectNameValidationError) {
-    cancel(projectNameValidationError);
-    return;
+    cancel(projectNameValidationError, { output });
+    return { ok: false, message: projectNameValidationError };
   }
 
   const template =
-    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate());
+    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate(output));
   if (!template) {
-    return;
+    return { ok: false, message: "Operation cancelled." };
   }
 
   const targetDirectory = path.resolve(process.cwd(), projectName);
   const targetPathState = await inspectTargetPath(targetDirectory);
   if (targetPathState.exists && !targetPathState.isDirectory) {
-    cancel(
-      `Target path ${formatPathForDisplay(
-        targetDirectory,
-      )} already exists and is not a directory. Choose a different project name.`,
-    );
-    return;
+    const message = `Target path ${formatPathForDisplay(
+      targetDirectory,
+    )} already exists and is not a directory. Choose a different project name.`;
+    cancel(message, { output });
+    return { ok: false, message };
   }
   if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
-    cancel(
-      `Target directory ${formatPathForDisplay(
-        targetDirectory,
-      )} is not empty. Use --force to continue.`,
-    );
-    return;
+    const message = `Target directory ${formatPathForDisplay(
+      targetDirectory,
+    )} is not empty. Use --force to continue.`;
+    cancel(message, { output });
+    return { ok: false, message };
   }
 
   const prismaSetupContext = await collectPrismaSetupContext(input, {
@@ -294,28 +337,32 @@ async function collectCreateContext(
     template,
   });
   if (!prismaSetupContext) {
-    return;
+    return { ok: false, message: "Operation cancelled." };
   }
 
   return {
-    targetDirectory,
-    targetPathState,
-    force,
-    template,
-    projectPackageName: toPackageName(path.basename(targetDirectory)),
-    prismaSetupContext,
+    ok: true,
+    context: {
+      targetDirectory,
+      targetPathState,
+      force,
+      template,
+      projectPackageName: toPackageName(path.basename(targetDirectory)),
+      prismaSetupContext,
+    },
   };
 }
 
 async function executeCreateContext(
   context: CreatePromptContext,
 ): Promise<ExecuteCreateContextResult> {
-  const createSpinner = context.prismaSetupContext.verbose ? undefined : spinner();
+  const output = context.prismaSetupContext.output;
+  const createSpinner = context.prismaSetupContext.verbose ? undefined : spinner({ output });
   createSpinner?.start("Creating Prisma 8 project...");
 
   try {
     if (context.prismaSetupContext.verbose) {
-      log.step(`Scaffolding ${context.template} starter.`);
+      log.step(`Scaffolding ${context.template} starter.`, { output });
     }
 
     await scaffoldCreateFrameworkTemplate({
@@ -328,7 +375,7 @@ async function executeCreateContext(
     });
 
     if (context.prismaSetupContext.verbose) {
-      log.success("Starter files scaffolded.");
+      log.success("Starter files scaffolded.", { output });
     }
   } catch (error) {
     createSpinner?.error("Could not create Prisma 8 project.");
@@ -354,15 +401,11 @@ async function executeCreateContext(
     };
   }
 
-  if (
-    context.targetPathState.exists &&
-    !context.targetPathState.isEmptyDirectory &&
-    context.force
-  ) {
-    log.warn(
-      `Used --force in non-empty directory ${formatPathForDisplay(context.targetDirectory)}.`,
-    );
-  }
+  const forceWarning =
+    context.targetPathState.exists && !context.targetPathState.isEmptyDirectory && context.force
+      ? `Used --force in non-empty directory ${formatPathForDisplay(context.targetDirectory)}.`
+      : undefined;
+  if (forceWarning) log.warn(forceWarning, { output });
 
   const nextSteps =
     formatPathForDisplay(context.targetDirectory) === "."
@@ -375,7 +418,7 @@ async function executeCreateContext(
         ];
 
   try {
-    const didSetupPrisma = await executePrismaSetupContext(context.prismaSetupContext, {
+    const setupResult = await executePrismaSetupContext(context.prismaSetupContext, {
       prependNextSteps: nextSteps,
       projectDir: context.targetDirectory,
       projectName: context.projectPackageName,
@@ -386,12 +429,29 @@ async function executeCreateContext(
       progressSpinner: createSpinner,
     });
 
-    if (!didSetupPrisma) {
+    if (!setupResult.ok) {
       return {
         ok: false,
         stage: "prisma_setup",
+        error: setupResult.error,
+        errorReported: setupResult.errorReported,
       };
     }
+
+    const warnings = [...setupResult.warnings];
+    if (forceWarning) warnings.unshift(forceWarning);
+
+    return {
+      ok: true,
+      result: {
+        schemaVersion: CREATE_PRISMA_RESULT_SCHEMA_VERSION,
+        ok: true,
+        project: getProjectResult(context),
+        deployment: setupResult.deployment,
+        nextSteps: setupResult.nextSteps,
+        warnings,
+      },
+    };
   } catch (error) {
     createSpinner?.error("Could not create Prisma 8 project.");
     return {
@@ -400,6 +460,4 @@ async function executeCreateContext(
       error,
     };
   }
-
-  return { ok: true };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,9 @@ export const router = os.router({
     })
     .input(CreateCliInputSchema)
     .handler(async ({ input }) => {
-      await runCreateCommand(normalizeCreateCliInput(input));
+      const createInput = normalizeCreateCliInput(input);
+      const result = await runCreateCommand(createInput);
+      return createInput.json ? result : undefined;
     }),
 });
 
@@ -52,6 +54,15 @@ export async function create(input: CreateCommandInput = {}): Promise<void> {
 }
 
 export type { CreateCommandInput };
+export type {
+  CreateCommandFailureStage,
+  CreateCommandFailureResult,
+  CreateCommandResult,
+  CreateCommandSuccessResult,
+  CreateNextStep,
+  CreateProjectResult,
+} from "./result";
+export { CREATE_PRISMA_RESULT_SCHEMA_VERSION } from "./result";
 export {
   AuthoringStyleSchema,
   CreateCommandInputSchema,

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,55 @@
+import type { CreateTelemetryFailureStage } from "./telemetry";
+import type { ComposerDeployResult } from "./tasks/deploy-with-composer";
+import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "./types";
+
+export const CREATE_PRISMA_RESULT_SCHEMA_VERSION = 1 as const;
+
+export type CreateNextStep = {
+  command: string;
+  description: string;
+};
+
+export type CreateProjectResult = {
+  name: string;
+  path: string;
+  template: CreateTemplate;
+  databaseProvider: DatabaseProvider;
+  authoring: AuthoringStyle;
+  packageManager: PackageManager;
+};
+
+export type CreateCommandFailureStage = CreateTelemetryFailureStage | "parse_arguments";
+
+export type CreateCommandSuccessResult = {
+  schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;
+  ok: true;
+  project: CreateProjectResult;
+  deployment: ComposerDeployResult | null;
+  nextSteps: CreateNextStep[];
+  warnings: string[];
+};
+
+export type CreateCommandFailureResult = {
+  schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;
+  ok: false;
+  error: {
+    stage: CreateCommandFailureStage;
+    message: string;
+  };
+  project?: CreateProjectResult;
+};
+
+export type CreateCommandResult = CreateCommandSuccessResult | CreateCommandFailureResult;
+
+export function createCommandFailureResult(
+  stage: CreateCommandFailureStage,
+  message: string,
+  project?: CreateProjectResult,
+): CreateCommandFailureResult {
+  return {
+    schemaVersion: CREATE_PRISMA_RESULT_SCHEMA_VERSION,
+    ok: false,
+    error: { stage, message },
+    ...(project ? { project } : {}),
+  };
+}

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -1,15 +1,18 @@
 import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts";
 import { execa } from "execa";
 import { createInterface } from "node:readline";
+import type { Writable } from "node:stream";
 
 import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import type { PackageManager } from "../types";
+import { getErrorMessage, redactSecrets } from "../utils/errors";
 import {
   getPackageExecutionArgs,
   getPackageExecutionCommand,
   getRunScriptArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
+import { runSetupCommand } from "../utils/run-command";
 
 type PrismaCliEnvelope<Result = unknown> = {
   ok: boolean;
@@ -64,6 +67,7 @@ type ComposerDeployCommandResult = {
 export type ComposerDeployResult = {
   appName: string;
   appUrl?: string;
+  serviceId?: string;
   workspace?: PrismaWorkspace;
   project: {
     id?: string;
@@ -71,24 +75,6 @@ export type ComposerDeployResult = {
     consoleUrl?: string;
   };
 };
-
-export function redactSecrets(message: string): string {
-  return message
-    .replace(
-      /\b((?:(?:prisma\+)?postgres(?:ql)?|mongodb(?:\+srv)?):\/\/)[^\s'"]+/gi,
-      "$1<redacted>",
-    )
-    .replace(
-      /\b([A-Z0-9_]*(?:MONGODB_(?:URL|URI)|DATABASE_URL|TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s]+)/gi,
-      "$1<redacted>",
-    )
-    .replace(/(\bAuthorization\s*:\s*Bearer\s+)[^\s'"]+/gi, "$1<redacted>");
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return redactSecrets(error.message);
-  return redactSecrets(String(error));
-}
 
 function stripResourcePrefix(id: string, prefix: "proj" | "wksp"): string {
   const marker = `${prefix}_`;
@@ -207,37 +193,39 @@ async function ensureProjectNameAvailable(options: {
   );
 }
 
-async function ensureAuthentication(
-  packageManager: PackageManager,
-  projectDir: string,
-  beforeInteractiveLogin?: () => void,
-): Promise<WhoamiResult> {
+async function ensureAuthentication(options: {
+  packageManager: PackageManager;
+  projectDir: string;
+  output: Writable;
+  allowInteractiveLogin: boolean;
+  beforeInteractiveLogin?: () => void;
+}): Promise<WhoamiResult> {
   const whoami = () =>
     runPrismaJsonCommand<WhoamiResult>({
-      packageManager,
-      projectDir,
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
       args: ["auth", "whoami"],
     });
 
   const authState = await whoami();
   if (authState.authenticated) return authState;
 
-  const loginCommand = getPackageExecutionCommand(packageManager, [
+  const loginCommand = getPackageExecutionCommand(options.packageManager, [
     PRISMA_PLATFORM_CLI_PACKAGE,
     "auth",
     "login",
   ]);
-  if (process.stdin.isTTY !== true) {
+  if (!options.allowInteractiveLogin || process.stdin.isTTY !== true) {
     throw new Error(
-      `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(packageManager, "deploy")}.`,
+      `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
     );
   }
 
-  beforeInteractiveLogin?.();
-  log.info("Sign in to Prisma to deploy.");
-  const login = getPrismaCliArgs(packageManager, ["auth", "login"]);
+  options.beforeInteractiveLogin?.();
+  log.info("Sign in to Prisma to deploy.", { output: options.output });
+  const login = getPrismaCliArgs(options.packageManager, ["auth", "login"]);
   await execa(login.command, login.args, {
-    cwd: projectDir,
+    cwd: options.projectDir,
     env: process.env,
     stdio: "inherit",
   });
@@ -274,6 +262,7 @@ async function selectDeploymentWorkspace(options: {
   authState: WhoamiResult;
   beforePrompt?: () => void;
   afterPrompt?: () => void;
+  output: Writable;
 }): Promise<PrismaWorkspace | undefined> {
   const activeWorkspace = options.authState.workspace;
   if (!activeWorkspace) {
@@ -316,9 +305,10 @@ async function selectDeploymentWorkspace(options: {
       label: workspace.workspaceName ?? workspace.workspaceId,
       hint: workspace.current ? `${workspace.workspaceId}, current` : workspace.workspaceId,
     })),
+    output: options.output,
   });
   if (isCancel(selectedWorkspaceId)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output: options.output });
     return;
   }
   options.afterPrompt?.();
@@ -335,6 +325,7 @@ export function parseComposerDeployResult(result: ComposerDeployCommandResult):
   | {
       appName: string;
       appUrl?: string;
+      serviceId?: string;
     }
   | undefined {
   const summary = result.summary;
@@ -344,6 +335,7 @@ export function parseComposerDeployResult(result: ComposerDeployCommandResult):
     .find((entity) => entity.kind === "compute-service");
   return {
     appName: summary.app,
+    ...(computeService?.id ? { serviceId: computeService.id } : {}),
     ...(computeService?.url ? { appUrl: computeService.url.replace(/\/$/, "") } : {}),
   };
 }
@@ -384,9 +376,14 @@ export async function deployNewProjectWithComposer(options: {
   projectDir: string;
   shouldPromptForWorkspace: boolean;
   verbose: boolean;
+  output?: Writable;
+  allowInteractiveLogin?: boolean;
+  json?: boolean;
+  throwOnError?: boolean;
   workspace?: string;
 }): Promise<ComposerDeployResult | undefined> {
-  const progress = options.verbose ? undefined : spinner();
+  const output = options.output ?? process.stdout;
+  const progress = options.verbose ? undefined : spinner({ output });
   let deploymentLog: ReturnType<typeof taskLog> | undefined;
   let progressRunning = false;
   const showProgress = (message: string) => {
@@ -406,20 +403,23 @@ export async function deployNewProjectWithComposer(options: {
 
   try {
     showProgress("Checking Prisma account...");
-    if (options.verbose) log.step("Checking Prisma account.");
-    const authState = await ensureAuthentication(
-      options.packageManager,
-      options.projectDir,
-      clearProgress,
-    );
+    if (options.verbose) log.step("Checking Prisma account.", { output });
+    const authState = await ensureAuthentication({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      output,
+      allowInteractiveLogin: options.allowInteractiveLogin ?? true,
+      beforeInteractiveLogin: clearProgress,
+    });
 
     showProgress("Checking Prisma workspace...");
-    if (options.verbose) log.step("Checking Prisma workspace.");
+    if (options.verbose) log.step("Checking Prisma workspace.", { output });
     const selectedWorkspace = await selectDeploymentWorkspace({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       shouldPrompt: options.shouldPromptForWorkspace,
       authState,
+      output,
       beforePrompt: clearProgress,
       afterPrompt: () => showProgress("Selecting Prisma workspace..."),
       ...(options.workspace ? { workspace: options.workspace } : {}),
@@ -427,7 +427,7 @@ export async function deployNewProjectWithComposer(options: {
     if (!selectedWorkspace) return;
 
     showProgress("Checking Prisma project name...");
-    if (options.verbose) log.step("Checking Prisma project name.");
+    if (options.verbose) log.step("Checking Prisma project name.", { output });
     await ensureProjectNameAvailable({
       appName: options.appName,
       packageManager: options.packageManager,
@@ -436,12 +436,15 @@ export async function deployNewProjectWithComposer(options: {
     });
 
     showProgress("Building for deployment...");
-    if (options.verbose) log.step("Building for deployment.");
+    if (options.verbose) log.step("Building for deployment.", { output });
     const build = getRunScriptArgs(options.packageManager, "build");
-    await execa(build.command, build.args, {
+    await runSetupCommand({
+      command: build.command,
+      args: build.args,
       cwd: options.projectDir,
       env: process.env,
-      stdio: options.verbose ? "inherit" : "pipe",
+      verbose: options.verbose,
+      json: options.json === true,
     });
 
     clearProgress();
@@ -451,9 +454,9 @@ export async function deployNewProjectWithComposer(options: {
       "module.ts",
     ]);
     if (options.verbose) {
-      log.step(`Deploying to Prisma with ${deployCommand}.`);
+      log.step(`Deploying to Prisma with ${deployCommand}.`, { output });
     } else {
-      deploymentLog = taskLog({ title: "Deploying to Prisma...", limit: 10 });
+      deploymentLog = taskLog({ title: "Deploying to Prisma...", limit: 10, output });
       deploymentLog.message(`$ ${deployCommand}`);
     }
     const deployment = parseComposerDeployResult(
@@ -464,7 +467,7 @@ export async function deployNewProjectWithComposer(options: {
         onStderrLine: (line) => {
           const redactedLine = redactSecrets(line);
           if (options.verbose) {
-            process.stderr.write(`${redactedLine}\n`);
+            output.write(`${redactedLine}\n`);
           } else {
             deploymentLog?.message(redactedLine);
           }
@@ -474,7 +477,7 @@ export async function deployNewProjectWithComposer(options: {
     const appName = deployment?.appName ?? options.appName;
 
     if (options.verbose) {
-      log.step("Loading deployment details.");
+      log.step("Loading deployment details.", { output });
     } else {
       deploymentLog?.message("Loading deployment details...");
     }
@@ -487,11 +490,12 @@ export async function deployNewProjectWithComposer(options: {
     deploymentLog?.success("Deployed to Prisma.");
     deploymentLog = undefined;
     progressRunning = false;
-    if (options.verbose) log.success("Deployed to Prisma.");
+    if (options.verbose) log.success("Deployed to Prisma.", { output });
     const workspace = details?.workspace ?? selectedWorkspace;
     return {
       appName,
       ...(deployment?.appUrl ? { appUrl: deployment.appUrl } : {}),
+      ...(deployment?.serviceId ? { serviceId: deployment.serviceId } : {}),
       ...(workspace ? { workspace } : {}),
       project: details?.project ?? { name: appName },
     };
@@ -503,7 +507,8 @@ export async function deployNewProjectWithComposer(options: {
       progress?.error("Deployment failed.");
     }
     progressRunning = false;
-    log.error(`Deploy failed: ${getErrorMessage(error)}`);
+    log.error(`Deploy failed: ${getErrorMessage(error)}`, { output });
+    if (options.throwOnError) throw error;
     return;
   }
 }

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -1,4 +1,3 @@
-import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
 
@@ -10,6 +9,7 @@ import {
 import { getDbPackages } from "../constants/db-packages";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
 import { getInstallArgs, getRunScriptCommand } from "../utils/package-manager";
+import { runSetupCommand } from "../utils/run-command";
 
 function getPrismaScriptMap(packageManager: PackageManager): Record<string, string> {
   if (packageManager === "deno") {
@@ -194,7 +194,7 @@ export async function writeCreateTemplateDependencies(opts: {
 export async function installProjectDependencies(
   packageManager: PackageManager,
   projectDir = process.cwd(),
-  options: { verbose?: boolean } = {},
+  options: { verbose?: boolean; json?: boolean } = {},
 ): Promise<void> {
   const installCommand = getInstallArgs(packageManager);
   const env =
@@ -204,9 +204,12 @@ export async function installProjectDependencies(
         }
       : undefined;
 
-  await execa(installCommand.command, installCommand.args, {
+  await runSetupCommand({
+    command: installCommand.command,
+    args: installCommand.args,
     cwd: projectDir,
     env,
-    stdio: options.verbose === true ? "inherit" : "pipe",
+    verbose: options.verbose === true,
+    json: options.json === true,
   });
 }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -183,7 +183,7 @@ export async function collectPrismaSetupContext(
   const shouldDeploy =
     packageManager === "deno"
       ? false
-      : (input.deploy ?? (useDefaults ? false : await promptForDeployment(output)));
+      : (input.deploy ?? (json ? true : useDefaults ? false : await promptForDeployment(output)));
   if (shouldDeploy === undefined) return;
 
   return {

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -1,9 +1,10 @@
 import { cancel, confirm, isCancel, log, note, outro, select, spinner } from "@clack/prompts";
-import { execa } from "execa";
 import fs from "fs-extra";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
+import type { CreateNextStep } from "../result";
 import { scaffoldCreateSharedTemplates } from "../templates/render-create-template";
 import {
   AuthoringStyleSchema,
@@ -16,12 +17,15 @@ import {
   type PackageManager,
   type PrismaSetupCommandInput,
 } from "../types";
+import { resolveExecutionSettings } from "../ui/output";
+import { getErrorMessage } from "../utils/errors";
 import {
   detectPackageManager,
   getInstallCommand,
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
+import { runSetupCommand } from "../utils/run-command";
 import { deployNewProjectWithComposer, type ComposerDeployResult } from "./deploy-with-composer";
 import { initializeGitRepository, type GitInitializationResult } from "./initialize-git";
 import { installProjectDependencies, writePrismaDependencies } from "./install";
@@ -29,13 +33,8 @@ import { installProjectDependencies, writePrismaDependencies } from "./install";
 const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
 const DEFAULT_AUTHORING: AuthoringStyle = "psl";
 
-type NextStep = {
-  command: string;
-  description: string;
-};
-
 type PrismaSetupRunOptions = {
-  prependNextSteps?: NextStep[];
+  prependNextSteps?: CreateNextStep[];
   projectDir?: string;
   projectName?: string;
   template?: CreateTemplate;
@@ -48,6 +47,8 @@ type PrismaSetupRunOptions = {
 export type PrismaSetupContext = {
   projectDir: string;
   verbose: boolean;
+  json: boolean;
+  output: Writable;
   databaseProvider: DatabaseProvider;
   authoring: AuthoringStyle;
   packageManager: PackageManager;
@@ -56,7 +57,17 @@ export type PrismaSetupContext = {
   workspace?: string;
 };
 
-async function promptForDatabaseProvider(): Promise<DatabaseProvider | undefined> {
+export type PrismaSetupExecutionResult =
+  | {
+      ok: true;
+      deployment: ComposerDeployResult | null;
+      nextSteps: CreateNextStep[];
+      gitInitialization?: GitInitializationResult;
+      warnings: string[];
+    }
+  | { ok: false; error?: unknown; errorReported?: boolean };
+
+async function promptForDatabaseProvider(output: Writable): Promise<DatabaseProvider | undefined> {
   const databaseProvider = await select({
     message: "Select your database",
     initialValue: DEFAULT_DATABASE_PROVIDER,
@@ -64,15 +75,16 @@ async function promptForDatabaseProvider(): Promise<DatabaseProvider | undefined
       { value: "postgres", label: "PostgreSQL", hint: "Prisma Postgres with Composer" },
       { value: "mongo", label: "MongoDB", hint: "Connect an existing MongoDB database" },
     ],
+    output,
   });
   if (isCancel(databaseProvider)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return;
   }
   return DatabaseProviderSchema.parse(databaseProvider);
 }
 
-async function promptForAuthoringStyle(): Promise<AuthoringStyle | undefined> {
+async function promptForAuthoringStyle(output: Writable): Promise<AuthoringStyle | undefined> {
   const authoring = await select({
     message: "Choose contract authoring style",
     initialValue: DEFAULT_AUTHORING,
@@ -80,9 +92,10 @@ async function promptForAuthoringStyle(): Promise<AuthoringStyle | undefined> {
       { value: "psl", label: "PSL", hint: "Prisma schema syntax" },
       { value: "typescript", label: "TypeScript", hint: "TypeScript contract builder" },
     ],
+    output,
   });
   if (isCancel(authoring)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return;
   }
   return AuthoringStyleSchema.parse(authoring);
@@ -101,6 +114,7 @@ function getPackageManagerHint(option: PackageManager, detected: PackageManager)
 
 async function promptForPackageManager(
   detected: PackageManager,
+  output: Writable,
 ): Promise<PackageManager | undefined> {
   const packageManager = await select({
     message: "Choose package manager",
@@ -110,21 +124,23 @@ async function promptForPackageManager(
       label: value,
       hint: getPackageManagerHint(value, detected),
     })),
+    output,
   });
   if (isCancel(packageManager)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return;
   }
   return PackageManagerSchema.parse(packageManager);
 }
 
-async function promptForDeployment(): Promise<boolean | undefined> {
+async function promptForDeployment(output: Writable): Promise<boolean | undefined> {
   const shouldDeploy = await confirm({
     message: "Deploy to Prisma now?",
     initialValue: true,
+    output,
   });
   if (isCancel(shouldDeploy)) {
-    cancel("Operation cancelled.");
+    cancel("Operation cancelled.", { output });
     return;
   }
   return Boolean(shouldDeploy);
@@ -135,20 +151,23 @@ export async function collectPrismaSetupContext(
   options: { projectDir?: string; template?: CreateTemplate } = {},
 ): Promise<PrismaSetupContext | undefined> {
   const projectDir = path.resolve(options.projectDir ?? process.cwd());
-  const useDefaults = input.yes === true;
+  const { json, output, useDefaults } = resolveExecutionSettings(input);
 
   const databaseProvider =
-    input.provider ?? (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider());
+    input.provider ??
+    (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider(output));
   if (!databaseProvider) return;
 
   const authoring =
-    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : await promptForAuthoringStyle());
+    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : await promptForAuthoringStyle(output));
   if (!authoring) return;
 
   const detectedPackageManager = await detectPackageManager(projectDir);
   const packageManager =
     input.packageManager ??
-    (useDefaults ? detectedPackageManager : await promptForPackageManager(detectedPackageManager));
+    (useDefaults
+      ? detectedPackageManager
+      : await promptForPackageManager(detectedPackageManager, output));
   if (!packageManager) return;
 
   if (packageManager === "deno" && databaseProvider !== "postgres") {
@@ -164,12 +183,14 @@ export async function collectPrismaSetupContext(
   const shouldDeploy =
     packageManager === "deno"
       ? false
-      : (input.deploy ?? (useDefaults ? false : await promptForDeployment()));
+      : (input.deploy ?? (useDefaults ? false : await promptForDeployment(output)));
   if (shouldDeploy === undefined) return;
 
   return {
     projectDir,
     verbose: input.verbose === true,
+    json,
+    output,
     databaseProvider,
     authoring,
     packageManager,
@@ -177,14 +198,6 @@ export async function collectPrismaSetupContext(
     shouldPromptForWorkspace: !useDefaults,
     ...(input.workspace ? { workspace: input.workspace } : {}),
   };
-}
-
-function getCommandErrorMessage(error: unknown): string {
-  if (error instanceof Error && "stderr" in error) {
-    const stderr = String((error as { stderr?: string }).stderr ?? "").trim();
-    if (stderr) return stderr;
-  }
-  return error instanceof Error ? error.message : String(error);
 }
 
 function getContractPath(authoring: AuthoringStyle) {
@@ -216,11 +229,18 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
     "--skip-install",
   ];
   const invocation = getPrismaCliInvocation(context.packageManager, args);
-  if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);
-  await execa(invocation.command, invocation.args, {
+  if (context.verbose) {
+    log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`, {
+      output: context.output,
+    });
+  }
+  await runSetupCommand({
+    command: invocation.command,
+    args: invocation.args,
     cwd: projectDir,
-    stdio: context.verbose ? "inherit" : "pipe",
     env: { ...process.env, CI: "1" },
+    verbose: context.verbose,
+    json: context.json,
   });
   if (context.packageManager === "deno") await fs.remove(path.join(projectDir, "prisma-next.md"));
 }
@@ -236,11 +256,18 @@ async function initializeAgentSkills(
     "--yes",
     "--no-interactive",
   ]);
-  if (context.verbose) log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`);
-  await execa(invocation.command, invocation.args, {
+  if (context.verbose) {
+    log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`, {
+      output: context.output,
+    });
+  }
+  await runSetupCommand({
+    command: invocation.command,
+    args: invocation.args,
     cwd: projectDir,
-    stdio: context.verbose ? "inherit" : "pipe",
     env: { ...process.env, CI: "1" },
+    verbose: context.verbose,
+    json: context.json,
   });
 }
 
@@ -296,12 +323,15 @@ async function runPrismaCli(
 ): Promise<void> {
   const invocation = getPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) {
-    log.step([invocation.command, ...invocation.args].join(" "));
+    log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
   }
-  await execa(invocation.command, invocation.args, {
+  await runSetupCommand({
+    command: invocation.command,
+    args: invocation.args,
     cwd: projectDir,
-    stdio: context.verbose ? "inherit" : "pipe",
     env: { ...process.env, CI: "1" },
+    verbose: context.verbose,
+    json: context.json,
   });
 }
 
@@ -318,7 +348,7 @@ async function planBaselineMigration(
   await runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]);
 }
 
-function formatNextSteps(steps: NextStep[]): string {
+function formatNextSteps(steps: CreateNextStep[]): string {
   return steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
 }
 
@@ -358,7 +388,10 @@ function formatProjectSummary(options: {
   return lines.join("\n");
 }
 
-function buildNextSteps(context: PrismaSetupContext, options: PrismaSetupRunOptions): NextStep[] {
+function buildNextSteps(
+  context: PrismaSetupContext,
+  options: PrismaSetupRunOptions,
+): CreateNextStep[] {
   const nextSteps = [...(options.prependNextSteps ?? [])];
   if (context.databaseProvider === "mongo") {
     nextSteps.push({
@@ -391,11 +424,13 @@ function buildNextSteps(context: PrismaSetupContext, options: PrismaSetupRunOpti
 export async function executePrismaSetupContext(
   context: PrismaSetupContext,
   options: PrismaSetupRunOptions = {},
-): Promise<boolean> {
+): Promise<PrismaSetupExecutionResult> {
   const projectDir = path.resolve(options.projectDir ?? context.projectDir);
   const projectName = options.projectName ?? path.basename(projectDir);
   const template = options.template ?? "minimal";
-  const progress = context.verbose ? undefined : (options.progressSpinner ?? spinner());
+  const progress = context.verbose
+    ? undefined
+    : (options.progressSpinner ?? spinner({ output: context.output }));
   const ownsProgress = progress !== undefined && !options.progressSpinner;
   let gitInitialization: GitInitializationResult | undefined;
   if (ownsProgress) progress.start("Creating Prisma 8 project...");
@@ -430,6 +465,7 @@ export async function executePrismaSetupContext(
     );
     await installProjectDependencies(context.packageManager, projectDir, {
       verbose: context.verbose,
+      json: context.json,
     });
 
     progress?.message("Installing Prisma agent skills...");
@@ -449,14 +485,16 @@ export async function executePrismaSetupContext(
     }
     progress?.stop("Prisma 8 project ready.");
     if (gitInitialization?.status === "initialized" && context.verbose) {
-      log.success("Initialized Git repository with an initial commit.");
+      log.success("Initialized Git repository with an initial commit.", { output: context.output });
     } else if (gitInitialization?.status === "skipped") {
-      log.warn(`Could not initialize Git repository: ${gitInitialization.reason}`);
+      log.warn(`Could not initialize Git repository: ${gitInitialization.reason}`, {
+        output: context.output,
+      });
     }
   } catch (error) {
     progress?.error("Could not create Prisma 8 project.");
-    cancel(getCommandErrorMessage(error));
-    return false;
+    cancel(getErrorMessage(error), { output: context.output });
+    return { ok: false, error, errorReported: true };
   }
 
   let deployment: ComposerDeployResult | undefined;
@@ -467,17 +505,39 @@ export async function executePrismaSetupContext(
       projectDir,
       shouldPromptForWorkspace: context.shouldPromptForWorkspace,
       verbose: context.verbose,
+      output: context.output,
+      allowInteractiveLogin: !context.json,
+      json: context.json,
+      throwOnError: context.json,
       ...(context.workspace ? { workspace: context.workspace } : {}),
     });
-    if (!deployment) return false;
+    if (!deployment) return { ok: false, errorReported: true };
   }
+
+  const nextSteps = buildNextSteps(context, options);
+  const warnings =
+    gitInitialization?.status === "skipped"
+      ? [`Could not initialize Git repository: ${gitInitialization.reason}`]
+      : [];
 
   const projectSummary = formatProjectSummary({
     createdProjectPath: options.createdProjectPath,
     deployment,
   });
-  if (projectSummary) note(projectSummary, context.shouldDeploy ? "Deployment" : "Project");
-  note(formatNextSteps(buildNextSteps(context, options)), "Next steps");
-  outro(context.shouldDeploy ? "Prisma 8 app deployed." : "Prisma 8 project ready.");
-  return true;
+  if (projectSummary) {
+    note(projectSummary, context.shouldDeploy ? "Deployment" : "Project", {
+      output: context.output,
+    });
+  }
+  note(formatNextSteps(nextSteps), "Next steps", { output: context.output });
+  outro(context.shouldDeploy ? "Prisma 8 app deployed." : "Prisma 8 project ready.", {
+    output: context.output,
+  });
+  return {
+    ok: true,
+    deployment: deployment ?? null,
+    nextSteps,
+    ...(gitInitialization ? { gitInitialization } : {}),
+    warnings,
+  };
 }

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -31,7 +31,8 @@ function getBaseCreateProperties(
 ): Record<string, boolean | number | string | string[] | null> {
   return {
     command: "create",
-    "uses-defaults": input.yes === true,
+    "uses-defaults": input.yes === true || input.json === true,
+    json: input.json === true,
     verbose: input.verbose === true,
     force: input.force === true,
     template: context?.template ?? input.template ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export const CommonCommandOptionsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "Emit one quiet JSON result for agents and automation (implies non-interactive defaults)",
+      "Emit one quiet JSON result for agents and automation (non-interactive; deploys unless --no-deploy)",
     ),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,12 @@ export type CreateTemplate = z.infer<typeof CreateTemplateSchema>;
 export const CommonCommandOptionsSchema = z.object({
   yes: z.boolean().optional().describe("Skip prompts and accept default choices"),
   verbose: z.boolean().optional().describe("Show verbose command output during setup"),
+  json: z
+    .boolean()
+    .optional()
+    .describe(
+      "Emit one quiet JSON result for agents and automation (implies non-interactive defaults)",
+    ),
 });
 
 export const PrismaSetupOptionsSchema = z.object({

--- a/src/ui/json-output.ts
+++ b/src/ui/json-output.ts
@@ -1,0 +1,73 @@
+import type { Logger } from "trpc-cli";
+
+import { createCommandFailureResult, type CreateCommandResult } from "../result";
+
+function isCreateCommandResult(value: unknown): value is CreateCommandResult {
+  if (typeof value !== "object" || value === null) return false;
+  return Reflect.get(value, "schemaVersion") === 1 && typeof Reflect.get(value, "ok") === "boolean";
+}
+
+function formatLoggerMessage(values: unknown[]): string {
+  return values
+    .map((value) => {
+      if (value instanceof Error) return value.message;
+      if (typeof value === "string") return value.trim();
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+    })
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function isJsonOutputRequested(argv: string[]): boolean {
+  let requested = false;
+  for (const [index, argument] of argv.entries()) {
+    if (argument === "--json") {
+      requested = argv[index + 1]?.toLowerCase() !== "false";
+    }
+    if (argument.startsWith("--json=")) {
+      requested = argument.slice("--json=".length).toLowerCase() !== "false";
+    }
+    if (argument === "--no-json") requested = false;
+  }
+  return requested;
+}
+
+export function createJsonOutputLogger(
+  write: (output: string) => void = (output) => process.stdout.write(output),
+): Logger {
+  let didWrite = false;
+  const writeResult = (result: CreateCommandResult) => {
+    if (didWrite) return;
+    didWrite = true;
+    write(`${JSON.stringify(result)}\n`);
+  };
+
+  return {
+    info(...values: unknown[]) {
+      const result = values.length === 1 ? values[0] : undefined;
+      if (isCreateCommandResult(result)) {
+        writeResult(result);
+        return;
+      }
+
+      writeResult(
+        createCommandFailureResult(
+          "parse_arguments",
+          formatLoggerMessage(values) || "The CLI returned an unexpected result.",
+        ),
+      );
+    },
+    error(...values: unknown[]) {
+      writeResult(
+        createCommandFailureResult(
+          "parse_arguments",
+          formatLoggerMessage(values) || "Could not parse command arguments.",
+        ),
+      );
+    },
+  };
+}

--- a/src/ui/output.ts
+++ b/src/ui/output.ts
@@ -1,0 +1,26 @@
+import { Writable } from "node:stream";
+
+const silentOutput = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+});
+
+export type ExecutionSettings = {
+  json: boolean;
+  output: Writable;
+  useDefaults: boolean;
+};
+
+/** Resolves the shared interaction policy for human and machine-readable modes. */
+export function resolveExecutionSettings(options: {
+  json?: boolean;
+  yes?: boolean;
+}): ExecutionSettings {
+  const json = options.json === true;
+  return {
+    json,
+    output: json ? silentOutput : process.stdout,
+    useDefaults: options.yes === true || json,
+  };
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,20 @@
+export function redactSecrets(message: string): string {
+  return message
+    .replace(
+      /\b((?:(?:prisma\+)?postgres(?:ql)?|mongodb(?:\+srv)?):\/\/)[^\s'"]+/gi,
+      "$1<redacted>",
+    )
+    .replace(
+      /\b([A-Z0-9_]*(?:MONGODB_(?:URL|URI)|DATABASE_URL|TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s]+)/gi,
+      "$1<redacted>",
+    )
+    .replace(/(\bAuthorization\s*:\s*Bearer\s+)[^\s'"]+/gi, "$1<redacted>");
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && "stderr" in error) {
+    const stderr = String((error as { stderr?: string }).stderr ?? "").trim();
+    if (stderr) return redactSecrets(stderr);
+  }
+  return redactSecrets(error instanceof Error ? error.message : String(error));
+}

--- a/src/utils/run-command.ts
+++ b/src/utils/run-command.ts
@@ -1,0 +1,21 @@
+import { execa } from "execa";
+
+/**
+ * Runs a setup command without allowing child output to corrupt structured CLI output.
+ * Human verbose mode keeps native streaming; JSON mode always captures child output.
+ */
+export async function runSetupCommand(options: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  verbose: boolean;
+  json: boolean;
+}): Promise<void> {
+  const shouldInheritOutput = options.verbose && !options.json;
+  await execa(options.command, options.args, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: shouldInheritOutput ? "inherit" : "pipe",
+  });
+}

--- a/tests/deploy-with-composer.test.ts
+++ b/tests/deploy-with-composer.test.ts
@@ -5,8 +5,8 @@ import {
   getConsoleProjectUrl,
   parseComposerDeployResult,
   parsePrismaCliEnvelope,
-  redactSecrets,
 } from "../src/tasks/deploy-with-composer";
+import { getErrorMessage, redactSecrets } from "../src/utils/errors";
 
 describe("redactSecrets", () => {
   test("redacts supported database URLs", () => {
@@ -31,6 +31,14 @@ describe("redactSecrets", () => {
         "Authorization: Bearer header.payload.signature App: https://example.prisma.build",
       ),
     ).toBe("Authorization: Bearer <redacted> App: https://example.prisma.build");
+  });
+
+  test("redacts captured subprocess stderr", () => {
+    const error = Object.assign(new Error("Command failed"), {
+      stderr: "DATABASE_URL=postgresql://user:password@host/database",
+    });
+
+    expect(getErrorMessage(error)).toBe("DATABASE_URL=<redacted>");
   });
 });
 
@@ -106,6 +114,7 @@ describe("parseComposerDeployResult", () => {
     ).toEqual({
       appName: "my-app",
       appUrl: "https://abc123.ewr.prisma.build",
+      serviceId: "cps_abc123",
     });
   });
 

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runCreateCommand } from "../../src/commands/create";
+import type { CreateCommandResult } from "../../src/result";
 
 const TEST_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_TIMEOUT_MS ?? 300_000);
 const tempRoots: string[] = [];
@@ -34,6 +35,40 @@ async function runCommand(projectDir: string, args: string[]) {
     throw new Error([`Command failed: ${args.join(" ")}`, stdout, stderr].join("\n"));
   }
   return `${stdout}\n${stderr}`;
+}
+
+async function runCreatePrismaJson(rootDir: string, args: string[]) {
+  const child = Bun.spawn({
+    cmd: [process.execPath, path.join(import.meta.dir, "../../src/cli.ts"), "create", ...args],
+    cwd: rootDir,
+    env: { ...Bun.env, CI: "1", CREATE_PRISMA_DISABLE_TELEMETRY: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  let result: CreateCommandResult;
+  try {
+    result = JSON.parse(stdout) as CreateCommandResult;
+  } catch (error) {
+    throw new Error(
+      [
+        `Could not parse create-prisma JSON output (exit ${exitCode}).`,
+        `stdout:\n${stdout}`,
+        `stderr:\n${stderr}`,
+      ].join("\n"),
+      { cause: error },
+    );
+  }
+  return {
+    result,
+    stderr,
+    stdout,
+    exitCode,
+  };
 }
 
 function findAppEndpoint(output: string): string | undefined {
@@ -133,6 +168,7 @@ describe("create-prisma e2e", () => {
         "npm",
         "--no-deploy",
         "--yes",
+        "--json",
       ],
       cwd: rootDir,
       env: {
@@ -145,8 +181,19 @@ describe("create-prisma e2e", () => {
       stderr: "pipe",
     });
 
-    const exitCode = await child.exited;
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
     expect(exitCode).toBe(1);
+    expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
+    expect(JSON.parse(stdout)).toMatchObject({
+      schemaVersion: 1,
+      ok: false,
+      error: { stage: "prisma_setup" },
+    });
+    expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);
   });
 
@@ -169,7 +216,7 @@ describe("create-prisma e2e", () => {
         "--package-manager",
         "deno",
         "--no-deploy",
-        "--yes",
+        "--json",
       ],
       cwd: rootDir,
       env: { ...Bun.env, CI: "1", CREATE_PRISMA_DISABLE_TELEMETRY: "1" },
@@ -183,10 +230,60 @@ describe("create-prisma e2e", () => {
       child.exited,
     ]);
     expect(exitCode).toBe(1);
-    expect(`${stdout}\n${stderr}`).toContain(
-      "Deno support currently requires the minimal template",
-    );
+    expect(JSON.parse(stdout)).toEqual({
+      schemaVersion: 1,
+      ok: false,
+      error: {
+        stage: "collect_context",
+        message: "Deno support currently requires the minimal template.",
+      },
+    });
+    expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "unsupported-deno-app"))).toBe(false);
+  });
+
+  test("returns structured JSON for invalid arguments", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-json-invalid-e2e-"));
+    tempRoots.push(rootDir);
+
+    const { result, stderr, stdout, exitCode } = await runCreatePrismaJson(rootDir, [
+      "invalid-app",
+      "--template",
+      "not-a-template",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toBe("");
+    expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
+    expect(result).toMatchObject({
+      schemaVersion: 1,
+      ok: false,
+      error: { stage: "parse_arguments" },
+    });
+  });
+
+  test("keeps JSON mode deterministic by rejecting verbose output", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-json-verbose-e2e-"));
+    tempRoots.push(rootDir);
+
+    const { result, stderr, stdout, exitCode } = await runCreatePrismaJson(rootDir, [
+      "verbose-app",
+      "--json",
+      "--verbose",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toBe("");
+    expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
+    expect(result).toEqual({
+      schemaVersion: 1,
+      ok: false,
+      error: {
+        stage: "validate_input",
+        message: "--verbose cannot be used with --json because JSON mode is output-only.",
+      },
+    });
   });
 
   test(
@@ -195,23 +292,51 @@ describe("create-prisma e2e", () => {
       const rootDir = await mkdtemp(path.join(tmpdir(), "create-prisma-next-e2e-"));
       tempRoots.push(rootDir);
       const appName = `composer-app-${path.basename(rootDir).toLowerCase()}`;
-      const previousCwd = process.cwd();
-      process.chdir(rootDir);
-      try {
-        await runCreateCommand({
-          name: appName,
-          template: "minimal",
-          provider: "postgres",
-          authoring: "psl",
-          packageManager: "bun",
-          deploy: false,
-          yes: true,
-        });
-      } finally {
-        process.chdir(previousCwd);
-      }
+      const { result, stdout, exitCode } = await runCreatePrismaJson(rootDir, [
+        appName,
+        "--template",
+        "minimal",
+        "--provider",
+        "postgres",
+        "--authoring",
+        "psl",
+        "--package-manager",
+        "bun",
+        "--no-deploy",
+        "--json",
+      ]);
 
       const projectDir = path.join(rootDir, appName);
+      expect(exitCode).toBe(0);
+      expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
+      expect(result).toMatchObject({
+        schemaVersion: 1,
+        ok: true,
+        project: {
+          name: appName,
+          path: await realpath(projectDir),
+          template: "minimal",
+          databaseProvider: "postgres",
+          authoring: "psl",
+          packageManager: "bun",
+        },
+        deployment: null,
+        nextSteps: [
+          {
+            command: `cd ${appName}`,
+            description: "Enter your new project directory.",
+          },
+          {
+            command: "bun run dev:composer",
+            description: "Build and start the app with Prisma Composer locally.",
+          },
+          {
+            command: "bun run deploy",
+            description: "Build and deploy the app with Prisma Composer.",
+          },
+        ],
+      });
+      expect(result.ok && Array.isArray(result.warnings)).toBe(true);
       const packageJson = JSON.parse(
         await readFile(path.join(projectDir, "package.json"), "utf8"),
       ) as Record<string, any>;

--- a/tests/json-output.test.ts
+++ b/tests/json-output.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+import { createJsonOutputLogger, isJsonOutputRequested } from "../src/ui/json-output";
+
+describe("isJsonOutputRequested", () => {
+  test("uses the last explicit JSON flag", () => {
+    expect(isJsonOutputRequested(["create-prisma", "app", "--json"])).toBe(true);
+    expect(isJsonOutputRequested(["create-prisma", "app", "--json", "true"])).toBe(true);
+    expect(isJsonOutputRequested(["create-prisma", "app", "--json", "false"])).toBe(false);
+    expect(isJsonOutputRequested(["create-prisma", "app", "--json=false"])).toBe(false);
+    expect(isJsonOutputRequested(["create-prisma", "app", "--json", "--no-json"])).toBe(false);
+    expect(isJsonOutputRequested(["create-prisma", "app", "--no-json", "--json"])).toBe(true);
+  });
+});
+
+describe("createJsonOutputLogger", () => {
+  test("writes one compact success result", () => {
+    const outputs: string[] = [];
+    const logger = createJsonOutputLogger((output) => outputs.push(output));
+
+    logger.info?.({
+      schemaVersion: 1,
+      ok: true,
+      project: {
+        name: "my-app",
+        path: "/tmp/my-app",
+        template: "minimal",
+        databaseProvider: "postgres",
+        authoring: "psl",
+        packageManager: "bun",
+      },
+      deployment: null,
+      nextSteps: [],
+      warnings: [],
+    });
+
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]?.split("\n")).toHaveLength(2);
+    expect(outputs[0]?.endsWith("\n")).toBe(true);
+    expect(JSON.parse(outputs[0]!)).toEqual({
+      schemaVersion: 1,
+      ok: true,
+      project: {
+        name: "my-app",
+        path: "/tmp/my-app",
+        template: "minimal",
+        databaseProvider: "postgres",
+        authoring: "psl",
+        packageManager: "bun",
+      },
+      deployment: null,
+      nextSteps: [],
+      warnings: [],
+    });
+  });
+
+  test("turns parser errors into one structured failure", () => {
+    const outputs: string[] = [];
+    const logger = createJsonOutputLogger((output) => outputs.push(output));
+
+    logger.error?.("Invalid template");
+    logger.info?.({ unexpected: true });
+
+    expect(outputs).toHaveLength(1);
+    expect(JSON.parse(outputs[0]!)).toEqual({
+      schemaVersion: 1,
+      ok: false,
+      error: { stage: "parse_arguments", message: "Invalid template" },
+    });
+  });
+
+  test("turns unexpected info values into a structured failure", () => {
+    const outputs: string[] = [];
+    const logger = createJsonOutputLogger((output) => outputs.push(output));
+
+    logger.info?.({ unexpected: true });
+
+    expect(outputs).toHaveLength(1);
+    expect(JSON.parse(outputs[0]!)).toEqual({
+      schemaVersion: 1,
+      ok: false,
+      error: {
+        stage: "parse_arguments",
+        message: '{"unexpected":true}',
+      },
+    });
+  });
+});

--- a/tests/setup-prisma.test.ts
+++ b/tests/setup-prisma.test.ts
@@ -32,6 +32,25 @@ describe("collectPrismaSetupContext", () => {
     });
   });
 
+  test("--json is non-interactive and uses Prisma Postgres defaults", async () => {
+    await withTempProject(async (projectDir) => {
+      const context = await collectPrismaSetupContext(
+        { json: true, packageManager: "bun" },
+        { projectDir },
+      );
+
+      expect(context).toMatchObject({
+        json: true,
+        databaseProvider: "postgres",
+        authoring: "psl",
+        packageManager: "bun",
+        shouldDeploy: false,
+        shouldPromptForWorkspace: false,
+      });
+      expect(context?.output).not.toBe(process.stdout);
+    });
+  });
+
   test("honors an explicit immediate deployment", async () => {
     await withTempProject(async (projectDir) => {
       const context = await collectPrismaSetupContext(

--- a/tests/setup-prisma.test.ts
+++ b/tests/setup-prisma.test.ts
@@ -32,7 +32,7 @@ describe("collectPrismaSetupContext", () => {
     });
   });
 
-  test("--json is non-interactive and uses Prisma Postgres defaults", async () => {
+  test("--json is non-interactive and deploys with Prisma Postgres defaults", async () => {
     await withTempProject(async (projectDir) => {
       const context = await collectPrismaSetupContext(
         { json: true, packageManager: "bun" },
@@ -44,10 +44,21 @@ describe("collectPrismaSetupContext", () => {
         databaseProvider: "postgres",
         authoring: "psl",
         packageManager: "bun",
-        shouldDeploy: false,
+        shouldDeploy: true,
         shouldPromptForWorkspace: false,
       });
       expect(context?.output).not.toBe(process.stdout);
+    });
+  });
+
+  test("--json honors an explicit deployment opt-out", async () => {
+    await withTempProject(async (projectDir) => {
+      const context = await collectPrismaSetupContext(
+        { json: true, packageManager: "bun", deploy: false },
+        { projectDir },
+      );
+
+      expect(context?.shouldDeploy).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- add `--json` as a dedicated non-interactive mode for agents and automation
- emit exactly one versioned JSON result on stdout with no Clack UI, spinner, subprocess chatter, or CLI stderr output
- deploy by default in JSON mode, with `--no-deploy` as the explicit local-only opt-out
- reject `--json --verbose` with a structured error so the machine-readable contract stays deterministic
- include generated project details, Composer deployment metadata, next steps, and warnings in successful results
- return structured parser and runtime failures with actionable stages, sanitized messages, and non-zero exit codes
- expose the result types and schema version from the package API

JSON mode uses non-interactive defaults. It deploys to the active Prisma workspace unless `--workspace` selects another workspace or `--no-deploy` disables deployment.

## Output contract

```console
$ bunx create-prisma@latest my-app --template next --package-manager bun --no-deploy --json
{"schemaVersion":1,"ok":true,"project":{"name":"my-app","path":"/absolute/path/my-app","template":"next","databaseProvider":"postgres","authoring":"psl","packageManager":"bun"},"deployment":null,"nextSteps":[...],"warnings":[]}
```

Failures use the same single-document contract:

```json
{"schemaVersion":1,"ok":false,"error":{"stage":"parse_arguments","message":"..."}}
```

When deployment succeeds, `deployment` includes the app URL and service ID plus workspace/project IDs, names, and the Console URL when the Prisma CLI reports them.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run test:unit` — 40 passed
- `bun run test:e2e` — 7 passed, including a real JSON-mode scaffold that builds and runs with Composer
- `bun run build`
- published preview smoke-tested for quiet single-line success and failure output with correct exit codes