### PR TITLE
fix: classify create telemetry outcomes

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -314,7 +314,7 @@ export async function runCreateCommand(
         stage: error.stage,
       });
       return createCommandFailureResult(
-        failureStage,
+        error.stage,
         error.message,
         context ? getProjectResult(context) : undefined,
       );

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -4,16 +4,18 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 
 import {
+  CreateCancellationError,
+  getCreateFailureReason,
+  type CreateFailureReason,
+  type CreateFailureStage,
+} from "../create-outcome";
+import {
   CREATE_PRISMA_RESULT_SCHEMA_VERSION,
   createCommandFailureResult,
   type CreateCommandResult,
   type CreateProjectResult,
 } from "../result";
-import {
-  trackCreateCompleted,
-  trackCreateFailed,
-  type CreateTelemetryFailureStage,
-} from "../telemetry";
+import { trackCreateCancelled, trackCreateCompleted, trackCreateFailed } from "../telemetry";
 import { scaffoldCreateFrameworkTemplate } from "../templates/render-create-template";
 import { writeCreateTemplateDependencies } from "../tasks/install";
 import type { PrismaSetupContext } from "../tasks/setup-prisma";
@@ -51,14 +53,22 @@ type ExecuteCreateContextResult =
   | { ok: true; result: CreateCommandResult }
   | {
       ok: false;
-      stage: CreateTelemetryFailureStage;
+      cancelled: true;
+      stage: "select_workspace";
+      errorReported?: boolean;
+    }
+  | {
+      ok: false;
+      cancelled?: false;
+      stage: CreateFailureStage;
+      reason: CreateFailureReason;
       error?: unknown;
       errorReported?: boolean;
     };
 
 type CollectCreateContextResult =
   | { ok: true; context: CreatePromptContext }
