### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -127,7 +127,8 @@ async function main(): Promise<void> {
 
 This PR bumps \`create-prisma\` to \`${newVersion}\`.
 
-When this PR merges, GitHub Actions publishes to npm using trusted publishing.
+**Squash-merge this PR.** The release workflow reads the squash commit title to
+publish to npm using trusted publishing; a merge commit will skip the release.
 `;
 
   await $`gh pr create --title ${prTitle} --body ${prBody} --base main --head ${branchName}`;


### PR DESCRIPTION
## Release v0.11.0

Publishes the current main branch, including the telemetry outcome fixes from #77.

Version 0.11.0 is already present in package.json but was never published: #75 and #76 used merge commits, so the release workflow correctly skipped them.

This also updates the generated release-PR instructions to explicitly require squash merging.

**Squash-merge this PR.** The resulting commit title triggers trusted publishing.