### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
Release 0.11.0 — first create-prisma release scaffolding the renamed Composer API (#72): composer 0.16.0 (`postgres()`/`dataContract()` from `/orm`), prisma CLI 8.0.0-rc.12 (bundles composer-cli 0.16.0), orm-postgres 8.0.0-rc.8, effect 4.0.0-rc.112, and the `temporal-polyfill` fix for ORM rc.8 timestamp defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)