### PR TITLE
fix: run setup through the installed Prisma CLI

### DIFF
--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -3,7 +3,6 @@ import { execa } from "execa";
 import { createInterface } from "node:readline";
 import type { Writable } from "node:stream";
 
-import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
   ClassifiedCreateError,
   getCreateFailureReason,
@@ -13,8 +12,8 @@ import {
 import type { PackageManager } from "../types";
 import { getErrorMessage, redactSecrets } from "../utils/errors";
 import {
-  getPackageExecutionArgs,
-  getPackageExecutionCommand,
+  getLocalPackageBinaryArgs,
+  getLocalPackageBinaryCommand,
   getRunScriptArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
@@ -149,7 +148,7 @@ export function parsePrismaCliEnvelope<Result = unknown>(
 }
 
 function getPrismaCliArgs(packageManager: PackageManager, args: string[]) {
-  return getPackageExecutionArgs(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
+  return getLocalPackageBinaryArgs(packageManager, "prisma", args);
 }
 
 async function runPrismaJsonCommand<Result>(options: {
@@ -251,8 +250,7 @@ async function ensureAuthentication(options: {
   const authState = await whoami();
   if (authState.authenticated) return authState;
 
-  const loginCommand = getPackageExecutionCommand(options.packageManager, [
-    PRISMA_PLATFORM_CLI_PACKAGE,
+  const loginCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
     "auth",
     "login",
   ]);
@@ -517,8 +515,7 @@ export async function deployNewProjectWithComposer(options: {
     clearProgress();
     failureStage = "composer_deploy";
     failureReason = "composer_deploy_failed";
-    const deployCommand = getPackageExecutionCommand(options.packageManager, [
-      PRISMA_PLATFORM_CLI_PACKAGE,
+    const deployCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
       "deploy",
       "module.ts",
     ]);

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -3,7 +3,6 @@ import fs from "fs-extra";
 import path from "node:path";
 import type { Writable } from "node:stream";
 
-import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
   ClassifiedCreateError,
   CreateCancellationError,
@@ -30,7 +29,6 @@ import {
   detectPackageManager,
   getInstallCommand,
   getLocalPackageBinaryArgs,
-  getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
@@ -230,12 +228,6 @@ function getInitTarget(provider: DatabaseProvider): "postgres" | "mongodb" {
   return provider === "mongo" ? "mongodb" : "postgres";
 }
 
-function getPrismaCliInvocation(packageManager: PackageManager, args: string[]) {
-  const packageName =
-    packageManager === "deno" ? PRISMA_DENO_CLI_PACKAGE : PRISMA_PLATFORM_CLI_PACKAGE;
-  return getPackageExecutionArgs(packageManager, [packageName, ...args]);
-}
-
 function getInstalledPrismaCliInvocation(packageManager: PackageManager, args: string[]) {
   return getLocalPackageBinaryArgs(packageManager, "prisma", args);
 }
@@ -254,7 +246,7 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
     getContractPath(context.authoring),
     "--skip-install",
   ];
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
+  const invocation = getInstalledPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) {
     log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`, {
       output: context.output,
@@ -459,12 +451,31 @@ export async function executePrismaSetupContext(
     : (options.progressSpinner ?? spinner({ output: context.output }));
   const ownsProgress = progress !== undefined && !options.progressSpinner;
   let gitInitialization: GitInitializationResult | undefined;
-  let setupStage: CreateFailureStage = "initialize_prisma";
-  let setupReason: CreateFailureReason = "prisma_init_failed";
+  let setupStage: CreateFailureStage = "configure_project";
+  let setupReason: CreateFailureReason = "project_configuration_failed";
   if (ownsProgress) progress.start("Creating Prisma 8 project...");
 
   try {
+    await writePrismaDependencies(
+      context.databaseProvider,
+      context.packageManager,
+      context.authoring,
+      projectDir,
+    );
+
+    progress?.message(
+      `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
+    );
+    setupStage = "install_dependencies";
+    setupReason = "dependency_install_failed";
+    await installProjectDependencies(context.packageManager, projectDir, {
+      verbose: context.verbose,
+      json: context.json,
+    });
+
     progress?.message("Preparing Prisma 8 project files...");
+    setupStage = "initialize_prisma";
+    setupReason = "prisma_init_failed";
     await runPrismaInit(context, projectDir);
 
     setupStage = "configure_project";
@@ -477,28 +488,12 @@ export async function executePrismaSetupContext(
       authoring: context.authoring,
       packageManager: context.packageManager,
     });
-    await writePrismaDependencies(
-      context.databaseProvider,
-      context.packageManager,
-      context.authoring,
-      projectDir,
-    );
     await ensureComposerTypeScriptOptions(projectDir);
     if (context.databaseProvider === "mongo") await ensureMongoEnvironment(projectDir);
     if (context.packageManager !== "deno") {
       await ensureGitignoreEntry(projectDir, "/.alchemy");
       await ensureGitignoreEntry(projectDir, "/.prisma-composer");
     }
-
-    progress?.message(
-      `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
-    );
-    setupStage = "install_dependencies";
-    setupReason = "dependency_install_failed";
-    await installProjectDependencies(context.packageManager, projectDir, {
-      verbose: context.verbose,
-      json: context.json,
-    });
 
     progress?.message("Installing Prisma agent skills...");
     setupStage = "initialize_agent_skills";

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -29,6 +29,7 @@ import { getErrorMessage } from "../utils/errors";
 import {
   detectPackageManager,
   getInstallCommand,
+  getLocalPackageBinaryArgs,
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
@@ -235,6 +236,10 @@ function getPrismaCliInvocation(packageManager: PackageManager, args: string[]) 
   return getPackageExecutionArgs(packageManager, [packageName, ...args]);
 }
 
+function getInstalledPrismaCliInvocation(packageManager: PackageManager, args: string[]) {
+  return getLocalPackageBinaryArgs(packageManager, "prisma", args);
+}
+
 async function runPrismaInit(context: PrismaSetupContext, projectDir: string): Promise<void> {
   const args = [
     "orm",
@@ -272,7 +277,7 @@ async function initializeAgentSkills(
 ): Promise<void> {
   if (context.packageManager === "deno") return;
 
-  const invocation = getPrismaCliInvocation(context.packageManager, [
+  const invocation = getInstalledPrismaCliInvocation(context.packageManager, [
     "init",
     "--yes",
     "--no-interactive",
@@ -342,7 +347,7 @@ async function runPrismaCli(
   projectDir: string,
   args: string[],
 ): Promise<void> {
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
+  const invocation = getInstalledPrismaCliInvocation(context.packageManager, args);
   if (context.verbose) {
     log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
   }

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -258,7 +258,7 @@ export function getLocalPackageBinaryArgs(
     case "deno":
       return {
         command: "deno",
-        args: ["run", "-A", DENO_ALLOW_FRESH_DEPENDENCIES, `npm:${binaryName}`, ...binaryArgs],
+        args: ["run", "-A", "--frozen", `npm:${binaryName}`, ...binaryArgs],
       };
     case "pnpm":
       return { command: "pnpm", args: ["exec", binaryName, ...binaryArgs] };
@@ -268,7 +268,10 @@ export function getLocalPackageBinaryArgs(
       return { command: "bun", args: [binaryName, ...binaryArgs] };
     case "npm":
     default:
-      return { command: "npm", args: ["exec", binaryName, "--", ...binaryArgs] };
+      return {
+        command: "npm",
+        args: ["exec", "--offline", "--yes=false", "--", binaryName, ...binaryArgs],
+      };
   }
 }
 

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -258,7 +258,7 @@ export function getLocalPackageBinaryArgs(
     case "deno":
       return {
         command: "deno",
-        args: ["run", "-A", "--frozen", `npm:${binaryName}`, ...binaryArgs],
+        args: ["run", "-A", "--frozen", `npm:${binaryName}@latest`, ...binaryArgs],
       };
     case "pnpm":
       return { command: "pnpm", args: ["exec", binaryName, ...binaryArgs] };

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -264,11 +264,11 @@ describe("create-prisma e2e", () => {
     ]);
     expect(exitCode).toBe(1);
     expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
-      expect(JSON.parse(stdout)).toMatchObject({
-        schemaVersion: 1,
-        ok: false,
-        error: { stage: "install_dependencies" },
-      });
+    expect(JSON.parse(stdout)).toMatchObject({
+      schemaVersion: 1,
+      ok: false,
+      error: { stage: "install_dependencies" },
+    });
     expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);
   });

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -264,11 +264,11 @@ describe("create-prisma e2e", () => {
     ]);
     expect(exitCode).toBe(1);
     expect(stdout.trim().split(/\r?\n/)).toHaveLength(1);
-    expect(JSON.parse(stdout)).toMatchObject({
-      schemaVersion: 1,
-      ok: false,
-      error: { stage: "initialize_prisma" },
-    });
+      expect(JSON.parse(stdout)).toMatchObject({
+        schemaVersion: 1,
+        ok: false,
+        error: { stage: "install_dependencies" },
+      });
     expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);
   });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -143,7 +143,7 @@ describe("Composer package-manager commands", () => {
     });
     expect(getLocalPackageBinaryArgs("deno", "prisma", ["contract", "emit"])).toEqual({
       command: "deno",
-      args: ["run", "-A", "--frozen", "npm:prisma", "contract", "emit"],
+      args: ["run", "-A", "--frozen", "npm:prisma@latest", "contract", "emit"],
     });
   });
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -13,6 +13,7 @@ import {
 import { authoringStyles, createTemplates, databaseProviders, packageManagers } from "../src/types";
 import {
   getInstallArgs,
+  getLocalPackageBinaryArgs,
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../src/utils/package-manager";
@@ -132,6 +133,17 @@ describe("Composer package-manager commands", () => {
     expect(getPackageExecutionArgs("deno", ["prisma@8.0.0-rc.11", "orm", "init"])).toEqual({
       command: "deno",
       args: ["run", "-A", "--minimum-dependency-age=0", "npm:prisma@8.0.0-rc.11", "orm", "init"],
+    });
+  });
+
+  test("runs the installed Prisma CLI without registry fallback", () => {
+    expect(getLocalPackageBinaryArgs("npm", "prisma", ["contract", "emit"])).toEqual({
+      command: "npm",
+      args: ["exec", "--offline", "--yes=false", "--", "prisma", "contract", "emit"],
+    });
+    expect(getLocalPackageBinaryArgs("deno", "prisma", ["contract", "emit"])).toEqual({
+      command: "deno",
+      args: ["run", "-A", "--frozen", "npm:prisma", "contract", "emit"],
     });
   });
 });


### PR DESCRIPTION
## Summary

- install the generated project's dependencies before Prisma initialization
- run `orm init`, skills, contract emission, migration planning, auth, workspace/project checks, and deployment through the installed `prisma` CLI
- prevent npm from downloading a fallback CLI and freeze Deno to the installed `prisma@latest` lock entry
- keep login and deploy output package-manager-native and copy-pasteable

## Why

`create-prisma` resolved `prisma@latest` before installation and then resolved it again for every Prisma step. A deployed scaffold could invoke a package resolver eight or more times. That added registry traffic, process launches, version drift, and a large Windows failure surface.

The framework scaffold already has a package manifest, so the correct order is to write all dependencies, install once, and use that locked local CLI for the entire Prisma setup and deployment path.

This directly targets the PostHog failure concentration in `initialize_prisma` and the shared deployment path. It does not relabel package-manager installation errors as fixed; those remain separately observable as `install_dependencies`.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run test:unit` — 47 passed
- `bun run test:e2e` — 8 passed, including a running Composer-backed app, Next.js TypeScript, every raw Node/tsdown template, and Deno
- real Deno scaffold verified against the frozen local `prisma@latest` lock entry
- npm local execution verified to fail instead of downloading a missing fallback package
- Windows creation smoke runs on this PR
