### PR TITLE
chore(release): 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.11.2

This PR bumps `create-prisma` to `0.11.2`.

**Squash-merge this PR.** The release workflow reads the squash commit title to
publish to npm using trusted publishing; a merge commit will skip the release.
