### PR TITLE
fix: preserve deployment failure diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,42 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  windows-smoke:
+    name: Windows creation smoke
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'labeled' || github.event.label.name == 'release:next')
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.18.0"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Scaffold and build a Prisma app
+        run: >-
+          bun test --timeout 300000
+          --test-name-pattern "builds a Next.js app with a TypeScript-authored contract"
+          ./tests/e2e/create-prisma.e2e.test.ts
+
   preview:
     name: Publish PR preview
+    needs: windows-smoke
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action != 'labeled' || github.event.label.name == 'release:next')
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -52,8 +52,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Scaffold and build a Prisma app
+        env:
+          CREATE_PRISMA_E2E_TIMEOUT_MS: "600000"
         run: >-
-          bun test --timeout 300000
+          bun test --timeout 600000
           --test-name-pattern "builds a Next.js app with a TypeScript-authored contract"
           ./tests/e2e/create-prisma.e2e.test.ts
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,19 +29,22 @@ jobs:
       (github.event.action != 'labeled' || github.event.label.name == 'release:next')
     runs-on: windows-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22.18.0"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn dlx create-prisma@latest my-app
 bunx create-prisma@latest my-app
 ```
 
-The CLI initializes Prisma 8 with `prisma@next`, installs dependencies, emits the contract, and generates a deployable Composer app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
+The CLI initializes Prisma 8 with `prisma@latest`, installs dependencies, emits the contract, and generates a deployable Composer app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
 
 The deployment prompt is:
 

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -18,7 +18,7 @@ export const dependencyVersionMap = {
   mongodb: "^7.1.0",
   "mongodb-memory-server": "^11.1.0",
   nitro: "^3.0.260610-beta",
-  prisma: "8.0.0-rc.12",
+  prisma: "latest",
   // The ORM runtime's timestamp columns need a global Temporal, which no
   // stable Node or Bun ships yet.
   "temporal-polyfill": "^1.0.4",
@@ -26,17 +26,11 @@ export const dependencyVersionMap = {
   typescript: "^5.9.3",
 } as const;
 
-// Pinned, not `prisma@next`: the scaffold's own invocations must not float
-// with the dist-tag — the rc line ships breaking changes between releases
-// (rc.10 broke every create). The pin must move in lockstep with the pins
-// above: the CLI bundles its own copies of @prisma/composer-cli and
-// @prisma/orm-toolchain, and those must match the @prisma/composer* and
-// @prisma/orm-* versions this map installs into the project.
-export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@8.0.0-rc.12";
-// Deno runs the same pinned consolidated CLI. The former `prisma-next`
-// fallback is dead: under Deno the bare `npm:prisma-next` specifier resolves
-// to the highest non-prerelease version (0.12.0, frozen), which cannot emit
-// against the ORM releases pinned above.
+// `prisma@next` is a compatibility tag that may intentionally lag behind the
+// current release. New scaffolds and every delegated command use `latest`.
+export const PRISMA_PLATFORM_CLI_PACKAGE = "prisma@latest";
+// Deno runs the same consolidated CLI. The former `prisma-next` fallback is
+// frozen and cannot emit against the current ORM releases.
 export const PRISMA_DENO_CLI_PACKAGE = PRISMA_PLATFORM_CLI_PACKAGE;
 
 export type AvailableDependency = keyof typeof dependencyVersionMap;

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -22,9 +22,23 @@ import { runSetupCommand } from "../utils/run-command";
 
 type PrismaCliEnvelope<Result = unknown> = {
   ok: boolean;
+  command?: string;
+  commandId?: string;
   result?: Result;
-  error?: { summary?: string; message?: string; why?: string };
+  error?: { code?: string; summary?: string; message?: string; why?: string };
 };
+
+export class PrismaCliCommandError extends Error {
+  readonly prismaCliCommand?: string;
+  readonly prismaCliErrorCode?: string;
+
+  constructor(options: { message: string; command?: string; code?: string }) {
+    super(options.message);
+    this.name = "PrismaCliCommandError";
+    this.prismaCliCommand = options.command;
+    this.prismaCliErrorCode = options.code;
+  }
+}
 
 type PrismaWorkspace = {
   id: string;
@@ -175,11 +189,16 @@ async function runPrismaJsonCommand<Result>(options: {
 
   if (result.exitCode !== 0 || !envelope.ok || envelope.result === undefined) {
     const summary = envelope.error?.summary ?? envelope.error?.message;
-    throw new Error(
-      [summary, envelope.error?.why].filter(Boolean).join(": ") ||
+    throw new PrismaCliCommandError({
+      message:
+        [summary, envelope.error?.why].filter(Boolean).join(": ") ||
         result.stderr.trim() ||
         "Prisma CLI command failed.",
-    );
+      ...(envelope.commandId || envelope.command
+        ? { command: envelope.commandId ?? envelope.command }
+        : {}),
+      ...(envelope.error?.code ? { code: envelope.error.code } : {}),
+    });
   }
   return envelope.result;
 }

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -22,6 +22,7 @@ const expectedRejectionReasons = new Set<CreateFailureReason>([
   "target_directory_not_empty",
   "unsupported_configuration",
   "not_authenticated",
+  "workspace_missing",
   "workspace_mismatch",
   "project_name_collision",
 ]);

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -14,6 +14,22 @@ export const CREATE_PRISMA_NEXT_CANCELLED_EVENT = "cli:create_prisma_next_comman
 
 export type CreateTelemetryFailureStage = CreateFailureStage;
 
+const expectedRejectionReasons = new Set<CreateFailureReason>([
+  "invalid_input",
+  "unsupported_node_version",
+  "invalid_project_name",
+  "target_path_not_directory",
+  "target_directory_not_empty",
+  "unsupported_configuration",
+  "not_authenticated",
+  "workspace_mismatch",
+  "project_name_collision",
+]);
+
+function getFailureClass(reason: CreateFailureReason): "expected_rejection" | "technical_failure" {
+  return expectedRejectionReasons.has(reason) ? "expected_rejection" : "technical_failure";
+}
+
 function getTargetDirectoryState(context: CreatePromptContext): string {
   if (!context.targetPathState.exists) {
     return "new";
@@ -68,6 +84,18 @@ function getErrorCode(error: unknown): number | string | null {
   return typeof code === "number" || typeof code === "string" ? code : null;
 }
 
+function getPrismaCliFailureProperty(
+  error: unknown,
+  property: "prismaCliCommand" | "prismaCliErrorCode",
+): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const value = Reflect.get(error, property);
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 export async function trackCreateCompleted(params: {
   input: CreateCommandInput;
   context: CreatePromptContext;
@@ -90,10 +118,13 @@ export async function trackCreateFailed(params: {
   await trackCliTelemetry(CREATE_PRISMA_NEXT_FAILED_EVENT, {
     ...getBaseCreateProperties(params.input, params.context),
     "duration-ms": params.durationMs,
+    "failure-class": getFailureClass(params.reason),
     "failure-stage": params.stage,
     "failure-reason": params.reason,
     "error-name": getErrorName(params.error),
     "error-code": getErrorCode(params.error),
+    "prisma-cli-command": getPrismaCliFailureProperty(params.error, "prismaCliCommand"),
+    "prisma-cli-error-code": getPrismaCliFailureProperty(params.error, "prismaCliErrorCode"),
   });
 }
 

--- a/src/utils/node-version.ts
+++ b/src/utils/node-version.ts
@@ -16,7 +16,7 @@ export function supportsPrisma(nodeVersion = process.versions.node): boolean {
 
 export function getUnsupportedNodeMessage(nodeVersion = process.versions.node): string {
   return [
-    `Node.js ${nodeVersion} is unsupported by create-prisma@next.`,
+    `Node.js ${nodeVersion} is unsupported by create-prisma@latest.`,
     "Required: Node.js 22.18 or newer.",
     "Update Node.js and run the command again.",
   ].join("\n");

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -8,7 +8,7 @@ describe("Prisma 8 dependency versions", () => {
     expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.8");
     expect(getDependencyVersion("@prisma/composer")).toBe("0.16.0");
     expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.16.0");
-    expect(getDependencyVersion("prisma")).toBe("8.0.0-rc.12");
+    expect(getDependencyVersion("prisma")).toBe("latest");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.112");
   });

--- a/tests/deploy-with-composer.test.ts
+++ b/tests/deploy-with-composer.test.ts
@@ -7,6 +7,7 @@ import {
   getConsoleProjectUrl,
   parseComposerDeployResult,
   parsePrismaCliEnvelope,
+  PrismaCliCommandError,
 } from "../src/tasks/deploy-with-composer";
 import { getErrorMessage, redactSecrets } from "../src/utils/errors";
 
@@ -90,6 +91,46 @@ describe("parsePrismaCliEnvelope", () => {
         ].join("\n"),
       ),
     ).toEqual({ ok: true, result: { summary: null } });
+  });
+
+  test("preserves stable command and error codes from a failure envelope", () => {
+    const envelope = parsePrismaCliEnvelope(
+      JSON.stringify({
+        kind: "result",
+        envelope: {
+          ok: false,
+          commandId: "app.deploy",
+          error: {
+            code: "APP.DEPLOY_FAILED",
+            summary: "Deployment failed",
+            why: "The compute service was not created",
+          },
+        },
+      }),
+    );
+
+    expect(envelope).toMatchObject({
+      ok: false,
+      commandId: "app.deploy",
+      error: { code: "APP.DEPLOY_FAILED" },
+    });
+  });
+});
+
+describe("PrismaCliCommandError", () => {
+  test("exposes only stable structured fields for telemetry", () => {
+    const error = new PrismaCliCommandError({
+      message: "Deployment failed",
+      command: "app.deploy",
+      code: "APP.DEPLOY_FAILED",
+    });
+
+    expect(error).toMatchObject({
+      name: "PrismaCliCommandError",
+      message: "Deployment failed",
+      prismaCliCommand: "app.deploy",
+      prismaCliErrorCode: "APP.DEPLOY_FAILED",
+    });
   });
 });
 

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -420,6 +420,14 @@ describe("create-prisma e2e", () => {
       expect(await pathExists(path.join(projectDir, "src/prisma/generated/contract.d.ts"))).toBe(
         true,
       );
+      expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
+      expect(await pathExists(path.join(projectDir, "migrations/app"))).toBe(true);
+      expect(
+        await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
+      ).toBe(true);
+      expect(
+        await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
+      ).toBe(true);
 
       await runCommand(projectDir, ["bun", "run", "build"]);
       await runCommand(projectDir, ["bunx", "tsc", "--noEmit"]);

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -368,7 +368,7 @@ describe("create-prisma e2e", () => {
       expect(
         await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
       ).toBe(true);
-      expect(packageJson.devDependencies.prisma).toBe("8.0.0-rc.12");
+      expect(packageJson.devDependencies.prisma).toBe("latest");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
       expect(packageJson.scripts.deploy).toContain("bun run composer:deploy");
       expect(packageJson.overrides.effect).toBe("4.0.0-rc.112");

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -69,12 +69,47 @@ describe("create telemetry", () => {
     expect(properties).toEqual(
       expect.objectContaining({
         "duration-ms": 456,
+        "failure-class": "technical_failure",
         "error-code": "ERR_TEST",
         "failure-stage": "plan_migration",
         "failure-reason": "migration_plan_failed",
       }),
     );
     expect(properties).not.toHaveProperty("error-message");
+    expect(JSON.stringify(properties)).not.toContain("secret");
+  });
+
+  test("separates expected guard rejections from technical failures", async () => {
+    await trackCreateFailed({
+      input: createInput,
+      context: createContext,
+      durationMs: 10,
+      stage: "collect_context",
+      reason: "target_directory_not_empty",
+    });
+    const [, properties] = trackCliTelemetry.mock.calls[0] as [string, Record<string, unknown>];
+    expect(properties["failure-class"]).toBe("expected_rejection");
+  });
+
+  test("tracks stable Prisma CLI failure fields without raw output", async () => {
+    await trackCreateFailed({
+      input: createInput,
+      context: createContext,
+      durationMs: 456,
+      error: Object.assign(new Error("token=secret"), {
+        prismaCliCommand: "app.deploy",
+        prismaCliErrorCode: "APP.DEPLOY_FAILED",
+      }),
+      stage: "composer_deploy",
+      reason: "composer_deploy_failed",
+    });
+    const [, properties] = trackCliTelemetry.mock.calls[0] as [string, Record<string, unknown>];
+    expect(properties).toEqual(
+      expect.objectContaining({
+        "prisma-cli-command": "app.deploy",
+        "prisma-cli-error-code": "APP.DEPLOY_FAILED",
+      }),
+    );
     expect(JSON.stringify(properties)).not.toContain("secret");
   });
 

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -89,9 +89,13 @@ describe("create telemetry", () => {
         reason,
       });
     }
-    for (const [, properties] of trackCliTelemetry.mock.calls as Array<
-      [string, Record<string, unknown>]
-    >) {
+    const calls = trackCliTelemetry.mock.calls as Array<[string, Record<string, unknown>]>;
+    expect(calls).toHaveLength(2);
+    expect(calls.map(([, properties]) => properties["failure-reason"])).toEqual([
+      "target_directory_not_empty",
+      "workspace_missing",
+    ]);
+    for (const [, properties] of calls) {
       expect(properties["failure-class"]).toBe("expected_rejection");
     }
   });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -79,16 +79,21 @@ describe("create telemetry", () => {
     expect(JSON.stringify(properties)).not.toContain("secret");
   });
 
-  test("separates expected guard rejections from technical failures", async () => {
-    await trackCreateFailed({
-      input: createInput,
-      context: createContext,
-      durationMs: 10,
-      stage: "collect_context",
-      reason: "target_directory_not_empty",
-    });
-    const [, properties] = trackCliTelemetry.mock.calls[0] as [string, Record<string, unknown>];
-    expect(properties["failure-class"]).toBe("expected_rejection");
+  test("separates expected input and environment rejections from technical failures", async () => {
+    for (const reason of ["target_directory_not_empty", "workspace_missing"] as const) {
+      await trackCreateFailed({
+        input: createInput,
+        context: createContext,
+        durationMs: 10,
+        stage: reason === "workspace_missing" ? "select_workspace" : "collect_context",
+        reason,
+      });
+    }
+    for (const [, properties] of trackCliTelemetry.mock.calls as Array<
+      [string, Record<string, unknown>]
+    >) {
+      expect(properties["failure-class"]).toBe("expected_rejection");
+    }
   });
 
   test("tracks stable Prisma CLI failure fields without raw output", async () => {


### PR DESCRIPTION
## Summary

- use `prisma@latest` for generated dependencies and every delegated Prisma CLI command, including Deno
- preserve the official Prisma CLI `commandId` and `error.code` from `--json` failure envelopes
- classify failed runs as `technical_failure` or `expected_rejection` without collecting raw messages or command output
- gate PR preview publishing on a Windows Next.js scaffold-and-build smoke test

## Why

`prisma@next` is a compatibility tag and may intentionally lag behind the current Prisma 8 release. New projects should resolve the current `prisma@latest`; their lockfile then records the exact resolved version.

`create-prisma@0.11.0` also records broad authentication and Composer deployment buckets, which hides the upstream failure responsible for each run. Expected guards such as a non-empty target directory and an unsupported Node version made the dashboard technical-failure rate look worse than it was.

This keeps the normalized create-prisma stage/reason and adds only stable, privacy-safe Prisma CLI protocol fields. The PostHog reliability insights have also been updated to show expected rejections separately from genuine technical failures.

## Windows verification

The repository had no Windows CI. The new hosted-runner smoke test exercises framework scaffolding, Prisma initialization, dependency installation, agent skills, contract emission, baseline migration generation, and the framework build before a preview can publish.

Authenticated Prisma deployment cannot run in CI yet because this repository has no Prisma service credential secret. Once this change is released, production failures will identify the exact auth or deploy `error.code`; a full cloud canary can be added when a dedicated test workspace and credential are available.

## Verification

- `prisma@latest` resolved to `8.0.0-rc.12`
- `bunx prisma@latest --version`
- `bun run format`
- `bun run check`
- `bun run typecheck`
- `bun run test:unit` (46 passing)
- full create-prisma E2E suite (7 passing)
  - Composer-backed local app
  - Bun + Next.js scaffold, skills, migration, build, and type-check
  - Deno scaffold using `npm:prisma@latest`, migration, and `deno check`
  - structured JSON and failure paths
- real Prisma CLI `--json` failure envelope checked against the current parser
- corrected PostHog reliability insights executed successfully