-  | { ok: false; message: string };
+  | { ok: false; message: string; reason: CreateFailureReason };
 
 function toPackageName(projectName: string): string {
   return (
@@ -102,7 +112,7 @@ function getProjectResult(context: CreatePromptContext): CreateProjectResult {
   };
 }
 
-async function promptForProjectName(output: Writable): Promise<string | undefined> {
+async function promptForProjectName(output: Writable): Promise<string> {
   const projectName = await text({
     message: "Project name",
     placeholder: DEFAULT_PROJECT_NAME,
@@ -113,13 +123,13 @@ async function promptForProjectName(output: Writable): Promise<string | undefine
 
   if (isCancel(projectName)) {
     cancel("Operation cancelled.", { output });
-    return undefined;
+    throw new CreateCancellationError("project_name");
   }
 
   return String(projectName).trim();
 }
 
-async function promptForCreateTemplate(output: Writable): Promise<CreateTemplate | undefined> {
+async function promptForCreateTemplate(output: Writable): Promise<CreateTemplate> {
   const template = await select({
     message: "Select template",
     initialValue: DEFAULT_TEMPLATE,
@@ -175,7 +185,7 @@ async function promptForCreateTemplate(output: Writable): Promise<CreateTemplate
 
   if (isCancel(template)) {
     cancel("Operation cancelled.", { output });
-    return undefined;
+    throw new CreateCancellationError("template");
   }
 
   return CreateTemplateSchema.parse(template);
@@ -213,7 +223,8 @@ export async function runCreateCommand(
   const startedAt = Date.now();
   let input: CreateCommandInput = {};
   let context: CreatePromptContext | undefined;
-  let failureStage: CreateTelemetryFailureStage = "validate_input";
+  let failureStage: CreateFailureStage = "validate_input";
+  let failureReason: CreateFailureReason = "invalid_input";
   const { output } = resolveExecutionSettings(rawInput);
 
   try {
@@ -225,12 +236,19 @@ export async function runCreateCommand(
       const message = getUnsupportedNodeMessage();
       cancel(message, { output });
       process.exitCode = 1;
+      await trackCreateFailed({
+        input,
+        durationMs: Date.now() - startedAt,
+        stage: failureStage,
+        reason: "unsupported_node_version",
+      });
       return createCommandFailureResult(failureStage, message);
     }
 
     intro(getCreatePrismaIntro(), { output });
 
     failureStage = "collect_context";
+    failureReason = "unexpected_error";
     const collected = await collectCreateContext(input);
     if (!collected.ok) {
       process.exitCode = 1;
@@ -239,6 +257,7 @@ export async function runCreateCommand(
         input,
         durationMs: Date.now() - startedAt,
         stage: failureStage,
+        reason: collected.reason,
       });
       return result;
     }
@@ -248,6 +267,19 @@ export async function runCreateCommand(
     const executionResult = await executeCreateContext(context);
     if (!executionResult.ok) {
       process.exitCode = 1;
+      if (executionResult.cancelled) {
+        await trackCreateCancelled({
+          input,
+          context,
+          durationMs: Date.now() - startedAt,
+          stage: executionResult.stage,
+        });
+        return createCommandFailureResult(
+          executionResult.stage,
+          "Operation cancelled.",
+          getProjectResult(context),
+        );
+      }
       const message = executionResult.error
         ? getErrorMessage(executionResult.error)
         : "Project setup did not complete.";
@@ -261,6 +293,7 @@ export async function runCreateCommand(
         durationMs: Date.now() - startedAt,
         error: executionResult.error,
         stage: executionResult.stage,
+        reason: executionResult.reason,
       });
       return createCommandFailureResult(executionResult.stage, message, getProjectResult(context));
     }
@@ -273,6 +306,19 @@ export async function runCreateCommand(
     return executionResult.result;
   } catch (error) {
     process.exitCode = 1;
+    if (error instanceof CreateCancellationError) {
+      await trackCreateCancelled({
+        input,
+        context,
+        durationMs: Date.now() - startedAt,
+        stage: error.stage,
+      });
+      return createCommandFailureResult(
+        failureStage,
+        error.message,
+        context ? getProjectResult(context) : undefined,
+      );
+    }
     const message = getErrorMessage(error);
     cancel(`Create command failed: ${message}`, { output });
     await trackCreateFailed({
@@ -281,6 +327,7 @@ export async function runCreateCommand(
       durationMs: Date.now() - startedAt,
       error,
       stage: failureStage,
+      reason: getCreateFailureReason(error, failureReason),
     });
     return createCommandFailureResult(
       failureStage,
@@ -298,23 +345,19 @@ async function collectCreateContext(
 
   const projectNameInput =
     input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : await promptForProjectName(output));
-  if (projectNameInput === undefined) {
-    return { ok: false, message: "Operation cancelled." };
-  }
-
   const projectName = String(projectNameInput).trim();
   const projectNameValidationError = validateProjectName(projectName);
   if (projectNameValidationError) {
     cancel(projectNameValidationError, { output });
-    return { ok: false, message: projectNameValidationError };
+    return {
+      ok: false,
+      message: projectNameValidationError,
+      reason: "invalid_project_name",
+    };
   }
 
   const template =
     input.template ?? (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate(output));
-  if (!template) {
-    return { ok: false, message: "Operation cancelled." };
-  }
-
   const targetDirectory = path.resolve(process.cwd(), projectName);
   const targetPathState = await inspectTargetPath(targetDirectory);
   if (targetPathState.exists && !targetPathState.isDirectory) {
@@ -322,24 +365,20 @@ async function collectCreateContext(
       targetDirectory,
     )} already exists and is not a directory. Choose a different project name.`;
     cancel(message, { output });
-    return { ok: false, message };
+    return { ok: false, message, reason: "target_path_not_directory" };
   }
   if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
     const message = `Target directory ${formatPathForDisplay(
       targetDirectory,
     )} is not empty. Use --force to continue.`;
     cancel(message, { output });
-    return { ok: false, message };
+    return { ok: false, message, reason: "target_directory_not_empty" };
   }
 
   const prismaSetupContext = await collectPrismaSetupContext(input, {
     projectDir: targetDirectory,
     template,
   });
-  if (!prismaSetupContext) {
-    return { ok: false, message: "Operation cancelled." };
-  }
-
   return {
     ok: true,
     context: {
@@ -382,6 +421,7 @@ async function executeCreateContext(
     return {
       ok: false,
       stage: "scaffold_template",
+      reason: "template_scaffold_failed",
       error,
     };
   }
@@ -397,6 +437,7 @@ async function executeCreateContext(
     return {
       ok: false,
       stage: "scaffold_template",
+      reason: "template_scaffold_failed",
       error,
     };
   }
@@ -430,9 +471,18 @@ async function executeCreateContext(
     });
 
     if (!setupResult.ok) {
+      if (setupResult.cancelled) {
+        return {
+          ok: false,
+          cancelled: true,
+          stage: setupResult.stage,
+          errorReported: setupResult.errorReported,
+        };
+      }
       return {
         ok: false,
-        stage: "prisma_setup",
+        stage: setupResult.stage,
+        reason: setupResult.reason,
         error: setupResult.error,
         errorReported: setupResult.errorReported,
       };
@@ -456,7 +506,8 @@ async function executeCreateContext(
     createSpinner?.error("Could not create Prisma 8 project.");
     return {
       ok: false,
-      stage: "prisma_setup",
+      stage: "unknown",
+      reason: getCreateFailureReason(error, "unexpected_error"),
       error,
     };
   }

--- a/src/create-outcome.ts
+++ b/src/create-outcome.ts
@@ -1,0 +1,80 @@
+export type CreateFailureStage =
+  | "validate_input"
+  | "collect_context"
+  | "scaffold_template"
+  | "initialize_prisma"
+  | "configure_project"
+  | "install_dependencies"
+  | "initialize_agent_skills"
+  | "emit_contract"
+  | "plan_migration"
+  | "initialize_git"
+  | "authenticate"
+  | "select_workspace"
+  | "check_project_name"
+  | "build"
+  | "composer_deploy"
+  | "unknown";
+
+export type CreateFailureReason =
+  | "invalid_input"
+  | "unsupported_node_version"
+  | "invalid_project_name"
+  | "target_path_not_directory"
+  | "target_directory_not_empty"
+  | "unsupported_configuration"
+  | "template_scaffold_failed"
+  | "prisma_init_failed"
+  | "project_configuration_failed"
+  | "dependency_install_failed"
+  | "agent_skills_init_failed"
+  | "contract_emit_failed"
+  | "migration_plan_failed"
+  | "git_initialization_failed"
+  | "prisma_auth_command_failed"
+  | "not_authenticated"
+  | "authentication_failed"
+  | "workspace_missing"
+  | "workspace_mismatch"
+  | "workspace_selection_failed"
+  | "project_lookup_failed"
+  | "project_name_collision"
+  | "build_failed"
+  | "composer_deploy_failed"
+  | "unexpected_error";
+
+export type CreateCancellationStage =
+  | "project_name"
+  | "template"
+  | "database_provider"
+  | "authoring_style"
+  | "package_manager"
+  | "deployment_intent"
+  | "select_workspace";
+
+export class CreateCancellationError extends Error {
+  readonly stage: CreateCancellationStage;
+
+  constructor(stage: CreateCancellationStage) {
+    super("Operation cancelled.");
+    this.name = "CreateCancellationError";
+    this.stage = stage;
+  }
+}
+
+export class ClassifiedCreateError extends Error {
+  readonly reason: CreateFailureReason;
+
+  constructor(reason: CreateFailureReason, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ClassifiedCreateError";
+    this.reason = reason;
+  }
+}
+
+export function getCreateFailureReason(
+  error: unknown,
+  fallback: CreateFailureReason,
+): CreateFailureReason {
+  return error instanceof ClassifiedCreateError ? error.reason : fallback;
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import type { CreateTelemetryFailureStage } from "./telemetry";
+import type { CreateFailureStage } from "./create-outcome";
 import type { ComposerDeployResult } from "./tasks/deploy-with-composer";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "./types";
 
@@ -18,7 +18,7 @@ export type CreateProjectResult = {
   packageManager: PackageManager;
 };
 
-export type CreateCommandFailureStage = CreateTelemetryFailureStage | "parse_arguments";
+export type CreateCommandFailureStage = CreateFailureStage | "parse_arguments";
 
 export type CreateCommandSuccessResult = {
   schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import type { CreateFailureStage } from "./create-outcome";
+import type { CreateCancellationStage, CreateFailureStage } from "./create-outcome";
 import type { ComposerDeployResult } from "./tasks/deploy-with-composer";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "./types";
 
@@ -18,7 +18,10 @@ export type CreateProjectResult = {
   packageManager: PackageManager;
 };
 
-export type CreateCommandFailureStage = CreateFailureStage | "parse_arguments";
+export type CreateCommandFailureStage =
+  | CreateFailureStage
+  | CreateCancellationStage
+  | "parse_arguments";
 
 export type CreateCommandSuccessResult = {
   schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -4,6 +4,12 @@ import { createInterface } from "node:readline";
 import type { Writable } from "node:stream";
 
 import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
+import {
+  ClassifiedCreateError,
+  getCreateFailureReason,
+  type CreateFailureReason,
+  type CreateFailureStage,
+} from "../create-outcome";
 import type { PackageManager } from "../types";
 import { getErrorMessage, redactSecrets } from "../utils/errors";
 import {
@@ -75,6 +81,21 @@ export type ComposerDeployResult = {
     consoleUrl?: string;
   };
 };
+
+export type ComposerDeployExecutionResult =
+  | { ok: true; deployment: ComposerDeployResult }
+  | { ok: false; cancelled: true; stage: "select_workspace" }
+  | {
+      ok: false;
+      cancelled?: false;
+      stage: CreateFailureStage;
+      reason: CreateFailureReason;
+      error: unknown;
+    };
+
+type WorkspaceSelectionResult =
+  | { ok: true; workspace: PrismaWorkspace }
+  | { ok: false; cancelled: true };
 
 function stripResourcePrefix(id: string, prefix: "proj" | "wksp"): string {
   const marker = `${prefix}_`;
@@ -185,7 +206,8 @@ async function ensureProjectNameAvailable(options: {
   if (collisions.length === 0) return;
 
   const projectIds = collisions.map((project) => project.id).join(", ");
-  throw new Error(
+  throw new ClassifiedCreateError(
+    "project_name_collision",
     `A Prisma project named "${options.appName}" already exists in workspace ${workspaceLabel(
       options.workspace,
     )} (${options.workspace.id}). Choose a different project name or delete the existing project ` +
@@ -216,7 +238,8 @@ async function ensureAuthentication(options: {
     "login",
   ]);
   if (!options.allowInteractiveLogin || process.stdin.isTTY !== true) {
-    throw new Error(
+    throw new ClassifiedCreateError(
+      "not_authenticated",
       `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
     );
   }
@@ -232,7 +255,10 @@ async function ensureAuthentication(options: {
 
   const authenticatedState = await whoami();
   if (!authenticatedState.authenticated) {
-    throw new Error("Prisma sign-in completed without an active workspace session.");
+    throw new ClassifiedCreateError(
+      "authentication_failed",
+      "Prisma sign-in completed without an active workspace session.",
+    );
   }
   return authenticatedState;
 }
@@ -263,38 +289,47 @@ async function selectDeploymentWorkspace(options: {
   beforePrompt?: () => void;
   afterPrompt?: () => void;
   output: Writable;
-}): Promise<PrismaWorkspace | undefined> {
+}): Promise<WorkspaceSelectionResult> {
   const activeWorkspace = options.authState.workspace;
   if (!activeWorkspace) {
-    throw new Error("The active Prisma credential does not specify a workspace.");
+    throw new ClassifiedCreateError(
+      "workspace_missing",
+      "The active Prisma credential does not specify a workspace.",
+    );
   }
 
   if (options.workspace) {
     if (options.authState.source === "environment") {
       if (options.workspace === activeWorkspace.id || options.workspace === activeWorkspace.name) {
-        return activeWorkspace;
+        return { ok: true, workspace: activeWorkspace };
       }
-      throw new Error(
+      throw new ClassifiedCreateError(
+        "workspace_mismatch",
         `The environment credential is fixed to workspace ${workspaceLabel(
           activeWorkspace,
         )}. Unset it before using --workspace ${options.workspace}.`,
       );
     }
-    return useWorkspace({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      workspace: options.workspace,
-    });
+    return {
+      ok: true,
+      workspace: await useWorkspace({
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        workspace: options.workspace,
+      }),
+    };
   }
 
-  if (!options.shouldPrompt || process.stdin.isTTY !== true) return activeWorkspace;
+  if (!options.shouldPrompt || process.stdin.isTTY !== true) {
+    return { ok: true, workspace: activeWorkspace };
+  }
 
   const available = await runPrismaJsonCommand<WorkspaceListResult>({
     packageManager: options.packageManager,
     projectDir: options.projectDir,
     args: ["auth", "workspace", "list"],
   });
-  if (available.items.length <= 1) return activeWorkspace;
+  if (available.items.length <= 1) return { ok: true, workspace: activeWorkspace };
 
   options.beforePrompt?.();
   const selectedWorkspaceId = await select({
@@ -309,16 +344,21 @@ async function selectDeploymentWorkspace(options: {
   });
   if (isCancel(selectedWorkspaceId)) {
     cancel("Operation cancelled.", { output: options.output });
-    return;
+    return { ok: false, cancelled: true };
   }
   options.afterPrompt?.();
-  if (selectedWorkspaceId === activeWorkspace.id) return activeWorkspace;
+  if (selectedWorkspaceId === activeWorkspace.id) {
+    return { ok: true, workspace: activeWorkspace };
+  }
 
-  return useWorkspace({
-    packageManager: options.packageManager,
-    projectDir: options.projectDir,
-    workspace: selectedWorkspaceId,
-  });
+  return {
+    ok: true,
+    workspace: await useWorkspace({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      workspace: selectedWorkspaceId,
+    }),
+  };
 }
 
 export function parseComposerDeployResult(result: ComposerDeployCommandResult):
@@ -379,13 +419,14 @@ export async function deployNewProjectWithComposer(options: {
   output?: Writable;
   allowInteractiveLogin?: boolean;
   json?: boolean;
-  throwOnError?: boolean;
   workspace?: string;
-}): Promise<ComposerDeployResult | undefined> {
+}): Promise<ComposerDeployExecutionResult> {
   const output = options.output ?? process.stdout;
   const progress = options.verbose ? undefined : spinner({ output });
   let deploymentLog: ReturnType<typeof taskLog> | undefined;
   let progressRunning = false;
+  let failureStage: CreateFailureStage = "authenticate";
+  let failureReason: CreateFailureReason = "prisma_auth_command_failed";
   const showProgress = (message: string) => {
     if (!progress) return;
     if (progressRunning) {
@@ -413,8 +454,10 @@ export async function deployNewProjectWithComposer(options: {
     });
 
     showProgress("Checking Prisma workspace...");
+    failureStage = "select_workspace";
+    failureReason = "workspace_selection_failed";
     if (options.verbose) log.step("Checking Prisma workspace.", { output });
-    const selectedWorkspace = await selectDeploymentWorkspace({
+    const workspaceResult = await selectDeploymentWorkspace({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       shouldPrompt: options.shouldPromptForWorkspace,
@@ -424,9 +467,12 @@ export async function deployNewProjectWithComposer(options: {
       afterPrompt: () => showProgress("Selecting Prisma workspace..."),
       ...(options.workspace ? { workspace: options.workspace } : {}),
     });
-    if (!selectedWorkspace) return;
+    if (!workspaceResult.ok) return { ok: false, cancelled: true, stage: "select_workspace" };
+    const selectedWorkspace = workspaceResult.workspace;
 
     showProgress("Checking Prisma project name...");
+    failureStage = "check_project_name";
+    failureReason = "project_lookup_failed";
     if (options.verbose) log.step("Checking Prisma project name.", { output });
     await ensureProjectNameAvailable({
       appName: options.appName,
@@ -436,6 +482,8 @@ export async function deployNewProjectWithComposer(options: {
     });
 
     showProgress("Building for deployment...");
+    failureStage = "build";
+    failureReason = "build_failed";
     if (options.verbose) log.step("Building for deployment.", { output });
     const build = getRunScriptArgs(options.packageManager, "build");
     await runSetupCommand({
@@ -448,6 +496,8 @@ export async function deployNewProjectWithComposer(options: {
     });
 
     clearProgress();
+    failureStage = "composer_deploy";
+    failureReason = "composer_deploy_failed";
     const deployCommand = getPackageExecutionCommand(options.packageManager, [
       PRISMA_PLATFORM_CLI_PACKAGE,
       "deploy",
@@ -493,11 +543,14 @@ export async function deployNewProjectWithComposer(options: {
     if (options.verbose) log.success("Deployed to Prisma.", { output });
     const workspace = details?.workspace ?? selectedWorkspace;
     return {
-      appName,
-      ...(deployment?.appUrl ? { appUrl: deployment.appUrl } : {}),
-      ...(deployment?.serviceId ? { serviceId: deployment.serviceId } : {}),
-      ...(workspace ? { workspace } : {}),
-      project: details?.project ?? { name: appName },
+      ok: true,
+      deployment: {
+        appName,
+        ...(deployment?.appUrl ? { appUrl: deployment.appUrl } : {}),
+        ...(deployment?.serviceId ? { serviceId: deployment.serviceId } : {}),
+        ...(workspace ? { workspace } : {}),
+        project: details?.project ?? { name: appName },
+      },
     };
   } catch (error) {
     if (deploymentLog) {
@@ -508,7 +561,11 @@ export async function deployNewProjectWithComposer(options: {
     }
     progressRunning = false;
     log.error(`Deploy failed: ${getErrorMessage(error)}`, { output });
-    if (options.throwOnError) throw error;
-    return;
+    return {
+      ok: false,
+      stage: failureStage,
+      reason: getCreateFailureReason(error, failureReason),
+      error,
+    };
   }
 }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 
 import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
+import {
+  ClassifiedCreateError,
+  CreateCancellationError,
+  getCreateFailureReason,
+  type CreateFailureReason,
+  type CreateFailureStage,
+} from "../create-outcome";
 import type { CreateNextStep } from "../result";
 import { scaffoldCreateSharedTemplates } from "../templates/render-create-template";
 import {
@@ -65,9 +72,22 @@ export type PrismaSetupExecutionResult =
       gitInitialization?: GitInitializationResult;
       warnings: string[];
     }
-  | { ok: false; error?: unknown; errorReported?: boolean };
+  | {
+      ok: false;
+      cancelled: true;
+      stage: "select_workspace";
+      errorReported?: boolean;
+    }
+  | {
+      ok: false;
+      cancelled?: false;
+      stage: CreateFailureStage;
+      reason: CreateFailureReason;
+      error?: unknown;
+      errorReported?: boolean;
+    };
 
-async function promptForDatabaseProvider(output: Writable): Promise<DatabaseProvider | undefined> {
+async function promptForDatabaseProvider(output: Writable): Promise<DatabaseProvider> {
   const databaseProvider = await select({
     message: "Select your database",
     initialValue: DEFAULT_DATABASE_PROVIDER,
@@ -79,12 +99,12 @@ async function promptForDatabaseProvider(output: Writable): Promise<DatabaseProv
   });
   if (isCancel(databaseProvider)) {
     cancel("Operation cancelled.", { output });
-    return;
+    throw new CreateCancellationError("database_provider");
   }
   return DatabaseProviderSchema.parse(databaseProvider);
 }
 
-async function promptForAuthoringStyle(output: Writable): Promise<AuthoringStyle | undefined> {
+async function promptForAuthoringStyle(output: Writable): Promise<AuthoringStyle> {
   const authoring = await select({
     message: "Choose contract authoring style",
     initialValue: DEFAULT_AUTHORING,
@@ -96,7 +116,7 @@ async function promptForAuthoringStyle(output: Writable): Promise<AuthoringStyle
   });
   if (isCancel(authoring)) {
     cancel("Operation cancelled.", { output });
-    return;
+    throw new CreateCancellationError("authoring_style");
   }
   return AuthoringStyleSchema.parse(authoring);
 }
@@ -115,7 +135,7 @@ function getPackageManagerHint(option: PackageManager, detected: PackageManager)
 async function promptForPackageManager(
   detected: PackageManager,
   output: Writable,
-): Promise<PackageManager | undefined> {
+): Promise<PackageManager> {
   const packageManager = await select({
     message: "Choose package manager",
     initialValue: detected,
@@ -128,12 +148,12 @@ async function promptForPackageManager(
   });
   if (isCancel(packageManager)) {
     cancel("Operation cancelled.", { output });
-    return;
+    throw new CreateCancellationError("package_manager");
   }
   return PackageManagerSchema.parse(packageManager);
 }
 
-async function promptForDeployment(output: Writable): Promise<boolean | undefined> {
+async function promptForDeployment(output: Writable): Promise<boolean> {
   const shouldDeploy = await confirm({
     message: "Deploy to Prisma now?",
     initialValue: true,
@@ -141,7 +161,7 @@ async function promptForDeployment(output: Writable): Promise<boolean | undefine
   });
   if (isCancel(shouldDeploy)) {
     cancel("Operation cancelled.", { output });
-    return;
+    throw new CreateCancellationError("deployment_intent");
   }
   return Boolean(shouldDeploy);
 }
@@ -149,43 +169,44 @@ async function promptForDeployment(output: Writable): Promise<boolean | undefine
 export async function collectPrismaSetupContext(
   input: PrismaSetupCommandInput,
   options: { projectDir?: string; template?: CreateTemplate } = {},
-): Promise<PrismaSetupContext | undefined> {
+): Promise<PrismaSetupContext> {
   const projectDir = path.resolve(options.projectDir ?? process.cwd());
   const { json, output, useDefaults } = resolveExecutionSettings(input);
 
   const databaseProvider =
     input.provider ??
     (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider(output));
-  if (!databaseProvider) return;
-
   const authoring =
     input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : await promptForAuthoringStyle(output));
-  if (!authoring) return;
-
   const detectedPackageManager = await detectPackageManager(projectDir);
   const packageManager =
     input.packageManager ??
     (useDefaults
       ? detectedPackageManager
       : await promptForPackageManager(detectedPackageManager, output));
-  if (!packageManager) return;
-
   if (packageManager === "deno" && databaseProvider !== "postgres") {
-    throw new Error("Deno support currently requires PostgreSQL.");
+    throw new ClassifiedCreateError(
+      "unsupported_configuration",
+      "Deno support currently requires PostgreSQL.",
+    );
   }
   if (packageManager === "deno" && options.template && options.template !== "minimal") {
-    throw new Error("Deno support currently requires the minimal template.");
+    throw new ClassifiedCreateError(
+      "unsupported_configuration",
+      "Deno support currently requires the minimal template.",
+    );
   }
   if (packageManager === "deno" && input.deploy === true) {
-    throw new Error("Prisma Compute does not support Deno deployments yet. Use --no-deploy.");
+    throw new ClassifiedCreateError(
+      "unsupported_configuration",
+      "Prisma Compute does not support Deno deployments yet. Use --no-deploy.",
+    );
   }
 
   const shouldDeploy =
     packageManager === "deno"
       ? false
       : (input.deploy ?? (json ? true : useDefaults ? false : await promptForDeployment(output)));
-  if (shouldDeploy === undefined) return;
-
   return {
     projectDir,
     verbose: input.verbose === true,
@@ -433,12 +454,16 @@ export async function executePrismaSetupContext(
     : (options.progressSpinner ?? spinner({ output: context.output }));
   const ownsProgress = progress !== undefined && !options.progressSpinner;
   let gitInitialization: GitInitializationResult | undefined;
+  let setupStage: CreateFailureStage = "initialize_prisma";
+  let setupReason: CreateFailureReason = "prisma_init_failed";
   if (ownsProgress) progress.start("Creating Prisma 8 project...");
 
   try {
     progress?.message("Preparing Prisma 8 project files...");
     await runPrismaInit(context, projectDir);
 
+    setupStage = "configure_project";
+    setupReason = "project_configuration_failed";
     await scaffoldCreateSharedTemplates({
       projectDir,
       projectName,
@@ -463,24 +488,34 @@ export async function executePrismaSetupContext(
     progress?.message(
       `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
     );
+    setupStage = "install_dependencies";
+    setupReason = "dependency_install_failed";
     await installProjectDependencies(context.packageManager, projectDir, {
       verbose: context.verbose,
       json: context.json,
     });
 
     progress?.message("Installing Prisma agent skills...");
+    setupStage = "initialize_agent_skills";
+    setupReason = "agent_skills_init_failed";
     await initializeAgentSkills(context, projectDir);
 
     progress?.message("Generating Prisma 8 contract artifacts...");
+    setupStage = "emit_contract";
+    setupReason = "contract_emit_failed";
     await emitContract(context, projectDir);
 
     if (context.databaseProvider === "postgres") {
       progress?.message("Authoring the baseline migration...");
+      setupStage = "plan_migration";
+      setupReason = "migration_plan_failed";
       await planBaselineMigration(context, projectDir);
     }
 
     if (options.initializeGit) {
       progress?.message("Initializing Git repository...");
+      setupStage = "initialize_git";
+      setupReason = "git_initialization_failed";
       gitInitialization = await initializeGitRepository(projectDir);
     }
     progress?.stop("Prisma 8 project ready.");
@@ -494,12 +529,18 @@ export async function executePrismaSetupContext(
   } catch (error) {
     progress?.error("Could not create Prisma 8 project.");
     cancel(getErrorMessage(error), { output: context.output });
-    return { ok: false, error, errorReported: true };
+    return {
+      ok: false,
+      stage: setupStage,
+      reason: getCreateFailureReason(error, setupReason),
+      error,
+      errorReported: true,
+    };
   }
 
   let deployment: ComposerDeployResult | undefined;
   if (context.shouldDeploy) {
-    deployment = await deployNewProjectWithComposer({
+    const deploymentResult = await deployNewProjectWithComposer({
       appName: projectName,
       packageManager: context.packageManager,
       projectDir,
@@ -508,10 +549,26 @@ export async function executePrismaSetupContext(
       output: context.output,
       allowInteractiveLogin: !context.json,
       json: context.json,
-      throwOnError: context.json,
       ...(context.workspace ? { workspace: context.workspace } : {}),
     });
-    if (!deployment) return { ok: false, errorReported: true };
+    if (!deploymentResult.ok) {
+      if (deploymentResult.cancelled) {
+        return {
+          ok: false,
+          cancelled: true,
+          stage: deploymentResult.stage,
+          errorReported: true,
+        };
+      }
+      return {
+        ok: false,
+        stage: deploymentResult.stage,
+        reason: deploymentResult.reason,
+        error: deploymentResult.error,
+        errorReported: true,
+      };
+    }
+    deployment = deploymentResult.deployment;
   }
 
   const nextSteps = buildNextSteps(context, options);

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -1,17 +1,18 @@
 import type { CreatePromptContext } from "../commands/create";
+import type {
+  CreateCancellationStage,
+  CreateFailureReason,
+  CreateFailureStage,
+} from "../create-outcome";
 import type { CreateCommandInput } from "../types";
 
 import { trackCliTelemetry } from "./client";
 
 export const CREATE_PRISMA_NEXT_COMPLETED_EVENT = "cli:create_prisma_next_command_completed";
 export const CREATE_PRISMA_NEXT_FAILED_EVENT = "cli:create_prisma_next_command_failed";
+export const CREATE_PRISMA_NEXT_CANCELLED_EVENT = "cli:create_prisma_next_command_cancelled";
 
-export type CreateTelemetryFailureStage =
-  | "validate_input"
-  | "collect_context"
-  | "scaffold_template"
-  | "prisma_setup"
-  | "unknown";
+export type CreateTelemetryFailureStage = CreateFailureStage;
 
 function getTargetDirectoryState(context: CreatePromptContext): string {
   if (!context.targetPathState.exists) {
@@ -30,6 +31,7 @@ function getBaseCreateProperties(
   context?: CreatePromptContext,
 ): Record<string, boolean | number | string | string[] | null> {
   return {
+    "telemetry-schema-version": 2,
     command: "create",
     "uses-defaults": input.yes === true || input.json === true,
     json: input.json === true,
@@ -83,12 +85,27 @@ export async function trackCreateFailed(params: {
   durationMs: number;
   error?: unknown;
   stage: CreateTelemetryFailureStage;
+  reason: CreateFailureReason;
 }): Promise<void> {
   await trackCliTelemetry(CREATE_PRISMA_NEXT_FAILED_EVENT, {
     ...getBaseCreateProperties(params.input, params.context),
     "duration-ms": params.durationMs,
     "failure-stage": params.stage,
+    "failure-reason": params.reason,
     "error-name": getErrorName(params.error),
     "error-code": getErrorCode(params.error),
+  });
+}
+
+export async function trackCreateCancelled(params: {
+  input: CreateCommandInput;
+  context?: CreatePromptContext;
+  durationMs: number;
+  stage: CreateCancellationStage;
+}): Promise<void> {
+  await trackCliTelemetry(CREATE_PRISMA_NEXT_CANCELLED_EVENT, {
+    ...getBaseCreateProperties(params.input, params.context),
+    "duration-ms": params.durationMs,
+    "cancellation-stage": params.stage,
   });
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,5 +1,7 @@
 export {
+  trackCreateCancelled,
   trackCreateCompleted,
   trackCreateFailed,
   type CreateTelemetryFailureStage,
 } from "./create";
+export type { CreateCancellationStage, CreateFailureReason } from "../create-outcome";

--- a/tests/deploy-with-composer.test.ts
+++ b/tests/deploy-with-composer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
 
 import {
+  deployNewProjectWithComposer,
   findProjectNameCollisions,
   getConsoleProjectUrl,
   parseComposerDeployResult,
@@ -131,5 +133,38 @@ describe("parseComposerDeployResult", () => {
 
   test("returns undefined when Composer has no deployment summary", () => {
     expect(parseComposerDeployResult({ summary: null })).toBeUndefined();
+  });
+});
+
+describe("deployNewProjectWithComposer", () => {
+  test("returns the authentication failure instead of swallowing it", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      const result = await deployNewProjectWithComposer({
+        appName: "test-app",
+        packageManager: "npm",
+        projectDir: process.cwd(),
+        shouldPromptForWorkspace: false,
+        verbose: false,
+        output: new PassThrough(),
+        allowInteractiveLogin: false,
+        json: true,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        stage: "authenticate",
+        reason: "prisma_auth_command_failed",
+      });
+      if (result.ok || result.cancelled) throw new Error("Expected a classified failure.");
+      expect(result.error).toBeDefined();
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+    }
   });
 });

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -205,7 +205,7 @@ describe("create-prisma e2e", () => {
     expect(JSON.parse(stdout)).toMatchObject({
       schemaVersion: 1,
       ok: false,
-      error: { stage: "prisma_setup" },
+      error: { stage: "initialize_prisma" },
     });
     expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -8,8 +8,10 @@ const trackCliTelemetry = mock(async () => {});
 mock.module("../src/telemetry/client", () => ({ trackCliTelemetry }));
 
 const {
+  CREATE_PRISMA_NEXT_CANCELLED_EVENT,
   CREATE_PRISMA_NEXT_COMPLETED_EVENT,
   CREATE_PRISMA_NEXT_FAILED_EVENT,
+  trackCreateCancelled,
   trackCreateCompleted,
   trackCreateFailed,
 } = await import("../src/telemetry/create");
@@ -41,6 +43,7 @@ describe("create telemetry", () => {
       CREATE_PRISMA_NEXT_COMPLETED_EVENT,
       expect.objectContaining({
         command: "create",
+        "telemetry-schema-version": 2,
         template: "hono",
         "database-provider": "postgres",
         "should-deploy": true,
@@ -49,20 +52,45 @@ describe("create telemetry", () => {
     );
   });
 
-  test("tracks setup failures", async () => {
+  test("tracks a normalized setup failure without its raw message", async () => {
     await trackCreateFailed({
       input: createInput,
       context: createContext,
       durationMs: 456,
-      error: Object.assign(new Error("boom"), { code: "ERR_TEST" }),
-      stage: "prisma_setup",
+      error: Object.assign(new Error("DATABASE_URL=secret"), { code: "ERR_TEST" }),
+      stage: "plan_migration",
+      reason: "migration_plan_failed",
     });
-    expect(trackCliTelemetry).toHaveBeenCalledWith(
-      CREATE_PRISMA_NEXT_FAILED_EVENT,
+    const [event, properties] = trackCliTelemetry.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(event).toBe(CREATE_PRISMA_NEXT_FAILED_EVENT);
+    expect(properties).toEqual(
       expect.objectContaining({
         "duration-ms": 456,
         "error-code": "ERR_TEST",
-        "failure-stage": "prisma_setup",
+        "failure-stage": "plan_migration",
+        "failure-reason": "migration_plan_failed",
+      }),
+    );
+    expect(properties).not.toHaveProperty("error-message");
+    expect(JSON.stringify(properties)).not.toContain("secret");
+  });
+
+  test("tracks prompt cancellation as a separate outcome", async () => {
+    await trackCreateCancelled({
+      input: createInput,
+      context: createContext,
+      durationMs: 789,
+      stage: "select_workspace",
+    });
+    expect(trackCliTelemetry).toHaveBeenCalledWith(
+      CREATE_PRISMA_NEXT_CANCELLED_EVENT,
+      expect.objectContaining({
+        "duration-ms": 789,
+        "cancellation-stage": "select_workspace",
+        "should-deploy": true,
       }),
     );
   });


### PR DESCRIPTION
## Summary

Fixes the telemetry gaps exposed by the first ~22 hours of `create-prisma@0.10.0`:

- records prompt cancellation as a separate terminal outcome instead of a technical failure
- records the exact cancelled prompt without recording the selected value
- replaces the broad `prisma_setup` bucket with precise setup and deployment stages
- adds a safe normalized `failure-reason` to every technical failure
- preserves the real deployment error through the normal human-readable path instead of swallowing it
- keeps raw error messages, paths, project/workspace names, emails, and credentials out of telemetry
- marks all new events/properties with `telemetry-schema-version: 2`

Dashboard: https://us.posthog.com/project/60295/dashboard/2038941

## Why

The initial `0.10.0` snapshot showed:

- 34.6% technical success after manually excluding prompt abandonment
- 66.1% local-only success versus 8.1% with deployment enabled
- 0 successful Windows deployments in the sample
- all post-context failures reported as `prisma_setup`
- most deployment-intent failures missing actionable metadata

The CLI could identify that deployment was unhealthy, but not whether auth, workspace selection, project lookup, build, migration planning, or Composer deployment was responsible.

## Event model

Existing completed and failed event names remain stable.

### Cancelled

`cli:create_prisma_next_command_cancelled`

Adds `cancellation-stage` with one of:

- `project_name`
- `template`
- `database_provider`
- `authoring_style`
- `package_manager`
- `deployment_intent`
- `select_workspace`

### Failed

Adds `failure-stage` and `failure-reason`. Stages now distinguish:

- input/context/template scaffolding
- Prisma initialization and project configuration
- dependency and agent-skill installation
- contract emit and migration planning
- Git initialization
- authentication and workspace selection
- project-name lookup
- build
- Composer deploy

Reasons are a closed, non-sensitive taxonomy such as `not_authenticated`, `workspace_mismatch`, `project_name_collision`, `build_failed`, and `composer_deploy_failed`. Existing `error-name` and `error-code` remain supplemental; raw messages are never sent.

## Error propagation

`deployNewProjectWithComposer` now returns a discriminated success/failure/cancellation result. Human and `--json` modes therefore report the same underlying failure while telemetry receives the exact stage and normalized reason.

The structured JSON failure `stage` is now precise as well—for example, an unavailable Prisma CLI reports `initialize_prisma` instead of `prisma_setup`.

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:unit` — 42 passed
- `bun run test:e2e` — 7 passed

The E2E suite covers generated Prisma Postgres, Next.js with a TypeScript contract, Deno, unsupported combinations, deterministic JSON, and classified setup failure output.
