### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,6 +186,8 @@ jobs:
 
   release:
     name: Release to npm
+    # Squash-merge release PRs: the merge-commit message of a plain merge does
+    # not start with the marker, and the release silently skips.
     if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Retriggers the 0.11.0 release: #75 was merged with a **merge commit**, whose message ("Merge pull request #75…") does not start with `chore(release):`, so the push-triggered release job skipped. `package.json` on main already carries 0.11.0; the release job is a no-op-safe re-run (it checks whether the version exists on npm first).

**Squash-merge this PR** — the squash commit title is what satisfies the release trigger. The diff adds a comment in publish.yml documenting exactly this trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)