### PR TITLE
refactor: migrate create-prisma to Effect v4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,18 +6,15 @@
       "name": "create-prisma",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@orpc/server": "^1.13.5",
+        "@effect/platform-node-shared": "4.0.0-rc.112",
+        "effect": "4.0.0-rc.112",
         "execa": "^9.6.1",
-        "fs-extra": "^11.3.3",
         "handlebars": "^4.7.8",
         "posthog-node": "^5.28.2",
-        "trpc-cli": "^0.12.4",
-        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@prisma/dev": "0.24.7",
         "@types/bun": "^1.3.9",
-        "@types/fs-extra": "^11.0.4",
         "@types/node": "^25.3.0",
         "changelogithub": "^14.0.0",
         "mongodb-memory-server": "11.1.0",
@@ -43,6 +40,8 @@
 
     "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.112", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ=="],
+
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.3", "", {}, "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ=="],
 
     "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.1.3", "", { "peerDependencies": { "@electric-sql/pglite": "0.4.3" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ=="],
@@ -67,29 +66,19 @@
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.11", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
-
-    "@orpc/client": ["@orpc/client@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-peer": "1.13.5" } }, "sha512-j0VJpiWiFv9Xfan3NOoouHL07nSiHX8haxYaZzHYWSdWh+ABzwa8aRTwQSUpuCfD6i0EtYEZJAB6gVwtAnQoxQ=="],
-
-    "@orpc/contract": ["@orpc/contract@1.13.5", "", { "dependencies": { "@orpc/client": "1.13.5", "@orpc/shared": "1.13.5", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-JeklRu2kxsRKyaPeKqA40YHsGRLjQdAuEGNCNU6VxA3v4UReh8ZsDG+WvEoHfXIOLRn2VWBzEsbE1G2MwRCGsg=="],
-
-    "@orpc/interop": ["@orpc/interop@1.13.5", "", {}, "sha512-l02yMZWJ9hJ2Z0PF14UsP2Hd71jbUbNgvA5/hxzGkx9ci89cgJ3F9yv3clpwz8VElfh2Qp9jta+peKgiRV1a5A=="],
-
-    "@orpc/server": ["@orpc/server@1.13.5", "", { "dependencies": { "@orpc/client": "1.13.5", "@orpc/contract": "1.13.5", "@orpc/interop": "1.13.5", "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-aws-lambda": "1.13.5", "@orpc/standard-server-fastify": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-node": "1.13.5", "@orpc/standard-server-peer": "1.13.5", "cookie": "^1.1.1" }, "peerDependencies": { "crossws": ">=0.3.4", "ws": ">=8.18.1" }, "optionalPeers": ["crossws", "ws"] }, "sha512-RiSzyZ8hp3XmG6F98czJNV3BsRW/5zjUnOk1v16KIiuYk3p46bYEpzhHJT5Sxr5DOjmm4xHTV+fe0gczyyf+gA=="],
-
-    "@orpc/shared": ["@orpc/shared@1.13.5", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-yBFD9FqwazpbcOegEOZ0kAz7i9oNO110HX5AV5YAPGh+zxOY3RfZFXODQ5kBR1mr2nyo4ju+5ohYbJppZuWlcA=="],
-
-    "@orpc/standard-server": ["@orpc/standard-server@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5" } }, "sha512-Upu82h5TlKOWlttcL+TTkIxyJEzjdKWd8Ri9ya8o1+BxYiqd/y3TQnmBQM+pfj8N1w+zI86Q3cLGB8RGtMqf5g=="],
-
-    "@orpc/standard-server-aws-lambda": ["@orpc/standard-server-aws-lambda@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-node": "1.13.5" } }, "sha512-fnjglw4a24ORmFxRgqrPATwOjxhjrAx7i1mDM9JYVSouRBb5X3J3kcvvOeuqiCw6Ov1X6WczykziB5cLy8aIpQ=="],
-
-    "@orpc/standard-server-fastify": ["@orpc/standard-server-fastify@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-node": "1.13.5" }, "peerDependencies": { "fastify": ">=5.6.1" }, "optionalPeers": ["fastify"] }, "sha512-UxfCfwMYxZdkjYxAn+/wTeUUpdCrKdf5bHiO/BFq89jex3uVbfWWr0zbB7NVqonF2hUtBu88P6ZoGup1UCLkVQ=="],
-
-    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5" } }, "sha512-Z0xzVQ2rpLxjrsgUC5b4ezlAEpL4enDXx9fOJUfYouUUVnbgUkDe/uTpavKLgA/I97svWeZ5Smt6ycWuuoHoAQ=="],
-
-    "@orpc/standard-server-node": ["@orpc/standard-server-node@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5" } }, "sha512-cFyoKU6kHM2AcLd+fLdty3hohm5h1Sc0wAvXasI7PVZlx9mKxSfV1n4Ej2Una8ik1Jt62AH+o9fMLtPJ6/wvbQ=="],
-
-    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5" } }, "sha512-pEvnaYtwXaw2Fjy0VJyvfZTma/AprSUGSJlOcnfBySo0TU3ZfsB54vhTlQCCN+WUCGjInZ75vCjIQnGj3Af3gg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
 
@@ -215,25 +204,21 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
-
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
-
-    "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -297,8 +282,6 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
@@ -306,8 +289,6 @@
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "convert-gitmoji": ["convert-gitmoji@0.1.5", "", {}, "sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ=="],
-
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -323,9 +304,13 @@
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
+
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
@@ -338,6 +323,8 @@
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -364,8 +351,6 @@
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
-
-    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
     "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
 
@@ -429,8 +414,6 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
-
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
@@ -459,11 +442,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "new-find-package-json": ["new-find-package-json@2.0.0", "", { "dependencies": { "debug": "^4.3.4" } }, "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -478,8 +467,6 @@
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
-
-    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "oxfmt": ["oxfmt@0.37.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.37.0", "@oxfmt/binding-android-arm64": "0.37.0", "@oxfmt/binding-darwin-arm64": "0.37.0", "@oxfmt/binding-darwin-x64": "0.37.0", "@oxfmt/binding-freebsd-x64": "0.37.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.37.0", "@oxfmt/binding-linux-arm-musleabihf": "0.37.0", "@oxfmt/binding-linux-arm64-gnu": "0.37.0", "@oxfmt/binding-linux-arm64-musl": "0.37.0", "@oxfmt/binding-linux-ppc64-gnu": "0.37.0", "@oxfmt/binding-linux-riscv64-gnu": "0.37.0", "@oxfmt/binding-linux-riscv64-musl": "0.37.0", "@oxfmt/binding-linux-s390x-gnu": "0.37.0", "@oxfmt/binding-linux-x64-gnu": "0.37.0", "@oxfmt/binding-linux-x64-musl": "0.37.0", "@oxfmt/binding-openharmony-arm64": "0.37.0", "@oxfmt/binding-win32-arm64-msvc": "0.37.0", "@oxfmt/binding-win32-ia32-msvc": "0.37.0", "@oxfmt/binding-win32-x64-msvc": "0.37.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Kd47gakZAU/i9KkXv3F0EDRoMvSso9O5966kflf9zYto0oZ0NN+Fh5vKKrLwp2Mkt0efYBk5LjCAS0BNC0y0eQ=="],
 
@@ -517,9 +504,9 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
-    "radash": ["radash@12.1.1", "", {}, "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA=="],
+    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
@@ -561,8 +548,6 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
-    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
-
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
@@ -583,13 +568,9 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "trpc-cli": ["trpc-cli@0.12.4", "", { "dependencies": { "commander": "^14.0.0" }, "peerDependencies": { "@orpc/server": "^1.0.0", "@trpc/server": "^10.45.2 || ^11.0.1", "@valibot/to-json-schema": "^1.1.0", "effect": "^3.14.2 || ^4.0.0", "valibot": "^1.1.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["@orpc/server", "@trpc/server", "@valibot/to-json-schema", "effect", "valibot", "zod"], "bin": { "trpc-cli": "dist/bin.js" } }, "sha512-Yo2Ob5J7hUZSWZ2A1M9Kb+0qfSxwmcmYIs3kkQyLd3sn0qU4ryGzNsySfrY3+urqp6FnDnIIdbCSqC9BKxK6Ag=="],
-
     "tsdown": ["tsdown@0.20.3", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.0.1", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.3", "rolldown": "1.0.0-rc.3", "rolldown-plugin-dts": "^0.22.1", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.2", "unrun": "^0.2.27" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -603,8 +584,6 @@
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "unrun": ["unrun@0.2.27", "", { "dependencies": { "rolldown": "1.0.0-rc.3" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
@@ -617,6 +596,8 @@
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
@@ -628,8 +609,6 @@
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zeptomatch": ["zeptomatch@2.1.0", "", { "dependencies": { "grammex": "^3.1.11", "graphmatch": "^1.1.0" } }, "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA=="],
-
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "tsdown --watch",
     "start": "bun run ./dist/cli.mjs",
     "test": "bun run test:unit && bun run test:e2e",
-    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/initialize-git.test.ts ./tests/install.test.ts ./tests/json-output.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry.test.ts",
+    "test:unit": "bun test ./tests/dependencies.test.ts ./tests/deploy-with-composer.test.ts ./tests/initialize-git.test.ts ./tests/install.test.ts ./tests/json-output.test.ts ./tests/node-version.test.ts ./tests/setup-prisma.test.ts ./tests/telemetry-client.test.ts ./tests/telemetry.test.ts",
     "test:e2e": "bun test --timeout 180000 ./tests/e2e/create-prisma.e2e.test.ts",
     "check": "bun run format:check && bun run lint",
     "lint": "oxlint . --deny-warnings",

--- a/package.json
+++ b/package.json
@@ -51,18 +51,15 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
-    "@orpc/server": "^1.13.5",
+    "@effect/platform-node-shared": "4.0.0-rc.112",
+    "effect": "4.0.0-rc.112",
     "execa": "^9.6.1",
-    "fs-extra": "^11.3.3",
     "handlebars": "^4.7.8",
-    "posthog-node": "^5.28.2",
-    "trpc-cli": "^0.12.4",
-    "zod": "^4.3.6"
+    "posthog-node": "^5.28.2"
   },
   "devDependencies": {
     "@prisma/dev": "0.24.7",
     "@types/bun": "^1.3.9",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.3.0",
     "changelogithub": "^14.0.0",
     "mongodb-memory-server": "11.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,10 @@
-import { createCreatePrismaCli } from "./index";
-import { createJsonOutputLogger, isJsonOutputRequested } from "./ui/json-output";
+import { NodeRuntime } from "@effect/platform-node-shared";
+import { Effect } from "effect";
 
-createCreatePrismaCli().run({
-  ...(isJsonOutputRequested(process.argv) ? { logger: createJsonOutputLogger() } : {}),
-  process: {
-    exit(code): never {
-      const commandExitCode =
-        typeof process.exitCode === "number" && process.exitCode !== 0 ? process.exitCode : code;
-      process.exit(commandExitCode);
-    },
-  },
-});
+import { runCreatePrismaCli } from "./index";
+import { ApplicationLayer } from "./runtime";
+
+runCreatePrismaCli().pipe(
+  Effect.provide(ApplicationLayer),
+  NodeRuntime.runMain({ disableErrorReporting: true }),
+);

--- a/src/commands/create-context.ts
+++ b/src/commands/create-context.ts
@@ -1,0 +1,193 @@
+import { cancel, isCancel, select, text } from "@clack/prompts";
+import { Effect, FileSystem, Schema } from "effect";
+import path from "node:path";
+import type { Writable } from "node:stream";
+
+import { CreateCancellationError, CreateFailure } from "../create-outcome";
+import type { CreateProjectResult } from "../result";
+import { collectPrismaSetupContextEffect, type PrismaSetupContext } from "../tasks/setup-prisma";
+import { CreateTemplateSchema, type CreateCommandInput, type CreateTemplate } from "../types";
+import { resolveExecutionSettings } from "../ui/output";
+
+const DEFAULT_PROJECT_NAME = "my-app";
+const DEFAULT_TEMPLATE: CreateTemplate = "minimal";
+
+export type CreateTargetPathState = {
+  exists: boolean;
+  isDirectory: boolean;
+  isEmptyDirectory: boolean;
+};
+
+export type CreatePromptContext = {
+  targetDirectory: string;
+  targetPathState: CreateTargetPathState;
+  force: boolean;
+  template: CreateTemplate;
+  projectPackageName: string;
+  prismaSetupContext: PrismaSetupContext;
+};
+
+const toPackageName = (projectName: string) =>
+  projectName
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "") || "app";
+
+export const formatPathForDisplay = (filePath: string) =>
+  path.relative(process.cwd(), filePath) || ".";
+
+function validateProjectName(value: string | undefined): string | undefined {
+  const trimmed = String(value ?? "").trim();
+  if (trimmed.length === 0) return "Please enter a project name.";
+  if (trimmed === "..") return "Project name cannot be '..'.";
+  if (path.isAbsolute(trimmed)) return "Use a relative project name instead of an absolute path.";
+}
+
+export const createProjectResult = (context: CreatePromptContext): CreateProjectResult => ({
+  name: context.projectPackageName,
+  path: context.targetDirectory,
+  template: context.template,
+  databaseProvider: context.prismaSetupContext.databaseProvider,
+  authoring: context.prismaSetupContext.authoring,
+  packageManager: context.prismaSetupContext.packageManager,
+});
+
+const promptForProjectName = Effect.fn("Prompts.projectName")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    text({
+      message: "Project name",
+      placeholder: DEFAULT_PROJECT_NAME,
+      initialValue: DEFAULT_PROJECT_NAME,
+      validate: validateProjectName,
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "project_name" });
+  }
+  return String(value).trim();
+});
+
+const promptForCreateTemplate = Effect.fn("Prompts.template")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Select template",
+      initialValue: DEFAULT_TEMPLATE,
+      options: [
+        {
+          value: "minimal",
+          label: "Minimal",
+          hint: "Script-first Prisma 8 starter with no web framework",
+        },
+        { value: "hono", label: "Hono", hint: "Lightweight TypeScript API server" },
+        { value: "elysia", label: "Elysia", hint: "Bun-friendly TypeScript API server" },
+        {
+          value: "nest",
+          label: "NestJS",
+          hint: "Structured Node API with controllers and services",
+        },
+        { value: "next", label: "Next.js", hint: "Full-stack React app with App Router" },
+        { value: "svelte", label: "SvelteKit", hint: "Full-stack Svelte 5 app with Vite" },
+        { value: "astro", label: "Astro", hint: "Content-oriented web app with server routes" },
+        { value: "nuxt", label: "Nuxt", hint: "Full-stack Vue app with Nitro server routes" },
+        {
+          value: "tanstack-start",
+          label: "TanStack Start",
+          hint: "React app with file routes and server functions",
+        },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "template" });
+  }
+  return yield* Schema.decodeUnknownEffect(CreateTemplateSchema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CreateFailure({
+          stage: "collect_context",
+          reason: "invalid_input",
+          message: cause.message,
+          cause,
+        }),
+    ),
+  );
+});
+
+const inspectTargetPath = Effect.fn("Create.inspectTargetPath")(function* (targetPath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(targetPath))) {
+    return { exists: false, isDirectory: true, isEmptyDirectory: true };
+  }
+  const stats = yield* fs.stat(targetPath);
+  if (stats.type !== "Directory") {
+    return { exists: true, isDirectory: false, isEmptyDirectory: false };
+  }
+  return {
+    exists: true,
+    isDirectory: true,
+    isEmptyDirectory: (yield* fs.readDirectory(targetPath)).length === 0,
+  };
+});
+
+export const collectCreateContext = Effect.fn("Create.collectContext")(function* (
+  input: CreateCommandInput,
+) {
+  const force = input.force === true;
+  const { output, useDefaults } = resolveExecutionSettings(input);
+  const projectName = String(
+    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : yield* promptForProjectName(output)),
+  ).trim();
+  const validationError = validateProjectName(projectName);
+  if (validationError) {
+    yield* Effect.sync(() => cancel(validationError, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "invalid_project_name",
+      message: validationError,
+      errorReported: true,
+    });
+  }
+
+  const template =
+    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : yield* promptForCreateTemplate(output));
+  const targetDirectory = path.resolve(process.cwd(), projectName);
+  const targetPathState = yield* inspectTargetPath(targetDirectory);
+  if (targetPathState.exists && !targetPathState.isDirectory) {
+    const message = `Target path ${formatPathForDisplay(targetDirectory)} already exists and is not a directory. Choose a different project name.`;
+    yield* Effect.sync(() => cancel(message, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "target_path_not_directory",
+      message,
+      errorReported: true,
+    });
+  }
+  if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
+    const message = `Target directory ${formatPathForDisplay(targetDirectory)} is not empty. Use --force to continue.`;
+    yield* Effect.sync(() => cancel(message, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "target_directory_not_empty",
+      message,
+      errorReported: true,
+    });
+  }
+
+  const prismaSetupContext = yield* collectPrismaSetupContextEffect(input, {
+    projectDir: targetDirectory,
+    template,
+  });
+  return {
+    targetDirectory,
+    targetPathState,
+    force,
+    template,
+    projectPackageName: toPackageName(path.basename(targetDirectory)),
+    prismaSetupContext,
+  } satisfies CreatePromptContext;
+});

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,11 +1,11 @@
 import { cancel, intro, isCancel, log, select, spinner, text } from "@clack/prompts";
-import fs from "fs-extra";
+import { Cause, Clock, Effect, Exit, FileSystem, Option, Ref, Schema } from "effect";
 import path from "node:path";
 import type { Writable } from "node:stream";
 
 import {
   CreateCancellationError,
-  getCreateFailureReason,
+  CreateFailure,
   type CreateFailureReason,
   type CreateFailureStage,
 } from "../create-outcome";
@@ -13,16 +13,25 @@ import {
   CREATE_PRISMA_RESULT_SCHEMA_VERSION,
   createCommandFailureResult,
   type CreateCommandResult,
+  type CreateNextStep,
   type CreateProjectResult,
 } from "../result";
-import { trackCreateCancelled, trackCreateCompleted, trackCreateFailed } from "../telemetry";
-import { scaffoldCreateFrameworkTemplate } from "../templates/render-create-template";
-import { writeCreateTemplateDependencies } from "../tasks/install";
-import type { PrismaSetupContext } from "../tasks/setup-prisma";
-import { collectPrismaSetupContext, executePrismaSetupContext } from "../tasks/setup-prisma";
+import { applicationRuntime } from "../runtime";
 import {
-  CreateCommandInputSchema,
+  trackCreateCancelledEffect,
+  trackCreateCompletedEffect,
+  trackCreateFailedEffect,
+} from "../telemetry/create";
+import { scaffoldCreateFrameworkTemplateEffect } from "../templates/render-create-template";
+import { writeCreateTemplateDependenciesEffect } from "../tasks/install";
+import {
+  collectPrismaSetupContextEffect,
+  executePrismaSetupContextEffect,
+  type PrismaSetupContext,
+} from "../tasks/setup-prisma";
+import {
   CreateTemplateSchema,
+  decodeCreateCommandInput,
   type CreateCommandInput,
   type CreateTemplate,
 } from "../types";
@@ -49,406 +58,228 @@ export type CreatePromptContext = {
   prismaSetupContext: PrismaSetupContext;
 };
 
-type ExecuteCreateContextResult =
-  | { ok: true; result: CreateCommandResult }
-  | {
-      ok: false;
-      cancelled: true;
-      stage: "select_workspace";
-      errorReported?: boolean;
-    }
-  | {
-      ok: false;
-      cancelled?: false;
-      stage: CreateFailureStage;
-      reason: CreateFailureReason;
-      error?: unknown;
-      errorReported?: boolean;
-    };
+const toPackageName = (projectName: string) =>
+  projectName
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "") || "app";
 
-type CollectCreateContextResult =
-  | { ok: true; context: CreatePromptContext }
-  | { ok: false; message: string; reason: CreateFailureReason };
-
-function toPackageName(projectName: string): string {
-  return (
-    projectName
-      .toLowerCase()
-      .replace(/[^a-z0-9._-]/g, "-")
-      .replace(/^-+/, "")
-      .replace(/-+$/, "") || "app"
-  );
-}
-
-function formatPathForDisplay(filePath: string): string {
-  return path.relative(process.cwd(), filePath) || ".";
-}
+const formatPathForDisplay = (filePath: string) => path.relative(process.cwd(), filePath) || ".";
 
 function validateProjectName(value: string | undefined): string | undefined {
   const trimmed = String(value ?? "").trim();
-  if (trimmed.length === 0) {
-    return "Please enter a project name.";
-  }
-
-  if (trimmed === "..") {
-    return "Project name cannot be '..'.";
-  }
-
-  if (path.isAbsolute(trimmed)) {
-    return "Use a relative project name instead of an absolute path.";
-  }
-
-  return undefined;
+  if (trimmed.length === 0) return "Please enter a project name.";
+  if (trimmed === "..") return "Project name cannot be '..'.";
+  if (path.isAbsolute(trimmed)) return "Use a relative project name instead of an absolute path.";
 }
 
-function getProjectResult(context: CreatePromptContext): CreateProjectResult {
-  return {
-    name: context.projectPackageName,
-    path: context.targetDirectory,
-    template: context.template,
-    databaseProvider: context.prismaSetupContext.databaseProvider,
-    authoring: context.prismaSetupContext.authoring,
-    packageManager: context.prismaSetupContext.packageManager,
-  };
-}
+const projectResult = (context: CreatePromptContext): CreateProjectResult => ({
+  name: context.projectPackageName,
+  path: context.targetDirectory,
+  template: context.template,
+  databaseProvider: context.prismaSetupContext.databaseProvider,
+  authoring: context.prismaSetupContext.authoring,
+  packageManager: context.prismaSetupContext.packageManager,
+});
 
-async function promptForProjectName(output: Writable): Promise<string> {
-  const projectName = await text({
-    message: "Project name",
-    placeholder: DEFAULT_PROJECT_NAME,
-    initialValue: DEFAULT_PROJECT_NAME,
-    validate: validateProjectName,
-    output,
-  });
-
-  if (isCancel(projectName)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("project_name");
+const promptForProjectName = Effect.fn("Prompts.projectName")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    text({
+      message: "Project name",
+      placeholder: DEFAULT_PROJECT_NAME,
+      initialValue: DEFAULT_PROJECT_NAME,
+      validate: validateProjectName,
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "project_name" });
   }
+  return String(value).trim();
+});
 
-  return String(projectName).trim();
-}
-
-async function promptForCreateTemplate(output: Writable): Promise<CreateTemplate> {
-  const template = await select({
-    message: "Select template",
-    initialValue: DEFAULT_TEMPLATE,
-    options: [
-      {
-        value: "minimal",
-        label: "Minimal",
-        hint: "Script-first Prisma 8 starter with no web framework",
-      },
-      {
-        value: "hono",
-        label: "Hono",
-        hint: "Lightweight TypeScript API server",
-      },
-      {
-        value: "elysia",
-        label: "Elysia",
-        hint: "Bun-friendly TypeScript API server",
-      },
-      {
-        value: "nest",
-        label: "NestJS",
-        hint: "Structured Node API with controllers and services",
-      },
-      {
-        value: "next",
-        label: "Next.js",
-        hint: "Full-stack React app with App Router",
-      },
-      {
-        value: "svelte",
-        label: "SvelteKit",
-        hint: "Full-stack Svelte 5 app with Vite",
-      },
-      {
-        value: "astro",
-        label: "Astro",
-        hint: "Content-oriented web app with server routes",
-      },
-      {
-        value: "nuxt",
-        label: "Nuxt",
-        hint: "Full-stack Vue app with Nitro server routes",
-      },
-      {
-        value: "tanstack-start",
-        label: "TanStack Start",
-        hint: "React app with file routes and server functions",
-      },
-    ],
-    output,
-  });
-
-  if (isCancel(template)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("template");
+const promptForCreateTemplate = Effect.fn("Prompts.template")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Select template",
+      initialValue: DEFAULT_TEMPLATE,
+      options: [
+        {
+          value: "minimal",
+          label: "Minimal",
+          hint: "Script-first Prisma 8 starter with no web framework",
+        },
+        { value: "hono", label: "Hono", hint: "Lightweight TypeScript API server" },
+        { value: "elysia", label: "Elysia", hint: "Bun-friendly TypeScript API server" },
+        {
+          value: "nest",
+          label: "NestJS",
+          hint: "Structured Node API with controllers and services",
+        },
+        { value: "next", label: "Next.js", hint: "Full-stack React app with App Router" },
+        { value: "svelte", label: "SvelteKit", hint: "Full-stack Svelte 5 app with Vite" },
+        { value: "astro", label: "Astro", hint: "Content-oriented web app with server routes" },
+        { value: "nuxt", label: "Nuxt", hint: "Full-stack Vue app with Nitro server routes" },
+        {
+          value: "tanstack-start",
+          label: "TanStack Start",
+          hint: "React app with file routes and server functions",
+        },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "template" });
   }
+  return yield* Schema.decodeUnknownEffect(CreateTemplateSchema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CreateFailure({
+          stage: "collect_context",
+          reason: "invalid_input",
+          message: cause.message,
+          cause,
+        }),
+    ),
+  );
+});
 
-  return CreateTemplateSchema.parse(template);
-}
-
-async function inspectTargetPath(targetPath: string): Promise<CreateTargetPathState> {
-  if (!(await fs.pathExists(targetPath))) {
-    return {
-      exists: false,
-      isDirectory: true,
-      isEmptyDirectory: true,
-    };
+const inspectTargetPath = Effect.fn("Create.inspectTargetPath")(function* (targetPath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(targetPath))) {
+    return { exists: false, isDirectory: true, isEmptyDirectory: true };
   }
-
-  const stats = await fs.stat(targetPath);
-  if (!stats.isDirectory()) {
-    return {
-      exists: true,
-      isDirectory: false,
-      isEmptyDirectory: false,
-    };
+  const stats = yield* fs.stat(targetPath);
+  if (stats.type !== "Directory") {
+    return { exists: true, isDirectory: false, isEmptyDirectory: false };
   }
-
-  const entries = await fs.readdir(targetPath);
   return {
     exists: true,
     isDirectory: true,
-    isEmptyDirectory: entries.length === 0,
+    isEmptyDirectory: (yield* fs.readDirectory(targetPath)).length === 0,
   };
-}
+});
 
-export async function runCreateCommand(
-  rawInput: CreateCommandInput = {},
-): Promise<CreateCommandResult> {
-  const startedAt = Date.now();
-  let input: CreateCommandInput = {};
-  let context: CreatePromptContext | undefined;
-  let failureStage: CreateFailureStage = "validate_input";
-  let failureReason: CreateFailureReason = "invalid_input";
-  const { output } = resolveExecutionSettings(rawInput);
-
-  try {
-    input = CreateCommandInputSchema.parse(rawInput);
-    if (input.json && input.verbose) {
-      throw new Error("--verbose cannot be used with --json because JSON mode is output-only.");
-    }
-    if (!supportsPrisma()) {
-      const message = getUnsupportedNodeMessage();
-      cancel(message, { output });
-      process.exitCode = 1;
-      await trackCreateFailed({
-        input,
-        durationMs: Date.now() - startedAt,
-        stage: failureStage,
-        reason: "unsupported_node_version",
-      });
-      return createCommandFailureResult(failureStage, message);
-    }
-
-    intro(getCreatePrismaIntro(), { output });
-
-    failureStage = "collect_context";
-    failureReason = "unexpected_error";
-    const collected = await collectCreateContext(input);
-    if (!collected.ok) {
-      process.exitCode = 1;
-      const result = createCommandFailureResult(failureStage, collected.message);
-      await trackCreateFailed({
-        input,
-        durationMs: Date.now() - startedAt,
-        stage: failureStage,
-        reason: collected.reason,
-      });
-      return result;
-    }
-    context = collected.context;
-
-    failureStage = "unknown";
-    const executionResult = await executeCreateContext(context);
-    if (!executionResult.ok) {
-      process.exitCode = 1;
-      if (executionResult.cancelled) {
-        await trackCreateCancelled({
-          input,
-          context,
-          durationMs: Date.now() - startedAt,
-          stage: executionResult.stage,
-        });
-        return createCommandFailureResult(
-          executionResult.stage,
-          "Operation cancelled.",
-          getProjectResult(context),
-        );
-      }
-      const message = executionResult.error
-        ? getErrorMessage(executionResult.error)
-        : "Project setup did not complete.";
-      if (executionResult.error && !executionResult.errorReported) {
-        cancel(`Create command failed: ${message}`, { output });
-      }
-
-      await trackCreateFailed({
-        input,
-        context,
-        durationMs: Date.now() - startedAt,
-        error: executionResult.error,
-        stage: executionResult.stage,
-        reason: executionResult.reason,
-      });
-      return createCommandFailureResult(executionResult.stage, message, getProjectResult(context));
-    }
-
-    await trackCreateCompleted({
-      input,
-      context,
-      durationMs: Date.now() - startedAt,
-    });
-    return executionResult.result;
-  } catch (error) {
-    process.exitCode = 1;
-    if (error instanceof CreateCancellationError) {
-      await trackCreateCancelled({
-        input,
-        context,
-        durationMs: Date.now() - startedAt,
-        stage: error.stage,
-      });
-      return createCommandFailureResult(
-        error.stage,
-        error.message,
-        context ? getProjectResult(context) : undefined,
-      );
-    }
-    const message = getErrorMessage(error);
-    cancel(`Create command failed: ${message}`, { output });
-    await trackCreateFailed({
-      input,
-      context,
-      durationMs: Date.now() - startedAt,
-      error,
-      stage: failureStage,
-      reason: getCreateFailureReason(error, failureReason),
-    });
-    return createCommandFailureResult(
-      failureStage,
-      message,
-      context ? getProjectResult(context) : undefined,
-    );
-  }
-}
-
-async function collectCreateContext(
+const collectCreateContext = Effect.fn("Create.collectContext")(function* (
   input: CreateCommandInput,
-): Promise<CollectCreateContextResult> {
+) {
   const force = input.force === true;
   const { output, useDefaults } = resolveExecutionSettings(input);
-
-  const projectNameInput =
-    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : await promptForProjectName(output));
-  const projectName = String(projectNameInput).trim();
-  const projectNameValidationError = validateProjectName(projectName);
-  if (projectNameValidationError) {
-    cancel(projectNameValidationError, { output });
-    return {
-      ok: false,
-      message: projectNameValidationError,
+  const projectName = String(
+    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : yield* promptForProjectName(output)),
+  ).trim();
+  const validationError = validateProjectName(projectName);
+  if (validationError) {
+    yield* Effect.sync(() => cancel(validationError, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
       reason: "invalid_project_name",
-    };
+      message: validationError,
+      errorReported: true,
+    });
   }
 
   const template =
-    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : await promptForCreateTemplate(output));
+    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : yield* promptForCreateTemplate(output));
   const targetDirectory = path.resolve(process.cwd(), projectName);
-  const targetPathState = await inspectTargetPath(targetDirectory);
+  const targetPathState = yield* inspectTargetPath(targetDirectory);
   if (targetPathState.exists && !targetPathState.isDirectory) {
-    const message = `Target path ${formatPathForDisplay(
-      targetDirectory,
-    )} already exists and is not a directory. Choose a different project name.`;
-    cancel(message, { output });
-    return { ok: false, message, reason: "target_path_not_directory" };
+    const message = `Target path ${formatPathForDisplay(targetDirectory)} already exists and is not a directory. Choose a different project name.`;
+    yield* Effect.sync(() => cancel(message, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "target_path_not_directory",
+      message,
+      errorReported: true,
+    });
   }
   if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
-    const message = `Target directory ${formatPathForDisplay(
-      targetDirectory,
-    )} is not empty. Use --force to continue.`;
-    cancel(message, { output });
-    return { ok: false, message, reason: "target_directory_not_empty" };
+    const message = `Target directory ${formatPathForDisplay(targetDirectory)} is not empty. Use --force to continue.`;
+    yield* Effect.sync(() => cancel(message, { output }));
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "target_directory_not_empty",
+      message,
+      errorReported: true,
+    });
   }
 
-  const prismaSetupContext = await collectPrismaSetupContext(input, {
+  const prismaSetupContext = yield* collectPrismaSetupContextEffect(input, {
     projectDir: targetDirectory,
     template,
   });
   return {
-    ok: true,
-    context: {
-      targetDirectory,
-      targetPathState,
-      force,
-      template,
-      projectPackageName: toPackageName(path.basename(targetDirectory)),
-      prismaSetupContext,
-    },
-  };
-}
+    targetDirectory,
+    targetPathState,
+    force,
+    template,
+    projectPackageName: toPackageName(path.basename(targetDirectory)),
+    prismaSetupContext,
+  } satisfies CreatePromptContext;
+});
 
-async function executeCreateContext(
-  context: CreatePromptContext,
-): Promise<ExecuteCreateContextResult> {
+const atStage = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  stage: CreateFailureStage,
+  reason: CreateFailureReason,
+) =>
+  effect.pipe(
+    Effect.mapError((error) =>
+      error instanceof CreateFailure || error instanceof CreateCancellationError
+        ? error
+        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
+    ),
+  );
+
+const executeCreateContext = Effect.fn("Create.execute")(function* (context: CreatePromptContext) {
   const output = context.prismaSetupContext.output;
   const createSpinner = context.prismaSetupContext.verbose ? undefined : spinner({ output });
-  createSpinner?.start("Creating Prisma 8 project...");
-
-  try {
-    if (context.prismaSetupContext.verbose) {
+  yield* Effect.sync(() => {
+    createSpinner?.start("Creating Prisma 8 project...");
+    if (context.prismaSetupContext.verbose)
       log.step(`Scaffolding ${context.template} starter.`, { output });
-    }
+  });
 
-    await scaffoldCreateFrameworkTemplate({
+  yield* atStage(
+    scaffoldCreateFrameworkTemplateEffect({
       projectDir: context.targetDirectory,
       projectName: context.projectPackageName,
       template: context.template,
       provider: context.prismaSetupContext.databaseProvider,
       authoring: context.prismaSetupContext.authoring,
       packageManager: context.prismaSetupContext.packageManager,
-    });
-
-    if (context.prismaSetupContext.verbose) {
-      log.success("Starter files scaffolded.", { output });
-    }
-  } catch (error) {
-    createSpinner?.error("Could not create Prisma 8 project.");
-    return {
-      ok: false,
-      stage: "scaffold_template",
-      reason: "template_scaffold_failed",
-      error,
-    };
-  }
-
-  try {
-    await writeCreateTemplateDependencies({
-      template: context.template,
-      packageManager: context.prismaSetupContext.packageManager,
-      projectDir: context.targetDirectory,
-    });
-  } catch (error) {
-    createSpinner?.error("Could not create Prisma 8 project.");
-    return {
-      ok: false,
-      stage: "scaffold_template",
-      reason: "template_scaffold_failed",
-      error,
-    };
-  }
+    }).pipe(
+      Effect.andThen(
+        writeCreateTemplateDependenciesEffect({
+          template: context.template,
+          packageManager: context.prismaSetupContext.packageManager,
+          projectDir: context.targetDirectory,
+        }),
+      ),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          if (context.prismaSetupContext.verbose)
+            log.success("Starter files scaffolded.", { output });
+        }),
+      ),
+      Effect.tapError(() =>
+        Effect.sync(() => createSpinner?.error("Could not create Prisma 8 project.")),
+      ),
+    ),
+    "scaffold_template",
+    "template_scaffold_failed",
+  );
 
   const forceWarning =
     context.targetPathState.exists && !context.targetPathState.isEmptyDirectory && context.force
       ? `Used --force in non-empty directory ${formatPathForDisplay(context.targetDirectory)}.`
       : undefined;
-  if (forceWarning) log.warn(forceWarning, { output });
-
-  const nextSteps =
+  if (forceWarning) yield* Effect.sync(() => log.warn(forceWarning, { output }));
+  const nextSteps: CreateNextStep[] =
     formatPathForDisplay(context.targetDirectory) === "."
       ? []
       : [
@@ -458,57 +289,137 @@ async function executeCreateContext(
           },
         ];
 
-  try {
-    const setupResult = await executePrismaSetupContext(context.prismaSetupContext, {
-      prependNextSteps: nextSteps,
-      projectDir: context.targetDirectory,
-      projectName: context.projectPackageName,
-      template: context.template,
-      createdProjectPath: context.targetDirectory,
-      includeDevNextStep: true,
-      initializeGit: !context.targetPathState.exists || context.targetPathState.isEmptyDirectory,
-      progressSpinner: createSpinner,
+  const setup = yield* executePrismaSetupContextEffect(context.prismaSetupContext, {
+    prependNextSteps: nextSteps,
+    projectDir: context.targetDirectory,
+    projectName: context.projectPackageName,
+    template: context.template,
+    createdProjectPath: context.targetDirectory,
+    includeDevNextStep: true,
+    initializeGit: !context.targetPathState.exists || context.targetPathState.isEmptyDirectory,
+    progressSpinner: createSpinner,
+  });
+  const warnings = [...setup.warnings];
+  if (forceWarning) warnings.unshift(forceWarning);
+  return {
+    schemaVersion: CREATE_PRISMA_RESULT_SCHEMA_VERSION,
+    ok: true,
+    project: projectResult(context),
+    deployment: setup.deployment,
+    nextSteps: setup.nextSteps,
+    warnings,
+  } satisfies CreateCommandResult;
+});
+
+const createProjectEffect = Effect.fn("Create.project")(function* (
+  rawInput: CreateCommandInput,
+  inputRef: Ref.Ref<CreateCommandInput>,
+  contextRef: Ref.Ref<Option.Option<CreatePromptContext>>,
+) {
+  const input = yield* decodeCreateCommandInput(rawInput).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CreateFailure({
+          stage: "validate_input",
+          reason: "invalid_input",
+          message: cause.message,
+          cause,
+        }),
+    ),
+  );
+  yield* Ref.set(inputRef, input);
+  const { output } = resolveExecutionSettings(input);
+  if (input.json && input.verbose) {
+    return yield* new CreateFailure({
+      stage: "validate_input",
+      reason: "invalid_input",
+      message: "--verbose cannot be used with --json because JSON mode is output-only.",
     });
-
-    if (!setupResult.ok) {
-      if (setupResult.cancelled) {
-        return {
-          ok: false,
-          cancelled: true,
-          stage: setupResult.stage,
-          errorReported: setupResult.errorReported,
-        };
-      }
-      return {
-        ok: false,
-        stage: setupResult.stage,
-        reason: setupResult.reason,
-        error: setupResult.error,
-        errorReported: setupResult.errorReported,
-      };
-    }
-
-    const warnings = [...setupResult.warnings];
-    if (forceWarning) warnings.unshift(forceWarning);
-
-    return {
-      ok: true,
-      result: {
-        schemaVersion: CREATE_PRISMA_RESULT_SCHEMA_VERSION,
-        ok: true,
-        project: getProjectResult(context),
-        deployment: setupResult.deployment,
-        nextSteps: setupResult.nextSteps,
-        warnings,
-      },
-    };
-  } catch (error) {
-    createSpinner?.error("Could not create Prisma 8 project.");
-    return {
-      ok: false,
-      stage: "unknown",
-      reason: getCreateFailureReason(error, "unexpected_error"),
-      error,
-    };
   }
+  if (!supportsPrisma()) {
+    const message = getUnsupportedNodeMessage();
+    yield* Effect.sync(() => cancel(message, { output }));
+    return yield* new CreateFailure({
+      stage: "validate_input",
+      reason: "unsupported_node_version",
+      message,
+      errorReported: true,
+    });
+  }
+
+  yield* Effect.sync(() => intro(getCreatePrismaIntro(), { output }));
+  const context = yield* atStage(
+    collectCreateContext(input),
+    "collect_context",
+    "unexpected_error",
+  );
+  yield* Ref.set(contextRef, Option.some(context));
+  return { input, context, result: yield* executeCreateContext(context) };
+});
+
+export const runCreateCommandEffect = Effect.fn("Create.run")(function* (
+  rawInput: CreateCommandInput = {},
+) {
+  const startedAt = yield* Clock.currentTimeMillis;
+  const inputRef = yield* Ref.make<CreateCommandInput>(rawInput);
+  const contextRef = yield* Ref.make<Option.Option<CreatePromptContext>>(Option.none());
+  const exit = yield* Effect.exit(createProjectEffect(rawInput, inputRef, contextRef));
+  const durationMs = (yield* Clock.currentTimeMillis) - startedAt;
+
+  if (Exit.isSuccess(exit)) {
+    yield* trackCreateCompletedEffect({
+      input: exit.value.input,
+      context: exit.value.context,
+      durationMs,
+    });
+    return exit.value.result;
+  }
+
+  const error = Cause.squash(exit.cause);
+  const input = yield* Ref.get(inputRef);
+  const context = Option.getOrUndefined(yield* Ref.get(contextRef));
+  if (error instanceof CreateCancellationError) {
+    yield* trackCreateCancelledEffect({
+      input,
+      ...(context ? { context } : {}),
+      durationMs,
+      stage: error.stage,
+    });
+    return createCommandFailureResult(
+      error.stage,
+      error.message ?? "Operation cancelled.",
+      context ? projectResult(context) : undefined,
+    );
+  }
+
+  const failure =
+    error instanceof CreateFailure
+      ? error
+      : new CreateFailure({
+          stage: "unknown",
+          reason: "unexpected_error",
+          message: getErrorMessage(error),
+          cause: error,
+        });
+  const { output } = resolveExecutionSettings(rawInput);
+  if (!failure.errorReported) {
+    yield* Effect.sync(() => cancel(`Create command failed: ${failure.message}`, { output }));
+  }
+  yield* trackCreateFailedEffect({
+    input,
+    ...(context ? { context } : {}),
+    durationMs,
+    error: failure.cause ?? failure,
+    stage: failure.stage,
+    reason: failure.reason,
+  });
+  return createCommandFailureResult(
+    failure.stage,
+    failure.message,
+    context ? projectResult(context) : undefined,
+  );
+});
+
+export function runCreateCommand(rawInput: CreateCommandInput = {}): Promise<CreateCommandResult> {
+  return applicationRuntime.runPromise(runCreateCommandEffect(rawInput));
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,20 +1,12 @@
-import { cancel, intro, isCancel, log, select, spinner, text } from "@clack/prompts";
-import { Cause, Clock, Effect, Exit, FileSystem, Option, Ref, Schema } from "effect";
-import path from "node:path";
-import type { Writable } from "node:stream";
+import { cancel, intro, log, spinner } from "@clack/prompts";
+import { Cause, Clock, Effect, Exit, Option, Ref } from "effect";
 
-import {
-  CreateCancellationError,
-  CreateFailure,
-  type CreateFailureReason,
-  type CreateFailureStage,
-} from "../create-outcome";
+import { CreateCancellationError, CreateFailure } from "../create-outcome";
 import {
   CREATE_PRISMA_RESULT_SCHEMA_VERSION,
   createCommandFailureResult,
   type CreateCommandResult,
   type CreateNextStep,
-  type CreateProjectResult,
 } from "../result";
 import { applicationRuntime } from "../runtime";
 import {
@@ -24,227 +16,31 @@ import {
 } from "../telemetry/create";
 import { scaffoldCreateFrameworkTemplateEffect } from "../templates/render-create-template";
 import { writeCreateTemplateDependenciesEffect } from "../tasks/install";
-import {
-  collectPrismaSetupContextEffect,
-  executePrismaSetupContextEffect,
-  type PrismaSetupContext,
-} from "../tasks/setup-prisma";
-import {
-  CreateTemplateSchema,
-  decodeCreateCommandInput,
-  type CreateCommandInput,
-  type CreateTemplate,
-} from "../types";
+import { executePrismaSetupContextEffect } from "../tasks/setup-prisma";
+import { decodeCreateCommandInput, type CreateCommandInput } from "../types";
 import { getCreatePrismaIntro } from "../ui/branding";
 import { resolveExecutionSettings } from "../ui/output";
 import { getErrorMessage } from "../utils/errors";
 import { getUnsupportedNodeMessage, supportsPrisma } from "../utils/node-version";
-
-const DEFAULT_PROJECT_NAME = "my-app";
-const DEFAULT_TEMPLATE: CreateTemplate = "minimal";
-
-export type CreateTargetPathState = {
-  exists: boolean;
-  isDirectory: boolean;
-  isEmptyDirectory: boolean;
-};
-
-export type CreatePromptContext = {
-  targetDirectory: string;
-  targetPathState: CreateTargetPathState;
-  force: boolean;
-  template: CreateTemplate;
-  projectPackageName: string;
-  prismaSetupContext: PrismaSetupContext;
-};
-
-const toPackageName = (projectName: string) =>
-  projectName
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "") || "app";
-
-const formatPathForDisplay = (filePath: string) => path.relative(process.cwd(), filePath) || ".";
-
-function validateProjectName(value: string | undefined): string | undefined {
-  const trimmed = String(value ?? "").trim();
-  if (trimmed.length === 0) return "Please enter a project name.";
-  if (trimmed === "..") return "Project name cannot be '..'.";
-  if (path.isAbsolute(trimmed)) return "Use a relative project name instead of an absolute path.";
-}
-
-const projectResult = (context: CreatePromptContext): CreateProjectResult => ({
-  name: context.projectPackageName,
-  path: context.targetDirectory,
-  template: context.template,
-  databaseProvider: context.prismaSetupContext.databaseProvider,
-  authoring: context.prismaSetupContext.authoring,
-  packageManager: context.prismaSetupContext.packageManager,
-});
-
-const promptForProjectName = Effect.fn("Prompts.projectName")(function* (output: Writable) {
-  const value = yield* Effect.tryPromise(() =>
-    text({
-      message: "Project name",
-      placeholder: DEFAULT_PROJECT_NAME,
-      initialValue: DEFAULT_PROJECT_NAME,
-      validate: validateProjectName,
-      output,
-    }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "project_name" });
-  }
-  return String(value).trim();
-});
-
-const promptForCreateTemplate = Effect.fn("Prompts.template")(function* (output: Writable) {
-  const value = yield* Effect.tryPromise(() =>
-    select({
-      message: "Select template",
-      initialValue: DEFAULT_TEMPLATE,
-      options: [
-        {
-          value: "minimal",
-          label: "Minimal",
-          hint: "Script-first Prisma 8 starter with no web framework",
-        },
-        { value: "hono", label: "Hono", hint: "Lightweight TypeScript API server" },
-        { value: "elysia", label: "Elysia", hint: "Bun-friendly TypeScript API server" },
-        {
-          value: "nest",
-          label: "NestJS",
-          hint: "Structured Node API with controllers and services",
-        },
-        { value: "next", label: "Next.js", hint: "Full-stack React app with App Router" },
-        { value: "svelte", label: "SvelteKit", hint: "Full-stack Svelte 5 app with Vite" },
-        { value: "astro", label: "Astro", hint: "Content-oriented web app with server routes" },
-        { value: "nuxt", label: "Nuxt", hint: "Full-stack Vue app with Nitro server routes" },
-        {
-          value: "tanstack-start",
-          label: "TanStack Start",
-          hint: "React app with file routes and server functions",
-        },
-      ],
-      output,
-    }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "template" });
-  }
-  return yield* Schema.decodeUnknownEffect(CreateTemplateSchema)(value).pipe(
-    Effect.mapError(
-      (cause) =>
-        new CreateFailure({
-          stage: "collect_context",
-          reason: "invalid_input",
-          message: cause.message,
-          cause,
-        }),
-    ),
-  );
-});
-
-const inspectTargetPath = Effect.fn("Create.inspectTargetPath")(function* (targetPath: string) {
-  const fs = yield* FileSystem.FileSystem;
-  if (!(yield* fs.exists(targetPath))) {
-    return { exists: false, isDirectory: true, isEmptyDirectory: true };
-  }
-  const stats = yield* fs.stat(targetPath);
-  if (stats.type !== "Directory") {
-    return { exists: true, isDirectory: false, isEmptyDirectory: false };
-  }
-  return {
-    exists: true,
-    isDirectory: true,
-    isEmptyDirectory: (yield* fs.readDirectory(targetPath)).length === 0,
-  };
-});
-
-const collectCreateContext = Effect.fn("Create.collectContext")(function* (
-  input: CreateCommandInput,
-) {
-  const force = input.force === true;
-  const { output, useDefaults } = resolveExecutionSettings(input);
-  const projectName = String(
-    input.name ?? (useDefaults ? DEFAULT_PROJECT_NAME : yield* promptForProjectName(output)),
-  ).trim();
-  const validationError = validateProjectName(projectName);
-  if (validationError) {
-    yield* Effect.sync(() => cancel(validationError, { output }));
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "invalid_project_name",
-      message: validationError,
-      errorReported: true,
-    });
-  }
-
-  const template =
-    input.template ?? (useDefaults ? DEFAULT_TEMPLATE : yield* promptForCreateTemplate(output));
-  const targetDirectory = path.resolve(process.cwd(), projectName);
-  const targetPathState = yield* inspectTargetPath(targetDirectory);
-  if (targetPathState.exists && !targetPathState.isDirectory) {
-    const message = `Target path ${formatPathForDisplay(targetDirectory)} already exists and is not a directory. Choose a different project name.`;
-    yield* Effect.sync(() => cancel(message, { output }));
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "target_path_not_directory",
-      message,
-      errorReported: true,
-    });
-  }
-  if (targetPathState.exists && !targetPathState.isEmptyDirectory && !force) {
-    const message = `Target directory ${formatPathForDisplay(targetDirectory)} is not empty. Use --force to continue.`;
-    yield* Effect.sync(() => cancel(message, { output }));
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "target_directory_not_empty",
-      message,
-      errorReported: true,
-    });
-  }
-
-  const prismaSetupContext = yield* collectPrismaSetupContextEffect(input, {
-    projectDir: targetDirectory,
-    template,
-  });
-  return {
-    targetDirectory,
-    targetPathState,
-    force,
-    template,
-    projectPackageName: toPackageName(path.basename(targetDirectory)),
-    prismaSetupContext,
-  } satisfies CreatePromptContext;
-});
-
-const atStage = <A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  stage: CreateFailureStage,
-  reason: CreateFailureReason,
-) =>
-  effect.pipe(
-    Effect.mapError((error) =>
-      error instanceof CreateFailure || error instanceof CreateCancellationError
-        ? error
-        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
-    ),
-  );
+import { atCreateStage } from "../workflow/failure";
+import {
+  collectCreateContext,
+  createProjectResult,
+  formatPathForDisplay,
+  type CreatePromptContext,
+} from "./create-context";
 
 const executeCreateContext = Effect.fn("Create.execute")(function* (context: CreatePromptContext) {
   const output = context.prismaSetupContext.output;
   const createSpinner = context.prismaSetupContext.verbose ? undefined : spinner({ output });
   yield* Effect.sync(() => {
     createSpinner?.start("Creating Prisma 8 project...");
-    if (context.prismaSetupContext.verbose)
+    if (context.prismaSetupContext.verbose) {
       log.step(`Scaffolding ${context.template} starter.`, { output });
+    }
   });
 
-  yield* atStage(
+  yield* atCreateStage(
     scaffoldCreateFrameworkTemplateEffect({
       projectDir: context.targetDirectory,
       projectName: context.projectPackageName,
@@ -262,8 +58,9 @@ const executeCreateContext = Effect.fn("Create.execute")(function* (context: Cre
       ),
       Effect.tap(() =>
         Effect.sync(() => {
-          if (context.prismaSetupContext.verbose)
+          if (context.prismaSetupContext.verbose) {
             log.success("Starter files scaffolded.", { output });
+          }
         }),
       ),
       Effect.tapError(() =>
@@ -304,7 +101,7 @@ const executeCreateContext = Effect.fn("Create.execute")(function* (context: Cre
   return {
     schemaVersion: CREATE_PRISMA_RESULT_SCHEMA_VERSION,
     ok: true,
-    project: projectResult(context),
+    project: createProjectResult(context),
     deployment: setup.deployment,
     nextSteps: setup.nextSteps,
     warnings,
@@ -348,7 +145,7 @@ const createProjectEffect = Effect.fn("Create.project")(function* (
   }
 
   yield* Effect.sync(() => intro(getCreatePrismaIntro(), { output }));
-  const context = yield* atStage(
+  const context = yield* atCreateStage(
     collectCreateContext(input),
     "collect_context",
     "unexpected_error",
@@ -388,7 +185,7 @@ export const runCreateCommandEffect = Effect.fn("Create.run")(function* (
     return createCommandFailureResult(
       error.stage,
       error.message ?? "Operation cancelled.",
-      context ? projectResult(context) : undefined,
+      context ? createProjectResult(context) : undefined,
     );
   }
 
@@ -416,10 +213,12 @@ export const runCreateCommandEffect = Effect.fn("Create.run")(function* (
   return createCommandFailureResult(
     failure.stage,
     failure.message,
-    context ? projectResult(context) : undefined,
+    context ? createProjectResult(context) : undefined,
   );
 });
 
 export function runCreateCommand(rawInput: CreateCommandInput = {}): Promise<CreateCommandResult> {
   return applicationRuntime.runPromise(runCreateCommandEffect(rawInput));
 }
+
+export type { CreatePromptContext, CreateTargetPathState } from "./create-context";

--- a/src/create-outcome.ts
+++ b/src/create-outcome.ts
@@ -1,80 +1,109 @@
-export type CreateFailureStage =
-  | "validate_input"
-  | "collect_context"
-  | "scaffold_template"
-  | "initialize_prisma"
-  | "configure_project"
-  | "install_dependencies"
-  | "initialize_agent_skills"
-  | "emit_contract"
-  | "plan_migration"
-  | "initialize_git"
-  | "authenticate"
-  | "select_workspace"
-  | "check_project_name"
-  | "build"
-  | "composer_deploy"
-  | "unknown";
+import { Schema } from "effect";
 
-export type CreateFailureReason =
-  | "invalid_input"
-  | "unsupported_node_version"
-  | "invalid_project_name"
-  | "target_path_not_directory"
-  | "target_directory_not_empty"
-  | "unsupported_configuration"
-  | "template_scaffold_failed"
-  | "prisma_init_failed"
-  | "project_configuration_failed"
-  | "dependency_install_failed"
-  | "agent_skills_init_failed"
-  | "contract_emit_failed"
-  | "migration_plan_failed"
-  | "git_initialization_failed"
-  | "prisma_auth_command_failed"
-  | "not_authenticated"
-  | "authentication_failed"
-  | "workspace_missing"
-  | "workspace_mismatch"
-  | "workspace_selection_failed"
-  | "project_lookup_failed"
-  | "project_name_collision"
-  | "build_failed"
-  | "composer_deploy_failed"
-  | "unexpected_error";
+export const CreateFailureStageSchema = Schema.Literals([
+  "validate_input",
+  "collect_context",
+  "scaffold_template",
+  "initialize_prisma",
+  "configure_project",
+  "install_dependencies",
+  "initialize_agent_skills",
+  "emit_contract",
+  "plan_migration",
+  "initialize_git",
+  "authenticate",
+  "select_workspace",
+  "check_project_name",
+  "build",
+  "composer_deploy",
+  "unknown",
+]);
+export type CreateFailureStage = typeof CreateFailureStageSchema.Type;
 
-export type CreateCancellationStage =
-  | "project_name"
-  | "template"
-  | "database_provider"
-  | "authoring_style"
-  | "package_manager"
-  | "deployment_intent"
-  | "select_workspace";
+export const CreateFailureReasonSchema = Schema.Literals([
+  "invalid_input",
+  "unsupported_node_version",
+  "invalid_project_name",
+  "target_path_not_directory",
+  "target_directory_not_empty",
+  "unsupported_configuration",
+  "template_scaffold_failed",
+  "prisma_init_failed",
+  "project_configuration_failed",
+  "dependency_install_failed",
+  "agent_skills_init_failed",
+  "contract_emit_failed",
+  "migration_plan_failed",
+  "git_initialization_failed",
+  "prisma_auth_command_failed",
+  "not_authenticated",
+  "authentication_failed",
+  "workspace_missing",
+  "workspace_mismatch",
+  "workspace_selection_failed",
+  "project_lookup_failed",
+  "project_name_collision",
+  "build_failed",
+  "composer_deploy_failed",
+  "unexpected_error",
+]);
+export type CreateFailureReason = typeof CreateFailureReasonSchema.Type;
 
-export class CreateCancellationError extends Error {
-  readonly stage: CreateCancellationStage;
+export const CreateCancellationStageSchema = Schema.Literals([
+  "project_name",
+  "template",
+  "database_provider",
+  "authoring_style",
+  "package_manager",
+  "deployment_intent",
+  "select_workspace",
+]);
+export type CreateCancellationStage = typeof CreateCancellationStageSchema.Type;
 
-  constructor(stage: CreateCancellationStage) {
-    super("Operation cancelled.");
-    this.name = "CreateCancellationError";
-    this.stage = stage;
+export class CreateCancellationError extends Schema.TaggedError<CreateCancellationError>()(
+  "CreateCancellationError",
+  {
+    stage: CreateCancellationStageSchema,
+    message: Schema.optionalKey(Schema.String),
+  },
+) {
+  constructor(options: { stage: CreateCancellationStage; message?: string }) {
+    super({ message: "Operation cancelled.", ...options });
   }
 }
 
-export class ClassifiedCreateError extends Error {
-  readonly reason: CreateFailureReason;
+export class CreateFailure extends Schema.TaggedError<CreateFailure>()("CreateFailure", {
+  stage: CreateFailureStageSchema,
+  reason: CreateFailureReasonSchema,
+  message: Schema.String,
+  cause: Schema.optionalKey(Schema.Defect()),
+  errorReported: Schema.optionalKey(Schema.Boolean),
+}) {}
 
-  constructor(reason: CreateFailureReason, message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "ClassifiedCreateError";
-    this.reason = reason;
-  }
+export class PrismaCliCommandError extends Schema.TaggedError<PrismaCliCommandError>()(
+  "PrismaCliCommandError",
+  {
+    message: Schema.String,
+    command: Schema.optionalKey(Schema.String),
+    code: Schema.optionalKey(Schema.String),
+    stderr: Schema.optionalKey(Schema.String),
+    exitCode: Schema.optionalKey(Schema.Number),
+  },
+) {
+  readonly prismaCliCommand = this.command;
+  readonly prismaCliErrorCode = this.code;
 }
 
-export function getCreateFailureReason(
-  error: unknown,
-  fallback: CreateFailureReason,
-): CreateFailureReason {
-  return error instanceof ClassifiedCreateError ? error.reason : fallback;
+export function isCreateFailure(error: unknown): error is CreateFailure {
+  return error instanceof CreateFailure;
+}
+
+export function toCreateFailure(options: {
+  stage: CreateFailureStage;
+  reason: CreateFailureReason;
+  message: string;
+  cause?: unknown;
+  errorReported?: boolean;
+}): CreateFailure {
+  return new CreateFailure(options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,144 @@
-import { os } from "@orpc/server";
-import { createCli } from "trpc-cli";
-import { z } from "zod";
+import { Console, Effect, Option } from "effect";
+import { Argument, CliError, Command, Flag } from "effect/unstable/cli";
 
-import { runCreateCommand } from "./commands/create";
-import { CreateCommandInputSchema, type CreateCommandInput } from "./types";
+import { runCreateCommandEffect } from "./commands/create";
+import { createCommandFailureResult } from "./result";
+import { applicationRuntime } from "./runtime";
+import {
+  authoringStyles,
+  createTemplates,
+  databaseProviderInputs,
+  normalizeDatabaseProvider,
+  packageManagers,
+  type CreateCommandInput,
+} from "./types";
+import { isJsonOutputRequested, writeJsonResult } from "./ui/json-output";
+import { getErrorMessage } from "./utils/errors";
 
 const CLI_VERSION = process.env.CREATE_PRISMA_CLI_VERSION ?? "0.0.0";
 
-const CreateCliInputSchema = z.tuple([
-  z
-    .string()
-    .trim()
-    .min(1, "Please enter a valid project name")
-    .optional()
-    .describe("Project name / directory"),
-  CreateCommandInputSchema,
-]);
+const optionalArgument = (name: string, description: string) =>
+  Argument.string(name).pipe(
+    Argument.withDescription(description),
+    Argument.optional,
+    Argument.map(Option.getOrUndefined),
+  );
+const optionalBoolean = (name: string, description: string) =>
+  Flag.boolean(name).pipe(
+    Flag.withDescription(description),
+    Flag.optional,
+    Flag.map(Option.getOrUndefined),
+  );
+const optionalString = (name: string, description: string) =>
+  Flag.string(name).pipe(
+    Flag.withDescription(description),
+    Flag.optional,
+    Flag.map(Option.getOrUndefined),
+  );
 
-function normalizeCreateCliInput(input: z.infer<typeof CreateCliInputSchema>): CreateCommandInput {
-  const [projectName, options] = input;
+export const createPrismaCommand = Command.make(
+  "create-prisma",
+  {
+    projectName: optionalArgument("project-name", "Project name / directory"),
+    name: optionalString("name", "Project name / directory"),
+    template: Flag.choice("template", createTemplates).pipe(
+      Flag.withDescription("Project template"),
+      Flag.optional,
+      Flag.map(Option.getOrUndefined),
+    ),
+    provider: Flag.choice("provider", databaseProviderInputs).pipe(
+      Flag.withDescription("Database provider"),
+      Flag.optional,
+      Flag.map(Option.map(normalizeDatabaseProvider)),
+      Flag.map(Option.getOrUndefined),
+    ),
+    authoring: Flag.choice("authoring", authoringStyles).pipe(
+      Flag.withDescription("Contract authoring style"),
+      Flag.optional,
+      Flag.map(Option.getOrUndefined),
+    ),
+    packageManager: Flag.choice("package-manager", packageManagers).pipe(
+      Flag.withDescription("Package manager used for dependency installation"),
+      Flag.optional,
+      Flag.map(Option.getOrUndefined),
+    ),
+    deploy: optionalBoolean("deploy", "Deploy the generated app to Prisma immediately"),
+    workspace: optionalString("workspace", "Prisma workspace id or name to deploy into"),
+    force: optionalBoolean("force", "Allow scaffolding into a non-empty target directory"),
+    yes: optionalBoolean("yes", "Skip prompts and accept default choices"),
+    verbose: optionalBoolean("verbose", "Show verbose command output during setup"),
+    json: optionalBoolean(
+      "json",
+      "Emit one quiet JSON result for agents and automation (non-interactive; deploys unless --no-deploy)",
+    ),
+  },
+  Effect.fn("Cli.create")(function* (options) {
+    const input: CreateCommandInput = {
+      ...((options.name ?? options.projectName)
+        ? { name: options.name ?? options.projectName }
+        : {}),
+      ...(options.template ? { template: options.template } : {}),
+      ...(options.provider ? { provider: options.provider } : {}),
+      ...(options.authoring ? { authoring: options.authoring } : {}),
+      ...(options.packageManager ? { packageManager: options.packageManager } : {}),
+      ...(options.deploy !== undefined ? { deploy: options.deploy } : {}),
+      ...(options.workspace ? { workspace: options.workspace } : {}),
+      ...(options.force !== undefined ? { force: options.force } : {}),
+      ...(options.yes !== undefined ? { yes: options.yes } : {}),
+      ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
+      ...(options.json !== undefined ? { json: options.json } : {}),
+    };
+    const result = yield* runCreateCommandEffect(input);
+    if (input.json) yield* writeJsonResult(result);
+    if (!result.ok) yield* Effect.sync(() => void (process.exitCode = 1));
+  }),
+).pipe(
+  Command.withDescription("Create a new project with Prisma setup"),
+  Command.withExamples([
+    { command: "create-prisma my-app", description: "Create a project interactively" },
+    {
+      command: "create-prisma my-app --yes --json",
+      description: "Create and deploy with machine-readable output",
+    },
+  ]),
+);
 
-  return {
-    ...options,
-    name: options.name ?? projectName,
-  };
-}
-
-export const router = os.router({
-  create: os
-    .meta({
-      description: "Create a new project with Prisma setup",
-      default: true,
-      negateBooleans: true,
-    })
-    .input(CreateCliInputSchema)
-    .handler(async ({ input }) => {
-      const createInput = normalizeCreateCliInput(input);
-      const result = await runCreateCommand(createInput);
-      return createInput.json ? result : undefined;
-    }),
+const silentConsole: Console.Console = Object.assign(Object.create(console), {
+  log() {},
+  error() {},
 });
 
 export function createCreatePrismaCli() {
-  return createCli({
-    router,
-    name: "create-prisma",
-    version: CLI_VERSION,
-  });
+  return createPrismaCommand;
 }
 
-export async function create(input: CreateCommandInput = {}): Promise<void> {
-  await runCreateCommand(input);
+export function runCreatePrismaCli(argv: readonly string[] = process.argv.slice(2)) {
+  const json = isJsonOutputRequested(argv);
+  const args = argv[0] === "create" ? argv.slice(1) : argv;
+  let program = Command.runWith(createPrismaCommand, {
+    version: CLI_VERSION,
+    renderErrors: !json,
+  })(args).pipe(
+    Effect.catch((error) =>
+      Effect.gen(function* () {
+        if (error instanceof CliError.ShowHelp && error.errors.length === 0) return;
+        process.exitCode = 1;
+        if (json) {
+          const message =
+            error instanceof CliError.ShowHelp
+              ? error.errors.map((item) => item.message).join("; ")
+              : getErrorMessage(error);
+          yield* writeJsonResult(createCommandFailureResult("parse_arguments", message));
+        }
+      }),
+    ),
+  );
+  if (json) program = Effect.provideService(program, Console.Console, silentConsole);
+  return program;
+}
+
+export function create(input: CreateCommandInput = {}): Promise<void> {
+  return applicationRuntime.runPromise(runCreateCommandEffect(input).pipe(Effect.asVoid));
 }
 
 export type { CreateCommandInput };
@@ -62,7 +150,7 @@ export type {
   CreateNextStep,
   CreateProjectResult,
 } from "./result";
-export { CREATE_PRISMA_RESULT_SCHEMA_VERSION } from "./result";
+export { CREATE_PRISMA_RESULT_SCHEMA_VERSION, CreateCommandResultSchema } from "./result";
 export {
   AuthoringStyleSchema,
   CreateCommandInputSchema,

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,48 +1,92 @@
-import type { CreateCancellationStage, CreateFailureStage } from "./create-outcome";
-import type { ComposerDeployResult } from "./tasks/deploy-with-composer";
-import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "./types";
+import { Schema } from "effect";
+
+import {
+  CreateCancellationStageSchema,
+  CreateFailureStageSchema,
+  type CreateCancellationStage,
+  type CreateFailureStage,
+} from "./create-outcome";
+import {
+  AuthoringStyleSchema,
+  CreateTemplateSchema,
+  DatabaseProviderSchema,
+  PackageManagerSchema,
+} from "./types";
 
 export const CREATE_PRISMA_RESULT_SCHEMA_VERSION = 1 as const;
 
-export type CreateNextStep = {
-  command: string;
-  description: string;
-};
+export const PrismaWorkspaceSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.NullOr(Schema.String),
+});
+export type PrismaWorkspace = typeof PrismaWorkspaceSchema.Type;
 
-export type CreateProjectResult = {
-  name: string;
-  path: string;
-  template: CreateTemplate;
-  databaseProvider: DatabaseProvider;
-  authoring: AuthoringStyle;
-  packageManager: PackageManager;
-};
+export const ComposerDeployResultSchema = Schema.Struct({
+  appName: Schema.String,
+  appUrl: Schema.optionalKey(Schema.String),
+  serviceId: Schema.optionalKey(Schema.String),
+  workspace: Schema.optionalKey(PrismaWorkspaceSchema),
+  project: Schema.Struct({
+    id: Schema.optionalKey(Schema.String),
+    name: Schema.String,
+    consoleUrl: Schema.optionalKey(Schema.String),
+  }),
+});
+export type ComposerDeployResult = typeof ComposerDeployResultSchema.Type;
+
+export const CreateNextStepSchema = Schema.Struct({
+  command: Schema.String,
+  description: Schema.String,
+});
+export type CreateNextStep = typeof CreateNextStepSchema.Type;
+
+export const CreateProjectResultSchema = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+  template: CreateTemplateSchema,
+  databaseProvider: DatabaseProviderSchema,
+  authoring: AuthoringStyleSchema,
+  packageManager: PackageManagerSchema,
+});
+export type CreateProjectResult = typeof CreateProjectResultSchema.Type;
 
 export type CreateCommandFailureStage =
   | CreateFailureStage
   | CreateCancellationStage
   | "parse_arguments";
 
-export type CreateCommandSuccessResult = {
-  schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;
-  ok: true;
-  project: CreateProjectResult;
-  deployment: ComposerDeployResult | null;
-  nextSteps: CreateNextStep[];
-  warnings: string[];
-};
+export const CreateCommandFailureStageSchema = Schema.Union([
+  CreateFailureStageSchema,
+  CreateCancellationStageSchema,
+  Schema.Literal("parse_arguments"),
+]);
 
-export type CreateCommandFailureResult = {
-  schemaVersion: typeof CREATE_PRISMA_RESULT_SCHEMA_VERSION;
-  ok: false;
-  error: {
-    stage: CreateCommandFailureStage;
-    message: string;
-  };
-  project?: CreateProjectResult;
-};
+export const CreateCommandSuccessResultSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(CREATE_PRISMA_RESULT_SCHEMA_VERSION),
+  ok: Schema.Literal(true),
+  project: CreateProjectResultSchema,
+  deployment: Schema.NullOr(ComposerDeployResultSchema),
+  nextSteps: Schema.Array(CreateNextStepSchema),
+  warnings: Schema.Array(Schema.String),
+});
+export type CreateCommandSuccessResult = typeof CreateCommandSuccessResultSchema.Type;
 
-export type CreateCommandResult = CreateCommandSuccessResult | CreateCommandFailureResult;
+export const CreateCommandFailureResultSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(CREATE_PRISMA_RESULT_SCHEMA_VERSION),
+  ok: Schema.Literal(false),
+  error: Schema.Struct({
+    stage: CreateCommandFailureStageSchema,
+    message: Schema.String,
+  }),
+  project: Schema.optionalKey(CreateProjectResultSchema),
+});
+export type CreateCommandFailureResult = typeof CreateCommandFailureResultSchema.Type;
+
+export const CreateCommandResultSchema = Schema.Union([
+  CreateCommandSuccessResultSchema,
+  CreateCommandFailureResultSchema,
+]);
+export type CreateCommandResult = typeof CreateCommandResultSchema.Type;
 
 export function createCommandFailureResult(
   stage: CreateCommandFailureStage,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,19 @@
+import {
+  NodeChildProcessSpawner,
+  NodeFileSystem,
+  NodePath,
+  NodeStdio,
+  NodeTerminal,
+} from "@effect/platform-node-shared";
+import { Layer, ManagedRuntime } from "effect";
+
+import { CommandRunner } from "./services/command-runner";
+
+const NodeCliLayer = Layer.provideMerge(
+  NodeChildProcessSpawner.layer,
+  Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, NodeStdio.layer, NodeTerminal.layer),
+);
+
+export const ApplicationLayer = Layer.merge(NodeCliLayer, CommandRunner.layer);
+
+export const applicationRuntime = ManagedRuntime.make(ApplicationLayer);

--- a/src/services/command-runner.ts
+++ b/src/services/command-runner.ts
@@ -68,7 +68,15 @@ export class CommandRunner extends Context.Service<
                 })()
               : Promise.resolve();
 
-          const [result] = await Promise.all([subprocess, stderrLines]);
+          let result: Awaited<typeof subprocess>;
+          try {
+            [result] = await Promise.all([subprocess, stderrLines]);
+          } catch (cause) {
+            const error = cause instanceof Error ? cause : new Error(String(cause));
+            subprocess.kill(error);
+            await subprocess.catch(() => undefined);
+            throw cause;
+          }
           return {
             exitCode: result.exitCode ?? 1,
             stdout: typeof result.stdout === "string" ? result.stdout : "",

--- a/src/services/command-runner.ts
+++ b/src/services/command-runner.ts
@@ -1,0 +1,105 @@
+import { Context, Effect, Layer, Schema } from "effect";
+import { execa } from "execa";
+import { createInterface } from "node:readline";
+
+export type CommandSpec = {
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  stdio?: "pipe" | "inherit";
+  onStderrLine?: (line: string) => void;
+};
+
+export type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export class CommandExecutionError extends Schema.TaggedError<CommandExecutionError>()(
+  "CommandExecutionError",
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    exitCode: Schema.optionalKey(Schema.Number),
+    stdout: Schema.String,
+    stderr: Schema.String,
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    const detail = this.stderr.trim() || this.stdout.trim();
+    const invocation = [this.command, ...this.args].join(" ");
+    return (
+      detail ||
+      `Command failed${this.exitCode === undefined ? "" : ` with exit code ${this.exitCode}`}: ${invocation}`
+    );
+  }
+}
+
+export class CommandRunner extends Context.Service<
+  CommandRunner,
+  {
+    run(spec: CommandSpec): Effect.Effect<CommandResult, CommandExecutionError>;
+    runChecked(spec: CommandSpec): Effect.Effect<CommandResult, CommandExecutionError>;
+  }
+>()("create-prisma/services/CommandRunner") {
+  static readonly layer = Layer.sync(CommandRunner, () => {
+    const run = Effect.fn("CommandRunner.run")((spec: CommandSpec) =>
+      Effect.tryPromise({
+        try: async (signal) => {
+          const subprocess = execa(spec.command, [...spec.args], {
+            cwd: spec.cwd,
+            env: spec.env,
+            stdio: spec.stdio ?? "pipe",
+            reject: false,
+            cancelSignal: signal,
+          });
+          const stderr = subprocess.stderr;
+
+          const stderrLines =
+            spec.onStderrLine && stderr
+              ? (async () => {
+                  const lines = createInterface({ input: stderr });
+                  for await (const line of lines) {
+                    if (line.trim()) spec.onStderrLine?.(line);
+                  }
+                })()
+              : Promise.resolve();
+
+          const [result] = await Promise.all([subprocess, stderrLines]);
+          return {
+            exitCode: result.exitCode ?? 1,
+            stdout: typeof result.stdout === "string" ? result.stdout : "",
+            stderr: typeof result.stderr === "string" ? result.stderr : "",
+          };
+        },
+        catch: (cause) =>
+          new CommandExecutionError({
+            command: spec.command,
+            args: [...spec.args],
+            stdout: "",
+            stderr: "",
+            cause,
+          }),
+      }),
+    );
+    const runChecked = Effect.fn("CommandRunner.runChecked")((spec: CommandSpec) =>
+      Effect.flatMap(run(spec), (result) =>
+        result.exitCode === 0
+          ? Effect.succeed(result)
+          : Effect.fail(
+              new CommandExecutionError({
+                command: spec.command,
+                args: [...spec.args],
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr,
+              }),
+            ),
+      ),
+    );
+    return CommandRunner.of({ run, runChecked });
+  });
+}

--- a/src/tasks/composer/auth.ts
+++ b/src/tasks/composer/auth.ts
@@ -1,0 +1,181 @@
+import { cancel, isCancel, log, select } from "@clack/prompts";
+import { Effect, Schema } from "effect";
+import type { Writable } from "node:stream";
+
+import { CreateCancellationError, CreateFailure } from "../../create-outcome";
+import { PrismaWorkspaceSchema } from "../../result";
+import { CommandRunner } from "../../services/command-runner";
+import type { PackageManager } from "../../types";
+import {
+  getLocalPackageBinaryArgs,
+  getLocalPackageBinaryCommand,
+  getRunScriptCommand,
+} from "../../utils/package-manager";
+import { decodePrismaCommandResult, runPrismaJsonCommandEffect } from "./prisma-cli";
+import { getWorkspaceLabel } from "./workspace";
+
+const WhoamiResultSchema = Schema.Struct({
+  authenticated: Schema.Boolean,
+  workspace: Schema.NullOr(PrismaWorkspaceSchema),
+  source: Schema.NullOr(Schema.Literals(["stored", "environment"])),
+});
+export type WhoamiResult = typeof WhoamiResultSchema.Type;
+
+const WorkspaceListResultSchema = Schema.Struct({
+  items: Schema.Array(
+    Schema.Struct({
+      workspaceId: Schema.String,
+      workspaceName: Schema.NullOr(Schema.String),
+      current: Schema.Boolean,
+    }),
+  ),
+});
+
+const WorkspaceUseResultSchema = Schema.Struct({ workspace: PrismaWorkspaceSchema });
+
+export const ensureAuthentication = Effect.fn("Deployment.ensureAuthentication")(
+  function* (options: {
+    packageManager: PackageManager;
+    projectDir: string;
+    output: Writable;
+    allowInteractiveLogin: boolean;
+    beforeInteractiveLogin?: () => void;
+  }) {
+    const whoami = Effect.fn("PrismaCli.whoami")(function* () {
+      const raw = yield* runPrismaJsonCommandEffect({
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        args: ["auth", "whoami"],
+      });
+      return yield* decodePrismaCommandResult(WhoamiResultSchema, raw);
+    });
+
+    const authState = yield* whoami();
+    if (authState.authenticated) return authState;
+    const loginCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
+      "auth",
+      "login",
+    ]);
+    if (!options.allowInteractiveLogin || process.stdin.isTTY !== true) {
+      return yield* new CreateFailure({
+        stage: "authenticate",
+        reason: "not_authenticated",
+        message: `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
+      });
+    }
+
+    yield* Effect.sync(() => {
+      options.beforeInteractiveLogin?.();
+      log.info("Sign in to Prisma to deploy.", { output: options.output });
+    });
+    const runner = yield* CommandRunner;
+    const login = getLocalPackageBinaryArgs(options.packageManager, "prisma", ["auth", "login"]);
+    yield* runner.runChecked({
+      command: login.command,
+      args: login.args,
+      cwd: options.projectDir,
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    const authenticatedState = yield* whoami();
+    if (!authenticatedState.authenticated) {
+      return yield* new CreateFailure({
+        stage: "authenticate",
+        reason: "authentication_failed",
+        message: "Prisma sign-in completed without an active workspace session.",
+      });
+    }
+    return authenticatedState;
+  },
+);
+
+const useWorkspace = Effect.fn("Deployment.useWorkspace")(function* (options: {
+  packageManager: PackageManager;
+  projectDir: string;
+  workspace: string;
+}) {
+  const raw = yield* runPrismaJsonCommandEffect({
+    packageManager: options.packageManager,
+    projectDir: options.projectDir,
+    args: ["auth", "workspace", "use", options.workspace],
+  });
+  return (yield* decodePrismaCommandResult(WorkspaceUseResultSchema, raw)).workspace;
+});
+
+export const selectDeploymentWorkspace = Effect.fn("Deployment.selectWorkspace")(
+  function* (options: {
+    packageManager: PackageManager;
+    projectDir: string;
+    shouldPrompt: boolean;
+    workspace?: string;
+    authState: WhoamiResult;
+    beforePrompt?: () => void;
+    afterPrompt?: () => void;
+    output: Writable;
+  }) {
+    const activeWorkspace = options.authState.workspace;
+    if (!activeWorkspace) {
+      return yield* new CreateFailure({
+        stage: "select_workspace",
+        reason: "workspace_missing",
+        message: "The active Prisma credential does not specify a workspace.",
+      });
+    }
+
+    if (options.workspace) {
+      if (options.authState.source === "environment") {
+        if (
+          options.workspace === activeWorkspace.id ||
+          options.workspace === activeWorkspace.name
+        ) {
+          return activeWorkspace;
+        }
+        return yield* new CreateFailure({
+          stage: "select_workspace",
+          reason: "workspace_mismatch",
+          message: `The environment credential is fixed to workspace ${getWorkspaceLabel(activeWorkspace)}. Unset it before using --workspace ${options.workspace}.`,
+        });
+      }
+      return yield* useWorkspace({
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        workspace: options.workspace,
+      });
+    }
+
+    if (!options.shouldPrompt || process.stdin.isTTY !== true) return activeWorkspace;
+    const raw = yield* runPrismaJsonCommandEffect({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      args: ["auth", "workspace", "list"],
+    });
+    const available = yield* decodePrismaCommandResult(WorkspaceListResultSchema, raw);
+    if (available.items.length <= 1) return activeWorkspace;
+
+    yield* Effect.sync(() => options.beforePrompt?.());
+    const selectedWorkspaceId = yield* Effect.tryPromise(() =>
+      select({
+        message: "Select Prisma workspace for deployment",
+        initialValue: activeWorkspace.id,
+        options: available.items.map((workspace) => ({
+          value: workspace.workspaceId,
+          label: workspace.workspaceName ?? workspace.workspaceId,
+          hint: workspace.current ? `${workspace.workspaceId}, current` : workspace.workspaceId,
+        })),
+        output: options.output,
+      }),
+    );
+    if (isCancel(selectedWorkspaceId)) {
+      yield* Effect.sync(() => cancel("Operation cancelled.", { output: options.output }));
+      return yield* new CreateCancellationError({ stage: "select_workspace" });
+    }
+    yield* Effect.sync(() => options.afterPrompt?.());
+    if (selectedWorkspaceId === activeWorkspace.id) return activeWorkspace;
+    return yield* useWorkspace({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      workspace: selectedWorkspaceId,
+    });
+  },
+);

--- a/src/tasks/composer/deployment-result.ts
+++ b/src/tasks/composer/deployment-result.ts
@@ -1,0 +1,35 @@
+import { Schema } from "effect";
+
+export const ComposerDeployCommandResultSchema = Schema.Struct({
+  summary: Schema.NullOr(
+    Schema.Struct({
+      app: Schema.String,
+      nodes: Schema.Array(
+        Schema.Struct({
+          entities: Schema.Array(
+            Schema.Struct({
+              kind: Schema.String,
+              id: Schema.String,
+              url: Schema.optionalKey(Schema.String),
+            }),
+          ),
+        }),
+      ),
+    }),
+  ),
+});
+export type ComposerDeployCommandResult = typeof ComposerDeployCommandResultSchema.Type;
+
+export function parseComposerDeployResult(
+  result: ComposerDeployCommandResult,
+): { appName: string; appUrl?: string; serviceId?: string } | undefined {
+  if (!result.summary) return;
+  const computeService = result.summary.nodes
+    .flatMap((node) => node.entities)
+    .find((entity) => entity.kind === "compute-service");
+  return {
+    appName: result.summary.app,
+    ...(computeService?.id ? { serviceId: computeService.id } : {}),
+    ...(computeService?.url ? { appUrl: computeService.url.replace(/\/$/, "") } : {}),
+  };
+}

--- a/src/tasks/composer/prisma-cli.ts
+++ b/src/tasks/composer/prisma-cli.ts
@@ -1,0 +1,105 @@
+import { Effect, Schema } from "effect";
+
+import { PrismaCliCommandError } from "../../create-outcome";
+import { CommandRunner } from "../../services/command-runner";
+import type { PackageManager } from "../../types";
+import { getErrorMessage } from "../../utils/errors";
+import { getLocalPackageBinaryArgs } from "../../utils/package-manager";
+
+const PrismaCliEnvelopeSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  command: Schema.optionalKey(Schema.String),
+  commandId: Schema.optionalKey(Schema.String),
+  result: Schema.optionalKey(Schema.Unknown),
+  error: Schema.optionalKey(
+    Schema.Struct({
+      code: Schema.optionalKey(Schema.String),
+      summary: Schema.optionalKey(Schema.String),
+      message: Schema.optionalKey(Schema.String),
+      why: Schema.optionalKey(Schema.String),
+    }),
+  ),
+});
+type PrismaCliEnvelope = typeof PrismaCliEnvelopeSchema.Type;
+const decodePrismaCliEnvelope = Schema.decodeUnknownExit(PrismaCliEnvelopeSchema);
+
+export function parsePrismaCliEnvelope(output: string): PrismaCliEnvelope {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reverse();
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const candidate = parsed.kind === "result" ? parsed.envelope : parsed;
+      const decoded = decodePrismaCliEnvelope(candidate);
+      if (decoded._tag === "Success") return decoded.value;
+    } catch {
+      // Prisma may emit progress frames before the terminal JSON envelope.
+    }
+  }
+  throw new Error("Prisma CLI returned output that is not a valid result envelope.");
+}
+
+export const runPrismaJsonCommandEffect = Effect.fn("PrismaCli.runJson")(function* (options: {
+  packageManager: PackageManager;
+  projectDir: string;
+  args: string[];
+  onStderrLine?: (line: string) => void;
+}) {
+  const runner = yield* CommandRunner;
+  const invocation = getLocalPackageBinaryArgs(options.packageManager, "prisma", [
+    ...options.args,
+    "--json",
+    "--no-interactive",
+  ]);
+  const result = yield* runner.run({
+    command: invocation.command,
+    args: invocation.args,
+    cwd: options.projectDir,
+    env: process.env,
+    ...(options.onStderrLine ? { onStderrLine: options.onStderrLine } : {}),
+  });
+
+  let envelope: PrismaCliEnvelope;
+  try {
+    envelope = parsePrismaCliEnvelope(result.stdout);
+  } catch (cause) {
+    return yield* new PrismaCliCommandError({
+      message: result.stderr.trim() || getErrorMessage(cause),
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+
+  if (result.exitCode !== 0 || !envelope.ok || envelope.result === undefined) {
+    const summary = envelope.error?.summary ?? envelope.error?.message;
+    return yield* new PrismaCliCommandError({
+      message:
+        [summary, envelope.error?.why].filter(Boolean).join(": ") ||
+        result.stderr.trim() ||
+        "Prisma CLI command failed.",
+      ...(envelope.commandId || envelope.command
+        ? { command: envelope.commandId ?? envelope.command }
+        : {}),
+      ...(envelope.error?.code ? { code: envelope.error.code } : {}),
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+  return envelope.result;
+});
+
+export const decodePrismaCommandResult = <A>(schema: Schema.Codec<A>, value: unknown) =>
+  Schema.decodeUnknownEffect(schema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new PrismaCliCommandError({
+          message: `Prisma CLI returned an invalid result: ${cause.message}`,
+        }),
+    ),
+  );
+
+export { PrismaCliCommandError } from "../../create-outcome";

--- a/src/tasks/composer/projects.ts
+++ b/src/tasks/composer/projects.ts
@@ -1,0 +1,79 @@
+import { Effect, Schema } from "effect";
+
+import { CreateFailure } from "../../create-outcome";
+import { PrismaWorkspaceSchema, type PrismaWorkspace } from "../../result";
+import type { PackageManager } from "../../types";
+import { decodePrismaCommandResult, runPrismaJsonCommandEffect } from "./prisma-cli";
+import { getWorkspaceLabel } from "./workspace";
+
+const ProjectShowResultSchema = Schema.Struct({
+  workspace: PrismaWorkspaceSchema,
+  project: Schema.NullOr(Schema.Struct({ id: Schema.String, name: Schema.String })),
+});
+
+const ProjectListResultSchema = Schema.Struct({
+  items: Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.String })),
+});
+type ProjectListResult = typeof ProjectListResultSchema.Type;
+
+const stripResourcePrefix = (id: string, prefix: "proj" | "wksp") =>
+  id.startsWith(`${prefix}_`) ? id.slice(prefix.length + 1) : id;
+
+export function getConsoleProjectUrl(workspaceId: string, projectId: string): string {
+  return `https://console.prisma.io/${encodeURIComponent(stripResourcePrefix(workspaceId, "wksp"))}/${encodeURIComponent(stripResourcePrefix(projectId, "proj"))}`;
+}
+
+export function findProjectNameCollisions(
+  projects: ProjectListResult["items"],
+  appName: string,
+): ProjectListResult["items"] {
+  return projects.filter((project) => project.name === appName);
+}
+
+export const ensureProjectNameAvailable = Effect.fn("Deployment.ensureProjectNameAvailable")(
+  function* (options: {
+    appName: string;
+    packageManager: PackageManager;
+    projectDir: string;
+    workspace: PrismaWorkspace;
+  }) {
+    const raw = yield* runPrismaJsonCommandEffect({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      args: ["project", "list"],
+    });
+    const result = yield* decodePrismaCommandResult(ProjectListResultSchema, raw);
+    const collisions = findProjectNameCollisions(result.items, options.appName);
+    if (collisions.length === 0) return;
+    const projectIds = collisions.map((project) => project.id).join(", ");
+    return yield* new CreateFailure({
+      stage: "check_project_name",
+      reason: "project_name_collision",
+      message: `A Prisma project named "${options.appName}" already exists in workspace ${getWorkspaceLabel(options.workspace)} (${options.workspace.id}). Choose a different project name or delete the existing project (${projectIds}) in Prisma Console, then retry.`,
+    });
+  },
+);
+
+export const getProjectDetails = Effect.fn("Deployment.getProjectDetails")(function* (options: {
+  packageManager: PackageManager;
+  projectDir: string;
+  appName: string;
+}) {
+  return yield* Effect.gen(function* () {
+    const raw = yield* runPrismaJsonCommandEffect({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      args: ["project", "show", options.appName],
+    });
+    const result = yield* decodePrismaCommandResult(ProjectShowResultSchema, raw);
+    if (!result.project) return undefined;
+    return {
+      workspace: result.workspace,
+      project: {
+        id: result.project.id,
+        name: result.project.name,
+        consoleUrl: getConsoleProjectUrl(result.workspace.id, result.project.id),
+      },
+    };
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+});

--- a/src/tasks/composer/workspace.ts
+++ b/src/tasks/composer/workspace.ts
@@ -1,0 +1,3 @@
+import type { PrismaWorkspace } from "../../result";
+
+export const getWorkspaceLabel = (workspace: PrismaWorkspace) => workspace.name ?? workspace.id;

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -2,7 +2,6 @@ import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts"
 import { Effect, Schema } from "effect";
 import type { Writable } from "node:stream";
 
-import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
   CreateCancellationError,
   CreateFailure,
@@ -16,8 +15,8 @@ import { CommandRunner } from "../services/command-runner";
 import type { PackageManager } from "../types";
 import { getErrorMessage, redactSecrets } from "../utils/errors";
 import {
-  getPackageExecutionArgs,
-  getPackageExecutionCommand,
+  getLocalPackageBinaryArgs,
+  getLocalPackageBinaryCommand,
   getRunScriptArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
@@ -128,7 +127,7 @@ export function parsePrismaCliEnvelope(output: string): PrismaCliEnvelope {
 }
 
 const getPrismaCliArgs = (packageManager: PackageManager, args: string[]) =>
-  getPackageExecutionArgs(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
+  getLocalPackageBinaryArgs(packageManager, "prisma", args);
 
 const runPrismaJsonCommandEffect = Effect.fn("PrismaCli.runJson")(function* (options: {
   packageManager: PackageManager;
@@ -240,8 +239,7 @@ const ensureAuthentication = Effect.fn("Deployment.ensureAuthentication")(functi
 
   const authState = yield* whoami();
   if (authState.authenticated) return authState;
-  const loginCommand = getPackageExecutionCommand(options.packageManager, [
-    PRISMA_PLATFORM_CLI_PACKAGE,
+  const loginCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
     "auth",
     "login",
   ]);
@@ -517,8 +515,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       "build_failed",
     );
 
-    const deployCommand = getPackageExecutionCommand(options.packageManager, [
-      PRISMA_PLATFORM_CLI_PACKAGE,
+    const deployCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
       "deploy",
       "module.ts",
     ]);

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -1,5 +1,5 @@
 import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts";
-import { Effect, Schema } from "effect";
+import { Cause, Effect, Exit, Schema } from "effect";
 import type { Writable } from "node:stream";
 
 import {
@@ -575,8 +575,9 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
   });
 
   return yield* program.pipe(
-    Effect.tapError((error) =>
+    Effect.tapCause((cause) =>
       Effect.sync(() => {
+        const error = Cause.squash(cause);
         if (deploymentLog) {
           deploymentLog.error("Deployment failed.");
           deploymentLog = undefined;
@@ -606,31 +607,34 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
 export async function deployNewProjectWithComposer(
   options: DeployOptions,
 ): Promise<ComposerDeployExecutionResult> {
-  try {
+  const exit = await applicationRuntime.runPromiseExit(deployNewProjectWithComposerEffect(options));
+  if (Exit.isSuccess(exit)) {
     return {
       ok: true,
-      deployment: await applicationRuntime.runPromise(deployNewProjectWithComposerEffect(options)),
-    };
-  } catch (error) {
-    if (error instanceof CreateCancellationError) {
-      return { ok: false, cancelled: true, stage: "select_workspace" };
-    }
-    const failure =
-      error instanceof CreateFailure
-        ? error
-        : new CreateFailure({
-            stage: "unknown",
-            reason: "unexpected_error",
-            message: getErrorMessage(error),
-            cause: error,
-          });
-    return {
-      ok: false,
-      stage: failure.stage,
-      reason: failure.reason,
-      error: failure.cause ?? failure,
+      deployment: exit.value,
     };
   }
+
+  const failureReason = exit.cause.reasons.find(Cause.isFailReason);
+  const error = failureReason?.error ?? Cause.squash(exit.cause);
+  if (error instanceof CreateCancellationError) {
+    return { ok: false, cancelled: true, stage: "select_workspace" };
+  }
+  const failure =
+    error instanceof CreateFailure
+      ? error
+      : new CreateFailure({
+          stage: "unknown",
+          reason: "unexpected_error",
+          message: getErrorMessage(error),
+          cause: error,
+        });
+  return {
+    ok: false,
+    stage: failure.stage,
+    reason: failure.reason,
+    error: failure.cause ?? failure,
+  };
 }
 
 export { PrismaCliCommandError };

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -1,15 +1,18 @@
 import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts";
-import { execa } from "execa";
-import { createInterface } from "node:readline";
+import { Effect, Schema } from "effect";
 import type { Writable } from "node:stream";
 
 import { PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
-  ClassifiedCreateError,
-  getCreateFailureReason,
+  CreateCancellationError,
+  CreateFailure,
+  PrismaCliCommandError,
   type CreateFailureReason,
   type CreateFailureStage,
 } from "../create-outcome";
+import { type ComposerDeployResult, PrismaWorkspaceSchema, type PrismaWorkspace } from "../result";
+import { applicationRuntime } from "../runtime";
+import { CommandRunner } from "../services/command-runner";
 import type { PackageManager } from "../types";
 import { getErrorMessage, redactSecrets } from "../utils/errors";
 import {
@@ -20,81 +23,71 @@ import {
 } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
 
-type PrismaCliEnvelope<Result = unknown> = {
-  ok: boolean;
-  command?: string;
-  commandId?: string;
-  result?: Result;
-  error?: { code?: string; summary?: string; message?: string; why?: string };
-};
+const PrismaCliEnvelopeSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  command: Schema.optionalKey(Schema.String),
+  commandId: Schema.optionalKey(Schema.String),
+  result: Schema.optionalKey(Schema.Unknown),
+  error: Schema.optionalKey(
+    Schema.Struct({
+      code: Schema.optionalKey(Schema.String),
+      summary: Schema.optionalKey(Schema.String),
+      message: Schema.optionalKey(Schema.String),
+      why: Schema.optionalKey(Schema.String),
+    }),
+  ),
+});
+type PrismaCliEnvelope = typeof PrismaCliEnvelopeSchema.Type;
+const decodePrismaCliEnvelope = Schema.decodeUnknownExit(PrismaCliEnvelopeSchema);
 
-export class PrismaCliCommandError extends Error {
-  readonly prismaCliCommand?: string;
-  readonly prismaCliErrorCode?: string;
+const WhoamiResultSchema = Schema.Struct({
+  authenticated: Schema.Boolean,
+  workspace: Schema.NullOr(PrismaWorkspaceSchema),
+  source: Schema.NullOr(Schema.Literals(["stored", "environment"])),
+});
+type WhoamiResult = typeof WhoamiResultSchema.Type;
 
-  constructor(options: { message: string; command?: string; code?: string }) {
-    super(options.message);
-    this.name = "PrismaCliCommandError";
-    this.prismaCliCommand = options.command;
-    this.prismaCliErrorCode = options.code;
-  }
-}
+const WorkspaceListResultSchema = Schema.Struct({
+  items: Schema.Array(
+    Schema.Struct({
+      workspaceId: Schema.String,
+      workspaceName: Schema.NullOr(Schema.String),
+      current: Schema.Boolean,
+    }),
+  ),
+});
 
-type PrismaWorkspace = {
-  id: string;
-  name: string | null;
-};
+const WorkspaceUseResultSchema = Schema.Struct({ workspace: PrismaWorkspaceSchema });
 
-type WhoamiResult = {
-  authenticated: boolean;
-  workspace: PrismaWorkspace | null;
-  source: "stored" | "environment" | null;
-};
+const ProjectShowResultSchema = Schema.Struct({
+  workspace: PrismaWorkspaceSchema,
+  project: Schema.NullOr(Schema.Struct({ id: Schema.String, name: Schema.String })),
+});
 
-type WorkspaceListResult = {
-  items: Array<{
-    workspaceId: string;
-    workspaceName: string | null;
-    current: boolean;
-  }>;
-};
+const ProjectListResultSchema = Schema.Struct({
+  items: Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.String })),
+});
+type ProjectListResult = typeof ProjectListResultSchema.Type;
 
-type WorkspaceUseResult = {
-  workspace: PrismaWorkspace;
-};
-
-type ProjectShowResult = {
-  workspace: PrismaWorkspace;
-  project: { id: string; name: string } | null;
-};
-
-type ProjectListResult = {
-  items: Array<{
-    id: string;
-    name: string;
-  }>;
-};
-
-type ComposerDeployCommandResult = {
-  summary: {
-    app: string;
-    nodes: Array<{
-      entities: Array<{ kind: string; id: string; url?: string }>;
-    }>;
-  } | null;
-};
-
-export type ComposerDeployResult = {
-  appName: string;
-  appUrl?: string;
-  serviceId?: string;
-  workspace?: PrismaWorkspace;
-  project: {
-    id?: string;
-    name: string;
-    consoleUrl?: string;
-  };
-};
+const ComposerDeployCommandResultSchema = Schema.Struct({
+  summary: Schema.NullOr(
+    Schema.Struct({
+      app: Schema.String,
+      nodes: Schema.Array(
+        Schema.Struct({
+          entities: Schema.Array(
+            Schema.Struct({
+              kind: Schema.String,
+              id: Schema.String,
+              url: Schema.optionalKey(Schema.String),
+            }),
+          ),
+        }),
+      ),
+    }),
+  ),
+});
+type ComposerDeployCommandResult = typeof ComposerDeployCommandResultSchema.Type;
 
 export type ComposerDeployExecutionResult =
   | { ok: true; deployment: ComposerDeployResult }
@@ -107,26 +100,14 @@ export type ComposerDeployExecutionResult =
       error: unknown;
     };
 
-type WorkspaceSelectionResult =
-  | { ok: true; workspace: PrismaWorkspace }
-  | { ok: false; cancelled: true };
-
-function stripResourcePrefix(id: string, prefix: "proj" | "wksp"): string {
-  const marker = `${prefix}_`;
-  return id.startsWith(marker) ? id.slice(marker.length) : id;
-}
+const stripResourcePrefix = (id: string, prefix: "proj" | "wksp") =>
+  id.startsWith(`${prefix}_`) ? id.slice(prefix.length + 1) : id;
 
 export function getConsoleProjectUrl(workspaceId: string, projectId: string): string {
-  const consoleWorkspaceId = stripResourcePrefix(workspaceId, "wksp");
-  const consoleProjectId = stripResourcePrefix(projectId, "proj");
-  return `https://console.prisma.io/${encodeURIComponent(
-    consoleWorkspaceId,
-  )}/${encodeURIComponent(consoleProjectId)}`;
+  return `https://console.prisma.io/${encodeURIComponent(stripResourcePrefix(workspaceId, "wksp"))}/${encodeURIComponent(stripResourcePrefix(projectId, "proj"))}`;
 }
 
-export function parsePrismaCliEnvelope<Result = unknown>(
-  output: string,
-): PrismaCliEnvelope<Result> {
+export function parsePrismaCliEnvelope(output: string): PrismaCliEnvelope {
   const lines = output
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -137,59 +118,52 @@ export function parsePrismaCliEnvelope<Result = unknown>(
     try {
       const parsed = JSON.parse(line) as Record<string, unknown>;
       const candidate = parsed.kind === "result" ? parsed.envelope : parsed;
-      if (typeof candidate !== "object" || candidate === null) continue;
-      if (typeof Reflect.get(candidate, "ok") !== "boolean") continue;
-      return candidate as PrismaCliEnvelope<Result>;
+      const decoded = decodePrismaCliEnvelope(candidate);
+      if (decoded._tag === "Success") return decoded.value;
     } catch {
-      // The CLI may print progress frames before its final JSON envelope.
+      // Prisma may emit progress frames before the terminal JSON envelope.
     }
   }
-
   throw new Error("Prisma CLI returned output that is not a valid result envelope.");
 }
 
-function getPrismaCliArgs(packageManager: PackageManager, args: string[]) {
-  return getPackageExecutionArgs(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
-}
+const getPrismaCliArgs = (packageManager: PackageManager, args: string[]) =>
+  getPackageExecutionArgs(packageManager, [PRISMA_PLATFORM_CLI_PACKAGE, ...args]);
 
-async function runPrismaJsonCommand<Result>(options: {
+const runPrismaJsonCommandEffect = Effect.fn("PrismaCli.runJson")(function* (options: {
   packageManager: PackageManager;
   projectDir: string;
   args: string[];
   onStderrLine?: (line: string) => void;
-}): Promise<Result> {
+}) {
+  const runner = yield* CommandRunner;
   const invocation = getPrismaCliArgs(options.packageManager, [
     ...options.args,
     "--json",
     "--no-interactive",
   ]);
-  const subprocess = execa(invocation.command, invocation.args, {
+  const result = yield* runner.run({
+    command: invocation.command,
+    args: invocation.args,
     cwd: options.projectDir,
     env: process.env,
-    reject: false,
+    ...(options.onStderrLine ? { onStderrLine: options.onStderrLine } : {}),
   });
-  const stderrLines =
-    options.onStderrLine && subprocess.stderr
-      ? (async () => {
-          const lines = createInterface({ input: subprocess.stderr });
-          for await (const line of lines) {
-            if (line.trim()) options.onStderrLine?.(line);
-          }
-        })()
-      : Promise.resolve();
-  const [result] = await Promise.all([subprocess, stderrLines]);
 
-  let envelope: PrismaCliEnvelope<Result>;
+  let envelope: PrismaCliEnvelope;
   try {
-    envelope = parsePrismaCliEnvelope<Result>(result.stdout);
-  } catch (error) {
-    if (result.exitCode !== 0 && result.stderr.trim()) throw new Error(result.stderr.trim());
-    throw error;
+    envelope = parsePrismaCliEnvelope(result.stdout);
+  } catch (cause) {
+    return yield* new PrismaCliCommandError({
+      message: result.stderr.trim() || getErrorMessage(cause),
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
   }
 
   if (result.exitCode !== 0 || !envelope.ok || envelope.result === undefined) {
     const summary = envelope.error?.summary ?? envelope.error?.message;
-    throw new PrismaCliCommandError({
+    return yield* new PrismaCliCommandError({
       message:
         [summary, envelope.error?.why].filter(Boolean).join(": ") ||
         result.stderr.trim() ||
@@ -198,10 +172,22 @@ async function runPrismaJsonCommand<Result>(options: {
         ? { command: envelope.commandId ?? envelope.command }
         : {}),
       ...(envelope.error?.code ? { code: envelope.error.code } : {}),
+      stderr: result.stderr,
+      exitCode: result.exitCode,
     });
   }
   return envelope.result;
-}
+});
+
+const decodeCommandResult = <A>(schema: Schema.Codec<A>, value: unknown) =>
+  Schema.decodeUnknownEffect(schema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new PrismaCliCommandError({
+          message: `Prisma CLI returned an invalid result: ${cause.message}`,
+        }),
+    ),
+  );
 
 export function findProjectNameCollisions(
   projects: ProjectListResult["items"],
@@ -210,96 +196,102 @@ export function findProjectNameCollisions(
   return projects.filter((project) => project.name === appName);
 }
 
-async function ensureProjectNameAvailable(options: {
-  appName: string;
-  packageManager: PackageManager;
-  projectDir: string;
-  workspace: PrismaWorkspace;
-}): Promise<void> {
-  const result = await runPrismaJsonCommand<ProjectListResult>({
-    packageManager: options.packageManager,
-    projectDir: options.projectDir,
-    args: ["project", "list"],
-  });
-  const collisions = findProjectNameCollisions(result.items, options.appName);
-  if (collisions.length === 0) return;
+const workspaceLabel = (workspace: PrismaWorkspace) => workspace.name ?? workspace.id;
 
-  const projectIds = collisions.map((project) => project.id).join(", ");
-  throw new ClassifiedCreateError(
-    "project_name_collision",
-    `A Prisma project named "${options.appName}" already exists in workspace ${workspaceLabel(
-      options.workspace,
-    )} (${options.workspace.id}). Choose a different project name or delete the existing project ` +
-      `(${projectIds}) in Prisma Console, then retry.`,
-  );
-}
+const ensureProjectNameAvailable = Effect.fn("Deployment.ensureProjectNameAvailable")(
+  function* (options: {
+    appName: string;
+    packageManager: PackageManager;
+    projectDir: string;
+    workspace: PrismaWorkspace;
+  }) {
+    const raw = yield* runPrismaJsonCommandEffect({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      args: ["project", "list"],
+    });
+    const result = yield* decodeCommandResult(ProjectListResultSchema, raw);
+    const collisions = findProjectNameCollisions(result.items, options.appName);
+    if (collisions.length === 0) return;
+    const projectIds = collisions.map((project) => project.id).join(", ");
+    return yield* new CreateFailure({
+      stage: "check_project_name",
+      reason: "project_name_collision",
+      message: `A Prisma project named "${options.appName}" already exists in workspace ${workspaceLabel(options.workspace)} (${options.workspace.id}). Choose a different project name or delete the existing project (${projectIds}) in Prisma Console, then retry.`,
+    });
+  },
+);
 
-async function ensureAuthentication(options: {
+const ensureAuthentication = Effect.fn("Deployment.ensureAuthentication")(function* (options: {
   packageManager: PackageManager;
   projectDir: string;
   output: Writable;
   allowInteractiveLogin: boolean;
   beforeInteractiveLogin?: () => void;
-}): Promise<WhoamiResult> {
-  const whoami = () =>
-    runPrismaJsonCommand<WhoamiResult>({
+}) {
+  const whoami = Effect.fn("PrismaCli.whoami")(function* () {
+    const raw = yield* runPrismaJsonCommandEffect({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       args: ["auth", "whoami"],
     });
+    return yield* decodeCommandResult(WhoamiResultSchema, raw);
+  });
 
-  const authState = await whoami();
+  const authState = yield* whoami();
   if (authState.authenticated) return authState;
-
   const loginCommand = getPackageExecutionCommand(options.packageManager, [
     PRISMA_PLATFORM_CLI_PACKAGE,
     "auth",
     "login",
   ]);
   if (!options.allowInteractiveLogin || process.stdin.isTTY !== true) {
-    throw new ClassifiedCreateError(
-      "not_authenticated",
-      `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
-    );
+    return yield* new CreateFailure({
+      stage: "authenticate",
+      reason: "not_authenticated",
+      message: `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
+    });
   }
 
-  options.beforeInteractiveLogin?.();
-  log.info("Sign in to Prisma to deploy.", { output: options.output });
+  yield* Effect.sync(() => {
+    options.beforeInteractiveLogin?.();
+    log.info("Sign in to Prisma to deploy.", { output: options.output });
+  });
+  const runner = yield* CommandRunner;
   const login = getPrismaCliArgs(options.packageManager, ["auth", "login"]);
-  await execa(login.command, login.args, {
+  yield* runner.runChecked({
+    command: login.command,
+    args: login.args,
     cwd: options.projectDir,
     env: process.env,
     stdio: "inherit",
   });
 
-  const authenticatedState = await whoami();
+  const authenticatedState = yield* whoami();
   if (!authenticatedState.authenticated) {
-    throw new ClassifiedCreateError(
-      "authentication_failed",
-      "Prisma sign-in completed without an active workspace session.",
-    );
+    return yield* new CreateFailure({
+      stage: "authenticate",
+      reason: "authentication_failed",
+      message: "Prisma sign-in completed without an active workspace session.",
+    });
   }
   return authenticatedState;
-}
+});
 
-function workspaceLabel(workspace: PrismaWorkspace): string {
-  return workspace.name ?? workspace.id;
-}
-
-async function useWorkspace(options: {
+const useWorkspace = Effect.fn("Deployment.useWorkspace")(function* (options: {
   packageManager: PackageManager;
   projectDir: string;
   workspace: string;
-}): Promise<PrismaWorkspace> {
-  const result = await runPrismaJsonCommand<WorkspaceUseResult>({
+}) {
+  const raw = yield* runPrismaJsonCommandEffect({
     packageManager: options.packageManager,
     projectDir: options.projectDir,
     args: ["auth", "workspace", "use", options.workspace],
   });
-  return result.workspace;
-}
+  return (yield* decodeCommandResult(WorkspaceUseResultSchema, raw)).workspace;
+});
 
-async function selectDeploymentWorkspace(options: {
+const selectDeploymentWorkspace = Effect.fn("Deployment.selectWorkspace")(function* (options: {
   packageManager: PackageManager;
   projectDir: string;
   shouldPrompt: boolean;
@@ -308,109 +300,96 @@ async function selectDeploymentWorkspace(options: {
   beforePrompt?: () => void;
   afterPrompt?: () => void;
   output: Writable;
-}): Promise<WorkspaceSelectionResult> {
+}) {
   const activeWorkspace = options.authState.workspace;
   if (!activeWorkspace) {
-    throw new ClassifiedCreateError(
-      "workspace_missing",
-      "The active Prisma credential does not specify a workspace.",
-    );
+    return yield* new CreateFailure({
+      stage: "select_workspace",
+      reason: "workspace_missing",
+      message: "The active Prisma credential does not specify a workspace.",
+    });
   }
 
   if (options.workspace) {
     if (options.authState.source === "environment") {
       if (options.workspace === activeWorkspace.id || options.workspace === activeWorkspace.name) {
-        return { ok: true, workspace: activeWorkspace };
+        return activeWorkspace;
       }
-      throw new ClassifiedCreateError(
-        "workspace_mismatch",
-        `The environment credential is fixed to workspace ${workspaceLabel(
-          activeWorkspace,
-        )}. Unset it before using --workspace ${options.workspace}.`,
-      );
+      return yield* new CreateFailure({
+        stage: "select_workspace",
+        reason: "workspace_mismatch",
+        message: `The environment credential is fixed to workspace ${workspaceLabel(activeWorkspace)}. Unset it before using --workspace ${options.workspace}.`,
+      });
     }
-    return {
-      ok: true,
-      workspace: await useWorkspace({
-        packageManager: options.packageManager,
-        projectDir: options.projectDir,
-        workspace: options.workspace,
-      }),
-    };
+    return yield* useWorkspace({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      workspace: options.workspace,
+    });
   }
 
-  if (!options.shouldPrompt || process.stdin.isTTY !== true) {
-    return { ok: true, workspace: activeWorkspace };
-  }
-
-  const available = await runPrismaJsonCommand<WorkspaceListResult>({
+  if (!options.shouldPrompt || process.stdin.isTTY !== true) return activeWorkspace;
+  const raw = yield* runPrismaJsonCommandEffect({
     packageManager: options.packageManager,
     projectDir: options.projectDir,
     args: ["auth", "workspace", "list"],
   });
-  if (available.items.length <= 1) return { ok: true, workspace: activeWorkspace };
+  const available = yield* decodeCommandResult(WorkspaceListResultSchema, raw);
+  if (available.items.length <= 1) return activeWorkspace;
 
-  options.beforePrompt?.();
-  const selectedWorkspaceId = await select({
-    message: "Select Prisma workspace for deployment",
-    initialValue: activeWorkspace.id,
-    options: available.items.map((workspace) => ({
-      value: workspace.workspaceId,
-      label: workspace.workspaceName ?? workspace.workspaceId,
-      hint: workspace.current ? `${workspace.workspaceId}, current` : workspace.workspaceId,
-    })),
-    output: options.output,
-  });
-  if (isCancel(selectedWorkspaceId)) {
-    cancel("Operation cancelled.", { output: options.output });
-    return { ok: false, cancelled: true };
-  }
-  options.afterPrompt?.();
-  if (selectedWorkspaceId === activeWorkspace.id) {
-    return { ok: true, workspace: activeWorkspace };
-  }
-
-  return {
-    ok: true,
-    workspace: await useWorkspace({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      workspace: selectedWorkspaceId,
+  yield* Effect.sync(() => options.beforePrompt?.());
+  const selectedWorkspaceId = yield* Effect.tryPromise(() =>
+    select({
+      message: "Select Prisma workspace for deployment",
+      initialValue: activeWorkspace.id,
+      options: available.items.map((workspace) => ({
+        value: workspace.workspaceId,
+        label: workspace.workspaceName ?? workspace.workspaceId,
+        hint: workspace.current ? `${workspace.workspaceId}, current` : workspace.workspaceId,
+      })),
+      output: options.output,
     }),
-  };
-}
+  );
+  if (isCancel(selectedWorkspaceId)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output: options.output }));
+    return yield* new CreateCancellationError({ stage: "select_workspace" });
+  }
+  yield* Effect.sync(() => options.afterPrompt?.());
+  if (selectedWorkspaceId === activeWorkspace.id) return activeWorkspace;
+  return yield* useWorkspace({
+    packageManager: options.packageManager,
+    projectDir: options.projectDir,
+    workspace: selectedWorkspaceId,
+  });
+});
 
-export function parseComposerDeployResult(result: ComposerDeployCommandResult):
-  | {
-      appName: string;
-      appUrl?: string;
-      serviceId?: string;
-    }
-  | undefined {
-  const summary = result.summary;
-  if (!summary) return;
-  const computeService = summary.nodes
+export function parseComposerDeployResult(
+  result: ComposerDeployCommandResult,
+): { appName: string; appUrl?: string; serviceId?: string } | undefined {
+  if (!result.summary) return;
+  const computeService = result.summary.nodes
     .flatMap((node) => node.entities)
     .find((entity) => entity.kind === "compute-service");
   return {
-    appName: summary.app,
+    appName: result.summary.app,
     ...(computeService?.id ? { serviceId: computeService.id } : {}),
     ...(computeService?.url ? { appUrl: computeService.url.replace(/\/$/, "") } : {}),
   };
 }
 
-async function getProjectDetails(options: {
+const getProjectDetails = Effect.fn("Deployment.getProjectDetails")(function* (options: {
   packageManager: PackageManager;
   projectDir: string;
   appName: string;
-}): Promise<Pick<ComposerDeployResult, "workspace" | "project"> | undefined> {
-  try {
-    const result = await runPrismaJsonCommand<ProjectShowResult>({
+}) {
+  const details = yield* Effect.gen(function* () {
+    const raw = yield* runPrismaJsonCommandEffect({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       args: ["project", "show", options.appName],
     });
-    if (!result.project) return;
+    const result = yield* decodeCommandResult(ProjectShowResultSchema, raw);
+    if (!result.project) return undefined;
     return {
       workspace: result.workspace,
       project: {
@@ -419,17 +398,11 @@ async function getProjectDetails(options: {
         consoleUrl: getConsoleProjectUrl(result.workspace.id, result.project.id),
       },
     };
-  } catch {
-    // Metadata enrichment must not turn a successful deploy into a failure.
-    return;
-  }
-}
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  return details;
+});
 
-/**
- * Performs the optional one-shot deployment at the end of a create-prisma scaffold.
- * Generated projects use their own `deploy` script for every subsequent deployment.
- */
-export async function deployNewProjectWithComposer(options: {
+type DeployOptions = {
   appName: string;
   packageManager: PackageManager;
   projectDir: string;
@@ -439,18 +412,32 @@ export async function deployNewProjectWithComposer(options: {
   allowInteractiveLogin?: boolean;
   json?: boolean;
   workspace?: string;
-}): Promise<ComposerDeployExecutionResult> {
+};
+
+const atStage = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  stage: CreateFailureStage,
+  reason: CreateFailureReason,
+) =>
+  effect.pipe(
+    Effect.mapError((error) =>
+      error instanceof CreateFailure || error instanceof CreateCancellationError
+        ? error
+        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
+    ),
+  );
+
+export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")(function* (
+  options: DeployOptions,
+) {
   const output = options.output ?? process.stdout;
   const progress = options.verbose ? undefined : spinner({ output });
   let deploymentLog: ReturnType<typeof taskLog> | undefined;
   let progressRunning = false;
-  let failureStage: CreateFailureStage = "authenticate";
-  let failureReason: CreateFailureReason = "prisma_auth_command_failed";
   const showProgress = (message: string) => {
     if (!progress) return;
-    if (progressRunning) {
-      progress.message(message);
-    } else {
+    if (progressRunning) progress.message(message);
+    else {
       progress.start(message);
       progressRunning = true;
     }
@@ -461,130 +448,193 @@ export async function deployNewProjectWithComposer(options: {
     progressRunning = false;
   };
 
-  try {
-    showProgress("Checking Prisma account...");
-    if (options.verbose) log.step("Checking Prisma account.", { output });
-    const authState = await ensureAuthentication({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      output,
-      allowInteractiveLogin: options.allowInteractiveLogin ?? true,
-      beforeInteractiveLogin: clearProgress,
+  const program = Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      showProgress("Checking Prisma account...");
+      if (options.verbose) log.step("Checking Prisma account.", { output });
     });
+    const authState = yield* atStage(
+      ensureAuthentication({
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        output,
+        allowInteractiveLogin: options.allowInteractiveLogin ?? true,
+        beforeInteractiveLogin: clearProgress,
+      }),
+      "authenticate",
+      "prisma_auth_command_failed",
+    );
 
-    showProgress("Checking Prisma workspace...");
-    failureStage = "select_workspace";
-    failureReason = "workspace_selection_failed";
-    if (options.verbose) log.step("Checking Prisma workspace.", { output });
-    const workspaceResult = await selectDeploymentWorkspace({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      shouldPrompt: options.shouldPromptForWorkspace,
-      authState,
-      output,
-      beforePrompt: clearProgress,
-      afterPrompt: () => showProgress("Selecting Prisma workspace..."),
-      ...(options.workspace ? { workspace: options.workspace } : {}),
+    yield* Effect.sync(() => {
+      showProgress("Checking Prisma workspace...");
+      if (options.verbose) log.step("Checking Prisma workspace.", { output });
     });
-    if (!workspaceResult.ok) return { ok: false, cancelled: true, stage: "select_workspace" };
-    const selectedWorkspace = workspaceResult.workspace;
+    const selectedWorkspace = yield* atStage(
+      selectDeploymentWorkspace({
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        shouldPrompt: options.shouldPromptForWorkspace,
+        authState,
+        output,
+        beforePrompt: clearProgress,
+        afterPrompt: () => showProgress("Selecting Prisma workspace..."),
+        ...(options.workspace ? { workspace: options.workspace } : {}),
+      }),
+      "select_workspace",
+      "workspace_selection_failed",
+    );
 
-    showProgress("Checking Prisma project name...");
-    failureStage = "check_project_name";
-    failureReason = "project_lookup_failed";
-    if (options.verbose) log.step("Checking Prisma project name.", { output });
-    await ensureProjectNameAvailable({
-      appName: options.appName,
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      workspace: selectedWorkspace,
+    yield* Effect.sync(() => {
+      showProgress("Checking Prisma project name...");
+      if (options.verbose) log.step("Checking Prisma project name.", { output });
     });
+    yield* atStage(
+      ensureProjectNameAvailable({
+        appName: options.appName,
+        packageManager: options.packageManager,
+        projectDir: options.projectDir,
+        workspace: selectedWorkspace,
+      }),
+      "check_project_name",
+      "project_lookup_failed",
+    );
 
-    showProgress("Building for deployment...");
-    failureStage = "build";
-    failureReason = "build_failed";
-    if (options.verbose) log.step("Building for deployment.", { output });
+    yield* Effect.sync(() => {
+      showProgress("Building for deployment...");
+      if (options.verbose) log.step("Building for deployment.", { output });
+    });
     const build = getRunScriptArgs(options.packageManager, "build");
-    await runSetupCommand({
-      command: build.command,
-      args: build.args,
-      cwd: options.projectDir,
-      env: process.env,
-      verbose: options.verbose,
-      json: options.json === true,
-    });
+    yield* atStage(
+      runSetupCommand({
+        command: build.command,
+        args: build.args,
+        cwd: options.projectDir,
+        env: process.env,
+        verbose: options.verbose,
+        json: options.json === true,
+      }),
+      "build",
+      "build_failed",
+    );
 
-    clearProgress();
-    failureStage = "composer_deploy";
-    failureReason = "composer_deploy_failed";
     const deployCommand = getPackageExecutionCommand(options.packageManager, [
       PRISMA_PLATFORM_CLI_PACKAGE,
       "deploy",
       "module.ts",
     ]);
-    if (options.verbose) {
-      log.step(`Deploying to Prisma with ${deployCommand}.`, { output });
-    } else {
-      deploymentLog = taskLog({ title: "Deploying to Prisma...", limit: 10, output });
-      deploymentLog.message(`$ ${deployCommand}`);
-    }
-    const deployment = parseComposerDeployResult(
-      await runPrismaJsonCommand<ComposerDeployCommandResult>({
+    yield* Effect.sync(() => {
+      clearProgress();
+      if (options.verbose) log.step(`Deploying to Prisma with ${deployCommand}.`, { output });
+      else {
+        deploymentLog = taskLog({ title: "Deploying to Prisma...", limit: 10, output });
+        deploymentLog.message(`$ ${deployCommand}`);
+      }
+    });
+    const rawDeployment = yield* atStage(
+      runPrismaJsonCommandEffect({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
         args: ["deploy", "module.ts"],
         onStderrLine: (line) => {
-          const redactedLine = redactSecrets(line);
-          if (options.verbose) {
-            output.write(`${redactedLine}\n`);
-          } else {
-            deploymentLog?.message(redactedLine);
-          }
+          const redacted = redactSecrets(line);
+          if (options.verbose) output.write(`${redacted}\n`);
+          else deploymentLog?.message(redacted);
         },
       }),
+      "composer_deploy",
+      "composer_deploy_failed",
     );
+    const deploymentResult = yield* atStage(
+      decodeCommandResult(ComposerDeployCommandResultSchema, rawDeployment),
+      "composer_deploy",
+      "composer_deploy_failed",
+    );
+    const deployment = parseComposerDeployResult(deploymentResult);
     const appName = deployment?.appName ?? options.appName;
 
-    if (options.verbose) {
-      log.step("Loading deployment details.", { output });
-    } else {
-      deploymentLog?.message("Loading deployment details...");
-    }
-    const details = await getProjectDetails({
+    yield* Effect.sync(() => {
+      if (options.verbose) log.step("Loading deployment details.", { output });
+      else deploymentLog?.message("Loading deployment details...");
+    });
+    const details = yield* getProjectDetails({
       packageManager: options.packageManager,
       projectDir: options.projectDir,
       appName,
     });
+    yield* Effect.sync(() => {
+      deploymentLog?.success("Deployed to Prisma.");
+      deploymentLog = undefined;
+      progressRunning = false;
+      if (options.verbose) log.success("Deployed to Prisma.", { output });
+    });
 
-    deploymentLog?.success("Deployed to Prisma.");
-    deploymentLog = undefined;
-    progressRunning = false;
-    if (options.verbose) log.success("Deployed to Prisma.", { output });
-    const workspace = details?.workspace ?? selectedWorkspace;
+    return {
+      appName,
+      ...(deployment?.appUrl ? { appUrl: deployment.appUrl } : {}),
+      ...(deployment?.serviceId ? { serviceId: deployment.serviceId } : {}),
+      workspace: details?.workspace ?? selectedWorkspace,
+      project: details?.project ?? { name: appName },
+    } satisfies ComposerDeployResult;
+  });
+
+  return yield* program.pipe(
+    Effect.tapError((error) =>
+      Effect.sync(() => {
+        if (deploymentLog) {
+          deploymentLog.error("Deployment failed.");
+          deploymentLog = undefined;
+        } else {
+          progress?.error("Deployment failed.");
+        }
+        progressRunning = false;
+        if (!(error instanceof CreateCancellationError)) {
+          log.error(`Deploy failed: ${getErrorMessage(error)}`, { output });
+        }
+      }),
+    ),
+    Effect.mapError((error) =>
+      error instanceof CreateFailure
+        ? new CreateFailure({
+            stage: error.stage,
+            reason: error.reason,
+            message: error.message,
+            cause: error.cause,
+            errorReported: true,
+          })
+        : error,
+    ),
+  );
+});
+
+export async function deployNewProjectWithComposer(
+  options: DeployOptions,
+): Promise<ComposerDeployExecutionResult> {
+  try {
     return {
       ok: true,
-      deployment: {
-        appName,
-        ...(deployment?.appUrl ? { appUrl: deployment.appUrl } : {}),
-        ...(deployment?.serviceId ? { serviceId: deployment.serviceId } : {}),
-        ...(workspace ? { workspace } : {}),
-        project: details?.project ?? { name: appName },
-      },
+      deployment: await applicationRuntime.runPromise(deployNewProjectWithComposerEffect(options)),
     };
   } catch (error) {
-    if (deploymentLog) {
-      deploymentLog.error("Deployment failed.");
-      deploymentLog = undefined;
-    } else {
-      progress?.error("Deployment failed.");
+    if (error instanceof CreateCancellationError) {
+      return { ok: false, cancelled: true, stage: "select_workspace" };
     }
-    progressRunning = false;
-    log.error(`Deploy failed: ${getErrorMessage(error)}`, { output });
+    const failure =
+      error instanceof CreateFailure
+        ? error
+        : new CreateFailure({
+            stage: "unknown",
+            reason: "unexpected_error",
+            message: getErrorMessage(error),
+            cause: error,
+          });
     return {
       ok: false,
-      stage: failureStage,
-      reason: getCreateFailureReason(error, failureReason),
-      error,
+      stage: failure.stage,
+      reason: failure.reason,
+      error: failure.cause ?? failure,
     };
   }
 }
+
+export { PrismaCliCommandError };
+export type { ComposerDeployResult } from "../result";

--- a/src/tasks/deploy-with-composer.ts
+++ b/src/tasks/deploy-with-composer.ts
@@ -1,92 +1,27 @@
-import { cancel, isCancel, log, select, spinner, taskLog } from "@clack/prompts";
-import { Cause, Effect, Exit, Schema } from "effect";
+import { log, spinner, taskLog } from "@clack/prompts";
+import { Cause, Effect, Exit } from "effect";
 import type { Writable } from "node:stream";
 
 import {
   CreateCancellationError,
   CreateFailure,
-  PrismaCliCommandError,
   type CreateFailureReason,
   type CreateFailureStage,
 } from "../create-outcome";
-import { type ComposerDeployResult, PrismaWorkspaceSchema, type PrismaWorkspace } from "../result";
+import type { ComposerDeployResult } from "../result";
 import { applicationRuntime } from "../runtime";
-import { CommandRunner } from "../services/command-runner";
 import type { PackageManager } from "../types";
 import { getErrorMessage, redactSecrets } from "../utils/errors";
-import {
-  getLocalPackageBinaryArgs,
-  getLocalPackageBinaryCommand,
-  getRunScriptArgs,
-  getRunScriptCommand,
-} from "../utils/package-manager";
+import { getLocalPackageBinaryCommand, getRunScriptArgs } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
-
-const PrismaCliEnvelopeSchema = Schema.Struct({
-  ok: Schema.Boolean,
-  command: Schema.optionalKey(Schema.String),
-  commandId: Schema.optionalKey(Schema.String),
-  result: Schema.optionalKey(Schema.Unknown),
-  error: Schema.optionalKey(
-    Schema.Struct({
-      code: Schema.optionalKey(Schema.String),
-      summary: Schema.optionalKey(Schema.String),
-      message: Schema.optionalKey(Schema.String),
-      why: Schema.optionalKey(Schema.String),
-    }),
-  ),
-});
-type PrismaCliEnvelope = typeof PrismaCliEnvelopeSchema.Type;
-const decodePrismaCliEnvelope = Schema.decodeUnknownExit(PrismaCliEnvelopeSchema);
-
-const WhoamiResultSchema = Schema.Struct({
-  authenticated: Schema.Boolean,
-  workspace: Schema.NullOr(PrismaWorkspaceSchema),
-  source: Schema.NullOr(Schema.Literals(["stored", "environment"])),
-});
-type WhoamiResult = typeof WhoamiResultSchema.Type;
-
-const WorkspaceListResultSchema = Schema.Struct({
-  items: Schema.Array(
-    Schema.Struct({
-      workspaceId: Schema.String,
-      workspaceName: Schema.NullOr(Schema.String),
-      current: Schema.Boolean,
-    }),
-  ),
-});
-
-const WorkspaceUseResultSchema = Schema.Struct({ workspace: PrismaWorkspaceSchema });
-
-const ProjectShowResultSchema = Schema.Struct({
-  workspace: PrismaWorkspaceSchema,
-  project: Schema.NullOr(Schema.Struct({ id: Schema.String, name: Schema.String })),
-});
-
-const ProjectListResultSchema = Schema.Struct({
-  items: Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.String })),
-});
-type ProjectListResult = typeof ProjectListResultSchema.Type;
-
-const ComposerDeployCommandResultSchema = Schema.Struct({
-  summary: Schema.NullOr(
-    Schema.Struct({
-      app: Schema.String,
-      nodes: Schema.Array(
-        Schema.Struct({
-          entities: Schema.Array(
-            Schema.Struct({
-              kind: Schema.String,
-              id: Schema.String,
-              url: Schema.optionalKey(Schema.String),
-            }),
-          ),
-        }),
-      ),
-    }),
-  ),
-});
-type ComposerDeployCommandResult = typeof ComposerDeployCommandResultSchema.Type;
+import { atCreateStage } from "../workflow/failure";
+import { ensureAuthentication, selectDeploymentWorkspace } from "./composer/auth";
+import {
+  ComposerDeployCommandResultSchema,
+  parseComposerDeployResult,
+} from "./composer/deployment-result";
+import { decodePrismaCommandResult, runPrismaJsonCommandEffect } from "./composer/prisma-cli";
+import { ensureProjectNameAvailable, getProjectDetails } from "./composer/projects";
 
 export type ComposerDeployExecutionResult =
   | { ok: true; deployment: ComposerDeployResult }
@@ -99,307 +34,6 @@ export type ComposerDeployExecutionResult =
       error: unknown;
     };
 
-const stripResourcePrefix = (id: string, prefix: "proj" | "wksp") =>
-  id.startsWith(`${prefix}_`) ? id.slice(prefix.length + 1) : id;
-
-export function getConsoleProjectUrl(workspaceId: string, projectId: string): string {
-  return `https://console.prisma.io/${encodeURIComponent(stripResourcePrefix(workspaceId, "wksp"))}/${encodeURIComponent(stripResourcePrefix(projectId, "proj"))}`;
-}
-
-export function parsePrismaCliEnvelope(output: string): PrismaCliEnvelope {
-  const lines = output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .reverse();
-
-  for (const line of lines) {
-    try {
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      const candidate = parsed.kind === "result" ? parsed.envelope : parsed;
-      const decoded = decodePrismaCliEnvelope(candidate);
-      if (decoded._tag === "Success") return decoded.value;
-    } catch {
-      // Prisma may emit progress frames before the terminal JSON envelope.
-    }
-  }
-  throw new Error("Prisma CLI returned output that is not a valid result envelope.");
-}
-
-const getPrismaCliArgs = (packageManager: PackageManager, args: string[]) =>
-  getLocalPackageBinaryArgs(packageManager, "prisma", args);
-
-const runPrismaJsonCommandEffect = Effect.fn("PrismaCli.runJson")(function* (options: {
-  packageManager: PackageManager;
-  projectDir: string;
-  args: string[];
-  onStderrLine?: (line: string) => void;
-}) {
-  const runner = yield* CommandRunner;
-  const invocation = getPrismaCliArgs(options.packageManager, [
-    ...options.args,
-    "--json",
-    "--no-interactive",
-  ]);
-  const result = yield* runner.run({
-    command: invocation.command,
-    args: invocation.args,
-    cwd: options.projectDir,
-    env: process.env,
-    ...(options.onStderrLine ? { onStderrLine: options.onStderrLine } : {}),
-  });
-
-  let envelope: PrismaCliEnvelope;
-  try {
-    envelope = parsePrismaCliEnvelope(result.stdout);
-  } catch (cause) {
-    return yield* new PrismaCliCommandError({
-      message: result.stderr.trim() || getErrorMessage(cause),
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-    });
-  }
-
-  if (result.exitCode !== 0 || !envelope.ok || envelope.result === undefined) {
-    const summary = envelope.error?.summary ?? envelope.error?.message;
-    return yield* new PrismaCliCommandError({
-      message:
-        [summary, envelope.error?.why].filter(Boolean).join(": ") ||
-        result.stderr.trim() ||
-        "Prisma CLI command failed.",
-      ...(envelope.commandId || envelope.command
-        ? { command: envelope.commandId ?? envelope.command }
-        : {}),
-      ...(envelope.error?.code ? { code: envelope.error.code } : {}),
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-    });
-  }
-  return envelope.result;
-});
-
-const decodeCommandResult = <A>(schema: Schema.Codec<A>, value: unknown) =>
-  Schema.decodeUnknownEffect(schema)(value).pipe(
-    Effect.mapError(
-      (cause) =>
-        new PrismaCliCommandError({
-          message: `Prisma CLI returned an invalid result: ${cause.message}`,
-        }),
-    ),
-  );
-
-export function findProjectNameCollisions(
-  projects: ProjectListResult["items"],
-  appName: string,
-): ProjectListResult["items"] {
-  return projects.filter((project) => project.name === appName);
-}
-
-const workspaceLabel = (workspace: PrismaWorkspace) => workspace.name ?? workspace.id;
-
-const ensureProjectNameAvailable = Effect.fn("Deployment.ensureProjectNameAvailable")(
-  function* (options: {
-    appName: string;
-    packageManager: PackageManager;
-    projectDir: string;
-    workspace: PrismaWorkspace;
-  }) {
-    const raw = yield* runPrismaJsonCommandEffect({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      args: ["project", "list"],
-    });
-    const result = yield* decodeCommandResult(ProjectListResultSchema, raw);
-    const collisions = findProjectNameCollisions(result.items, options.appName);
-    if (collisions.length === 0) return;
-    const projectIds = collisions.map((project) => project.id).join(", ");
-    return yield* new CreateFailure({
-      stage: "check_project_name",
-      reason: "project_name_collision",
-      message: `A Prisma project named "${options.appName}" already exists in workspace ${workspaceLabel(options.workspace)} (${options.workspace.id}). Choose a different project name or delete the existing project (${projectIds}) in Prisma Console, then retry.`,
-    });
-  },
-);
-
-const ensureAuthentication = Effect.fn("Deployment.ensureAuthentication")(function* (options: {
-  packageManager: PackageManager;
-  projectDir: string;
-  output: Writable;
-  allowInteractiveLogin: boolean;
-  beforeInteractiveLogin?: () => void;
-}) {
-  const whoami = Effect.fn("PrismaCli.whoami")(function* () {
-    const raw = yield* runPrismaJsonCommandEffect({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      args: ["auth", "whoami"],
-    });
-    return yield* decodeCommandResult(WhoamiResultSchema, raw);
-  });
-
-  const authState = yield* whoami();
-  if (authState.authenticated) return authState;
-  const loginCommand = getLocalPackageBinaryCommand(options.packageManager, "prisma", [
-    "auth",
-    "login",
-  ]);
-  if (!options.allowInteractiveLogin || process.stdin.isTTY !== true) {
-    return yield* new CreateFailure({
-      stage: "authenticate",
-      reason: "not_authenticated",
-      message: `Sign in first with ${loginCommand}, then run ${getRunScriptCommand(options.packageManager, "deploy")}.`,
-    });
-  }
-
-  yield* Effect.sync(() => {
-    options.beforeInteractiveLogin?.();
-    log.info("Sign in to Prisma to deploy.", { output: options.output });
-  });
-  const runner = yield* CommandRunner;
-  const login = getPrismaCliArgs(options.packageManager, ["auth", "login"]);
-  yield* runner.runChecked({
-    command: login.command,
-    args: login.args,
-    cwd: options.projectDir,
-    env: process.env,
-    stdio: "inherit",
-  });
-
-  const authenticatedState = yield* whoami();
-  if (!authenticatedState.authenticated) {
-    return yield* new CreateFailure({
-      stage: "authenticate",
-      reason: "authentication_failed",
-      message: "Prisma sign-in completed without an active workspace session.",
-    });
-  }
-  return authenticatedState;
-});
-
-const useWorkspace = Effect.fn("Deployment.useWorkspace")(function* (options: {
-  packageManager: PackageManager;
-  projectDir: string;
-  workspace: string;
-}) {
-  const raw = yield* runPrismaJsonCommandEffect({
-    packageManager: options.packageManager,
-    projectDir: options.projectDir,
-    args: ["auth", "workspace", "use", options.workspace],
-  });
-  return (yield* decodeCommandResult(WorkspaceUseResultSchema, raw)).workspace;
-});
-
-const selectDeploymentWorkspace = Effect.fn("Deployment.selectWorkspace")(function* (options: {
-  packageManager: PackageManager;
-  projectDir: string;
-  shouldPrompt: boolean;
-  workspace?: string;
-  authState: WhoamiResult;
-  beforePrompt?: () => void;
-  afterPrompt?: () => void;
-  output: Writable;
-}) {
-  const activeWorkspace = options.authState.workspace;
-  if (!activeWorkspace) {
-    return yield* new CreateFailure({
-      stage: "select_workspace",
-      reason: "workspace_missing",
-      message: "The active Prisma credential does not specify a workspace.",
-    });
-  }
-
-  if (options.workspace) {
-    if (options.authState.source === "environment") {
-      if (options.workspace === activeWorkspace.id || options.workspace === activeWorkspace.name) {
-        return activeWorkspace;
-      }
-      return yield* new CreateFailure({
-        stage: "select_workspace",
-        reason: "workspace_mismatch",
-        message: `The environment credential is fixed to workspace ${workspaceLabel(activeWorkspace)}. Unset it before using --workspace ${options.workspace}.`,
-      });
-    }
-    return yield* useWorkspace({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      workspace: options.workspace,
-    });
-  }
-
-  if (!options.shouldPrompt || process.stdin.isTTY !== true) return activeWorkspace;
-  const raw = yield* runPrismaJsonCommandEffect({
-    packageManager: options.packageManager,
-    projectDir: options.projectDir,
-    args: ["auth", "workspace", "list"],
-  });
-  const available = yield* decodeCommandResult(WorkspaceListResultSchema, raw);
-  if (available.items.length <= 1) return activeWorkspace;
-
-  yield* Effect.sync(() => options.beforePrompt?.());
-  const selectedWorkspaceId = yield* Effect.tryPromise(() =>
-    select({
-      message: "Select Prisma workspace for deployment",
-      initialValue: activeWorkspace.id,
-      options: available.items.map((workspace) => ({
-        value: workspace.workspaceId,
-        label: workspace.workspaceName ?? workspace.workspaceId,
-        hint: workspace.current ? `${workspace.workspaceId}, current` : workspace.workspaceId,
-      })),
-      output: options.output,
-    }),
-  );
-  if (isCancel(selectedWorkspaceId)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output: options.output }));
-    return yield* new CreateCancellationError({ stage: "select_workspace" });
-  }
-  yield* Effect.sync(() => options.afterPrompt?.());
-  if (selectedWorkspaceId === activeWorkspace.id) return activeWorkspace;
-  return yield* useWorkspace({
-    packageManager: options.packageManager,
-    projectDir: options.projectDir,
-    workspace: selectedWorkspaceId,
-  });
-});
-
-export function parseComposerDeployResult(
-  result: ComposerDeployCommandResult,
-): { appName: string; appUrl?: string; serviceId?: string } | undefined {
-  if (!result.summary) return;
-  const computeService = result.summary.nodes
-    .flatMap((node) => node.entities)
-    .find((entity) => entity.kind === "compute-service");
-  return {
-    appName: result.summary.app,
-    ...(computeService?.id ? { serviceId: computeService.id } : {}),
-    ...(computeService?.url ? { appUrl: computeService.url.replace(/\/$/, "") } : {}),
-  };
-}
-
-const getProjectDetails = Effect.fn("Deployment.getProjectDetails")(function* (options: {
-  packageManager: PackageManager;
-  projectDir: string;
-  appName: string;
-}) {
-  const details = yield* Effect.gen(function* () {
-    const raw = yield* runPrismaJsonCommandEffect({
-      packageManager: options.packageManager,
-      projectDir: options.projectDir,
-      args: ["project", "show", options.appName],
-    });
-    const result = yield* decodeCommandResult(ProjectShowResultSchema, raw);
-    if (!result.project) return undefined;
-    return {
-      workspace: result.workspace,
-      project: {
-        id: result.project.id,
-        name: result.project.name,
-        consoleUrl: getConsoleProjectUrl(result.workspace.id, result.project.id),
-      },
-    };
-  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
-  return details;
-});
-
 type DeployOptions = {
   appName: string;
   packageManager: PackageManager;
@@ -411,19 +45,6 @@ type DeployOptions = {
   json?: boolean;
   workspace?: string;
 };
-
-const atStage = <A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  stage: CreateFailureStage,
-  reason: CreateFailureReason,
-) =>
-  effect.pipe(
-    Effect.mapError((error) =>
-      error instanceof CreateFailure || error instanceof CreateCancellationError
-        ? error
-        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
-    ),
-  );
 
 export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")(function* (
   options: DeployOptions,
@@ -451,7 +72,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       showProgress("Checking Prisma account...");
       if (options.verbose) log.step("Checking Prisma account.", { output });
     });
-    const authState = yield* atStage(
+    const authState = yield* atCreateStage(
       ensureAuthentication({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
@@ -467,7 +88,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       showProgress("Checking Prisma workspace...");
       if (options.verbose) log.step("Checking Prisma workspace.", { output });
     });
-    const selectedWorkspace = yield* atStage(
+    const selectedWorkspace = yield* atCreateStage(
       selectDeploymentWorkspace({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
@@ -486,7 +107,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       showProgress("Checking Prisma project name...");
       if (options.verbose) log.step("Checking Prisma project name.", { output });
     });
-    yield* atStage(
+    yield* atCreateStage(
       ensureProjectNameAvailable({
         appName: options.appName,
         packageManager: options.packageManager,
@@ -502,7 +123,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       if (options.verbose) log.step("Building for deployment.", { output });
     });
     const build = getRunScriptArgs(options.packageManager, "build");
-    yield* atStage(
+    yield* atCreateStage(
       runSetupCommand({
         command: build.command,
         args: build.args,
@@ -527,7 +148,7 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
         deploymentLog.message(`$ ${deployCommand}`);
       }
     });
-    const rawDeployment = yield* atStage(
+    const rawDeployment = yield* atCreateStage(
       runPrismaJsonCommandEffect({
         packageManager: options.packageManager,
         projectDir: options.projectDir,
@@ -541,8 +162,8 @@ export const deployNewProjectWithComposerEffect = Effect.fn("Deployment.deploy")
       "composer_deploy",
       "composer_deploy_failed",
     );
-    const deploymentResult = yield* atStage(
-      decodeCommandResult(ComposerDeployCommandResultSchema, rawDeployment),
+    const deploymentResult = yield* atCreateStage(
+      decodePrismaCommandResult(ComposerDeployCommandResultSchema, rawDeployment),
       "composer_deploy",
       "composer_deploy_failed",
     );
@@ -637,5 +258,7 @@ export async function deployNewProjectWithComposer(
   };
 }
 
-export { PrismaCliCommandError };
+export { parseComposerDeployResult } from "./composer/deployment-result";
+export { parsePrismaCliEnvelope, PrismaCliCommandError } from "./composer/prisma-cli";
+export { findProjectNameCollisions, getConsoleProjectUrl } from "./composer/projects";
 export type { ComposerDeployResult } from "../result";

--- a/src/tasks/initialize-git.ts
+++ b/src/tasks/initialize-git.ts
@@ -1,53 +1,63 @@
-import { execa } from "execa";
-import fs from "fs-extra";
+import { Effect, FileSystem, Result } from "effect";
 import path from "node:path";
+
+import { applicationRuntime } from "../runtime";
+import { CommandRunner } from "../services/command-runner";
+import { getErrorMessage } from "../utils/errors";
 
 export type GitInitializationResult =
   | { status: "initialized" }
   | { status: "already-in-repository" }
   | { status: "skipped"; reason: string };
 
-function errorMessage(error: unknown): string {
-  if (error instanceof Error && "stderr" in error) {
-    const stderr = String((error as { stderr?: string }).stderr ?? "").trim();
-    if (stderr) return stderr;
-  }
-  return error instanceof Error ? error.message : String(error);
-}
+export const initializeGitRepositoryEffect = Effect.fn("Git.initialize")(function* (
+  projectDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const runner = yield* CommandRunner;
+  const fs = yield* FileSystem.FileSystem;
+  const existing = yield* runner
+    .run({ command: "git", args: ["rev-parse", "--is-inside-work-tree"], cwd: projectDir, env })
+    .pipe(Effect.result);
 
-/**
- * Initializes a standalone scaffold as a Git repository and records its generated files.
- * Projects created inside an existing repository remain part of that repository.
- */
-export async function initializeGitRepository(
+  if (Result.isFailure(existing)) {
+    return {
+      status: "skipped",
+      reason: getErrorMessage(existing.failure),
+    } satisfies GitInitializationResult;
+  }
+  if (existing.success.exitCode === 0 && existing.success.stdout.trim() === "true") {
+    return { status: "already-in-repository" } satisfies GitInitializationResult;
+  }
+
+  const initialize = Effect.gen(function* () {
+    yield* runner.runChecked({ command: "git", args: ["init"], cwd: projectDir, env });
+    yield* runner.runChecked({ command: "git", args: ["add", "--all"], cwd: projectDir, env });
+    yield* runner.runChecked({
+      command: "git",
+      args: ["commit", "--no-verify", "-m", "Initial commit from create-prisma"],
+      cwd: projectDir,
+      env,
+    });
+    return { status: "initialized" } satisfies GitInitializationResult;
+  });
+
+  return yield* initialize.pipe(
+    Effect.catch((error) =>
+      fs.remove(path.join(projectDir, ".git"), { recursive: true, force: true }).pipe(
+        Effect.catch(() => Effect.void),
+        Effect.as({
+          status: "skipped",
+          reason: getErrorMessage(error),
+        } satisfies GitInitializationResult),
+      ),
+    ),
+  );
+});
+
+export function initializeGitRepository(
   projectDir: string,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<GitInitializationResult> {
-  try {
-    const existing = await execa("git", ["rev-parse", "--is-inside-work-tree"], {
-      cwd: projectDir,
-      env,
-      reject: false,
-    });
-    if (existing.exitCode === 0 && existing.stdout.trim() === "true") {
-      return { status: "already-in-repository" };
-    }
-  } catch (error) {
-    return { status: "skipped", reason: errorMessage(error) };
-  }
-
-  let initialized = false;
-  try {
-    await execa("git", ["init"], { cwd: projectDir, env });
-    initialized = true;
-    await execa("git", ["add", "--all"], { cwd: projectDir, env });
-    await execa("git", ["commit", "--no-verify", "-m", "Initial commit from create-prisma"], {
-      cwd: projectDir,
-      env,
-    });
-    return { status: "initialized" };
-  } catch (error) {
-    if (initialized) await fs.remove(path.join(projectDir, ".git"));
-    return { status: "skipped", reason: errorMessage(error) };
-  }
+  return applicationRuntime.runPromise(initializeGitRepositoryEffect(projectDir, env));
 }

--- a/src/tasks/install.ts
+++ b/src/tasks/install.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import { Effect, FileSystem } from "effect";
 import path from "node:path";
 
 import {
@@ -7,9 +7,19 @@ import {
   PRISMA_DENO_CLI_PACKAGE,
 } from "../constants/dependencies";
 import { getDbPackages } from "../constants/db-packages";
+import { applicationRuntime } from "../runtime";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
 import { getInstallArgs, getRunScriptCommand } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  resolutions?: Record<string, string>;
+  overrides?: Record<string, string>;
+  [key: string]: unknown;
+};
 
 function getPrismaScriptMap(packageManager: PackageManager): Record<string, string> {
   if (packageManager === "deno") {
@@ -34,7 +44,6 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
   }
 
   const prismaCommand = (...args: string[]) => ["prisma", ...args].join(" ");
-
   return {
     "contract:emit": prismaCommand("contract", "emit"),
     "db:init": prismaCommand("db", "init"),
@@ -49,168 +58,176 @@ function getPrismaScriptMap(packageManager: PackageManager): Record<string, stri
 }
 
 export function getComposerScriptMap(packageManager: PackageManager): Record<string, string> {
-  if (packageManager === "deno") {
-    return {};
-  }
-
+  if (packageManager === "deno") return {};
   const composerCommand = (subcommand: "dev" | "deploy") =>
     ["prisma", subcommand, "module.ts"].join(" ");
-
   return {
     "composer:dev": composerCommand("dev"),
     "composer:deploy": composerCommand("deploy"),
-    deploy: `${getRunScriptCommand(packageManager, "build")} && ${getRunScriptCommand(
-      packageManager,
-      "composer:deploy",
-    )}`,
-    "dev:composer": `${getRunScriptCommand(packageManager, "build")} && ${getRunScriptCommand(
-      packageManager,
-      "composer:dev",
-    )}`,
+    deploy: `${getRunScriptCommand(packageManager, "build")} && ${getRunScriptCommand(packageManager, "composer:deploy")}`,
+    "dev:composer": `${getRunScriptCommand(packageManager, "build")} && ${getRunScriptCommand(packageManager, "composer:dev")}`,
   };
 }
 
-function unique(items: string[]): string[] {
-  return [...new Set(items)];
-}
+const unique = (items: string[]) => [...new Set(items)];
+const sortRecord = (record: Record<string, string>) =>
+  Object.fromEntries(Object.entries(record).sort(([left], [right]) => left.localeCompare(right)));
 
-function sortRecord(record: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
-}
+const readPackageJson = Effect.fn("Dependencies.readPackageJson")(function* (
+  packageJsonPath: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const source = yield* fs.readFileString(packageJsonPath);
+  return yield* Effect.try({
+    try: () => JSON.parse(source) as PackageJson,
+    catch: (cause) => new Error(`Invalid package.json at ${packageJsonPath}`, { cause }),
+  });
+});
 
-export async function addPackageDependency(opts: {
+const writePackageJson = Effect.fn("Dependencies.writePackageJson")(function* (
+  packageJsonPath: string,
+  packageJson: PackageJson,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.writeFileString(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+});
+
+export const addPackageDependencyEffect = Effect.fn("Dependencies.add")(function* (opts: {
   dependencies?: string[];
   devDependencies?: string[];
   customDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
   scriptMode?: "if-missing";
   projectDir: string;
-}): Promise<void> {
-  const {
-    dependencies = [],
-    devDependencies = [],
-    customDependencies = {},
-    scripts = {},
-    scriptMode,
-    projectDir,
-  } = opts;
-
-  const pkgJsonPath = path.join(projectDir, "package.json");
-  if (!(await fs.pathExists(pkgJsonPath))) {
-    throw new Error(
-      `No package.json found in ${projectDir}. Run this command inside an existing JavaScript/TypeScript project.`,
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const dependencies = opts.dependencies ?? [];
+  const devDependencies = opts.devDependencies ?? [];
+  const customDependencies = opts.customDependencies ?? {};
+  const scripts = opts.scripts ?? {};
+  const packageJsonPath = path.join(opts.projectDir, "package.json");
+  if (!(yield* fs.exists(packageJsonPath))) {
+    return yield* Effect.fail(
+      new Error(
+        `No package.json found in ${opts.projectDir}. Run this command inside an existing JavaScript/TypeScript project.`,
+      ),
     );
   }
 
-  const pkgJson = await fs.readJson(pkgJsonPath);
-  pkgJson.dependencies ??= {};
-  pkgJson.devDependencies ??= {};
-  pkgJson.scripts ??= {};
+  const packageJson = yield* readPackageJson(packageJsonPath);
+  packageJson.dependencies ??= {};
+  packageJson.devDependencies ??= {};
+  packageJson.scripts ??= {};
 
   for (const packageName of unique(dependencies)) {
     const version = getDependencyVersion(packageName);
-    if (!version) throw new Error(`Dependency ${packageName} is missing from the version map.`);
-    pkgJson.dependencies[packageName] = version;
+    if (!version)
+      return yield* Effect.fail(
+        new Error(`Dependency ${packageName} is missing from the version map.`),
+      );
+    packageJson.dependencies[packageName] = version;
   }
   for (const packageName of unique(devDependencies)) {
     const version = getDependencyVersion(packageName);
-    if (!version) throw new Error(`Dependency ${packageName} is missing from the version map.`);
-    pkgJson.devDependencies[packageName] = version;
+    if (!version)
+      return yield* Effect.fail(
+        new Error(`Dependency ${packageName} is missing from the version map.`),
+      );
+    packageJson.devDependencies[packageName] = version;
   }
-  for (const [packageName, version] of Object.entries(customDependencies)) {
-    pkgJson.dependencies[packageName] = version;
-  }
+  Object.assign(packageJson.dependencies, customDependencies);
   for (const [scriptName, command] of Object.entries(scripts)) {
     if (
-      scriptMode === "if-missing" &&
-      typeof pkgJson.scripts[scriptName] === "string" &&
-      pkgJson.scripts[scriptName].trim().length > 0
+      opts.scriptMode === "if-missing" &&
+      typeof packageJson.scripts[scriptName] === "string" &&
+      packageJson.scripts[scriptName].trim().length > 0
     ) {
       continue;
     }
-    pkgJson.scripts[scriptName] = command;
+    packageJson.scripts[scriptName] = command;
   }
 
-  pkgJson.dependencies = sortRecord(pkgJson.dependencies);
-  pkgJson.devDependencies = sortRecord(pkgJson.devDependencies);
-  pkgJson.scripts = sortRecord(pkgJson.scripts);
-  await fs.writeJson(pkgJsonPath, pkgJson, { spaces: 2 });
-}
+  packageJson.dependencies = sortRecord(packageJson.dependencies);
+  packageJson.devDependencies = sortRecord(packageJson.devDependencies);
+  packageJson.scripts = sortRecord(packageJson.scripts);
+  yield* writePackageJson(packageJsonPath, packageJson);
+});
 
-export async function writePrismaDependencies(
+export const writePrismaDependenciesEffect = Effect.fn("Dependencies.writePrisma")(function* (
   provider: DatabaseProvider,
   packageManager: PackageManager,
   _authoring: AuthoringStyle,
   projectDir = process.cwd(),
-): Promise<void> {
+) {
   const dependencies = [getDbPackages(provider)];
   if (provider === "postgres" && packageManager !== "deno") dependencies.push("temporal-polyfill");
   if (provider === "mongo") dependencies.push("arktype", "mongodb");
   if (packageManager === "deno") dependencies.push("dotenv");
-
-  const devDependencies = ["@types/node", "prisma"];
-
-  await addPackageDependency({
+  yield* addPackageDependencyEffect({
     dependencies,
-    devDependencies,
+    devDependencies: ["@types/node", "prisma"],
     scripts: getPrismaScriptMap(packageManager),
     projectDir,
   });
-}
+});
 
-export async function writeCreateTemplateDependencies(opts: {
-  template: CreateTemplate;
-  packageManager: PackageManager;
-  projectDir?: string;
-}): Promise<void> {
-  const { template, packageManager, projectDir = process.cwd() } = opts;
+export const writeCreateTemplateDependenciesEffect = Effect.fn("Dependencies.writeTemplate")(
+  function* (opts: {
+    template: CreateTemplate;
+    packageManager: PackageManager;
+    projectDir?: string;
+  }) {
+    const projectDir = opts.projectDir ?? process.cwd();
+    if (opts.packageManager === "deno") return;
 
-  if (packageManager === "deno") {
-    return;
-  }
+    for (const target of getCreateTemplateDependencies(opts.template, opts.packageManager)) {
+      yield* addPackageDependencyEffect({
+        dependencies: target.dependencies,
+        devDependencies: target.devDependencies,
+        customDependencies: target.customDependencies,
+        scripts: getComposerScriptMap(opts.packageManager),
+        projectDir: path.join(projectDir, path.dirname(target.packageJsonPath)),
+      });
+    }
 
-  for (const target of getCreateTemplateDependencies(template, packageManager)) {
-    await addPackageDependency({
-      dependencies: target.dependencies,
-      devDependencies: target.devDependencies,
-      customDependencies: target.customDependencies,
-      scripts: getComposerScriptMap(packageManager),
-      projectDir: path.join(projectDir, path.dirname(target.packageJsonPath)),
-    });
-  }
+    const packageJsonPath = path.join(projectDir, "package.json");
+    const packageJson = yield* readPackageJson(packageJsonPath);
+    const effectVersion = getDependencyVersion("effect");
+    if (!effectVersion)
+      return yield* Effect.fail(new Error("Dependency effect is missing from the version map."));
+    if (opts.packageManager === "yarn") {
+      packageJson.resolutions = { ...packageJson.resolutions, effect: effectVersion };
+    } else if (opts.packageManager !== "pnpm") {
+      packageJson.overrides = { ...packageJson.overrides, effect: effectVersion };
+    }
+    yield* writePackageJson(packageJsonPath, packageJson);
+  },
+);
 
-  const packageJsonPath = path.join(projectDir, "package.json");
-  const packageJson = await fs.readJson(packageJsonPath);
-  const effectVersion = getDependencyVersion("effect");
-  if (!effectVersion) throw new Error("Dependency effect is missing from the version map.");
-
-  if (packageManager === "yarn") {
-    packageJson.resolutions = { ...packageJson.resolutions, effect: effectVersion };
-  } else if (packageManager !== "pnpm") {
-    packageJson.overrides = { ...packageJson.overrides, effect: effectVersion };
-  }
-  await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
-}
-
-export async function installProjectDependencies(
+export const installProjectDependenciesEffect = Effect.fn("Dependencies.install")(function* (
   packageManager: PackageManager,
   projectDir = process.cwd(),
   options: { verbose?: boolean; json?: boolean } = {},
-): Promise<void> {
+) {
   const installCommand = getInstallArgs(packageManager);
-  const env =
-    packageManager === "yarn"
-      ? {
-          YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
-        }
-      : undefined;
-
-  await runSetupCommand({
+  yield* runSetupCommand({
     command: installCommand.command,
     args: installCommand.args,
     cwd: projectDir,
-    env,
+    ...(packageManager === "yarn" ? { env: { YARN_ENABLE_IMMUTABLE_INSTALLS: "false" } } : {}),
     verbose: options.verbose === true,
     json: options.json === true,
   });
-}
+});
+
+export const addPackageDependency = (opts: Parameters<typeof addPackageDependencyEffect>[0]) =>
+  applicationRuntime.runPromise(addPackageDependencyEffect(opts));
+export const writePrismaDependencies = (
+  ...args: Parameters<typeof writePrismaDependenciesEffect>
+) => applicationRuntime.runPromise(writePrismaDependenciesEffect(...args));
+export const writeCreateTemplateDependencies = (
+  opts: Parameters<typeof writeCreateTemplateDependenciesEffect>[0],
+) => applicationRuntime.runPromise(writeCreateTemplateDependenciesEffect(opts));
+export const installProjectDependencies = (
+  ...args: Parameters<typeof installProjectDependenciesEffect>
+) => applicationRuntime.runPromise(installProjectDependenciesEffect(...args));

--- a/src/tasks/prisma-setup/commands.ts
+++ b/src/tasks/prisma-setup/commands.ts
@@ -1,0 +1,66 @@
+import { log } from "@clack/prompts";
+import { Effect, FileSystem } from "effect";
+import path from "node:path";
+
+import type { AuthoringStyle, DatabaseProvider } from "../../types";
+import { getLocalPackageBinaryArgs } from "../../utils/package-manager";
+import { runSetupCommand } from "../../utils/run-command";
+import type { PrismaSetupContext } from "./types";
+
+const getContractPath = (authoring: AuthoringStyle) =>
+  `src/prisma/contract${authoring === "typescript" ? ".ts" : ".prisma"}`;
+
+const getInitTarget = (provider: DatabaseProvider) =>
+  provider === "mongo" ? ("mongodb" as const) : ("postgres" as const);
+
+export const runPrismaCli = Effect.fn("PrismaSetup.runCli")(function* (
+  context: PrismaSetupContext,
+  projectDir: string,
+  args: string[],
+) {
+  const invocation = getLocalPackageBinaryArgs(context.packageManager, "prisma", args);
+  yield* Effect.sync(() => {
+    if (context.verbose) {
+      log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
+    }
+  });
+  yield* runSetupCommand({
+    command: invocation.command,
+    args: invocation.args,
+    cwd: projectDir,
+    env: { ...process.env, CI: "1" },
+    verbose: context.verbose,
+    json: context.json,
+  });
+});
+
+export const runPrismaInit = Effect.fn("PrismaSetup.init")(function* (
+  context: PrismaSetupContext,
+  projectDir: string,
+) {
+  yield* runPrismaCli(context, projectDir, [
+    "orm",
+    "init",
+    "--yes",
+    "--no-interactive",
+    "--target",
+    getInitTarget(context.databaseProvider),
+    "--authoring",
+    context.authoring,
+    "--schema-path",
+    getContractPath(context.authoring),
+    "--skip-install",
+  ]);
+  if (context.packageManager === "deno") {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(path.join(projectDir, "prisma-next.md"), { force: true });
+  }
+});
+
+export const initializeAgentSkills = Effect.fn("PrismaSetup.initializeSkills")(function* (
+  context: PrismaSetupContext,
+  projectDir: string,
+) {
+  if (context.packageManager === "deno") return;
+  yield* runPrismaCli(context, projectDir, ["init", "--yes", "--no-interactive"]);
+});

--- a/src/tasks/prisma-setup/context.ts
+++ b/src/tasks/prisma-setup/context.ts
@@ -1,0 +1,179 @@
+import { cancel, confirm, isCancel, select } from "@clack/prompts";
+import { Effect, Schema } from "effect";
+import path from "node:path";
+import type { Writable } from "node:stream";
+
+import { CreateCancellationError, CreateFailure } from "../../create-outcome";
+import {
+  AuthoringStyleSchema,
+  DatabaseProviderSchema,
+  PackageManagerSchema,
+  packageManagers,
+  type AuthoringStyle,
+  type CreateTemplate,
+  type DatabaseProvider,
+  type PackageManager,
+  type PrismaSetupCommandInput,
+} from "../../types";
+import { resolveExecutionSettings } from "../../ui/output";
+import { detectPackageManagerEffect } from "../../utils/package-manager";
+import type { PrismaSetupContext } from "./types";
+
+const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
+const DEFAULT_AUTHORING: AuthoringStyle = "psl";
+
+const decodePromptValue = <A>(schema: Schema.Codec<A>, value: unknown) =>
+  Schema.decodeUnknownEffect(schema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CreateFailure({
+          stage: "collect_context",
+          reason: "invalid_input",
+          message: cause.message,
+          cause,
+        }),
+    ),
+  );
+
+const promptForDatabaseProvider = Effect.fn("Prompts.databaseProvider")(function* (
+  output: Writable,
+) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Select your database",
+      initialValue: DEFAULT_DATABASE_PROVIDER,
+      options: [
+        { value: "postgres", label: "PostgreSQL", hint: "Prisma Postgres with Composer" },
+        { value: "mongo", label: "MongoDB", hint: "Connect an existing MongoDB database" },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "database_provider" });
+  }
+  return yield* decodePromptValue(DatabaseProviderSchema, value);
+});
+
+const promptForAuthoringStyle = Effect.fn("Prompts.authoringStyle")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Choose contract authoring style",
+      initialValue: DEFAULT_AUTHORING,
+      options: [
+        { value: "psl", label: "PSL", hint: "Prisma schema syntax" },
+        { value: "typescript", label: "TypeScript", hint: "TypeScript contract builder" },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "authoring_style" });
+  }
+  return yield* decodePromptValue(AuthoringStyleSchema, value);
+});
+
+const packageManagerHint = (option: PackageManager, detected: PackageManager) => {
+  const hints = {
+    npm: "Node.js default",
+    pnpm: "Fast, disk-efficient package manager",
+    yarn: "Yarn package manager",
+    bun: "Fast runtime and package manager",
+    deno: "Deno runtime (minimal PostgreSQL apps)",
+  } satisfies Record<PackageManager, string>;
+  return option === detected ? `Detected; ${hints[option]}` : hints[option];
+};
+
+const promptForPackageManager = Effect.fn("Prompts.packageManager")(function* (
+  detected: PackageManager,
+  output: Writable,
+) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Choose package manager",
+      initialValue: detected,
+      options: packageManagers.map((packageManager) => ({
+        value: packageManager,
+        label: packageManager,
+        hint: packageManagerHint(packageManager, detected),
+      })),
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "package_manager" });
+  }
+  return yield* decodePromptValue(PackageManagerSchema, value);
+});
+
+const promptForDeployment = Effect.fn("Prompts.deployment")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    confirm({ message: "Deploy to Prisma now?", initialValue: true, output }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "deployment_intent" });
+  }
+  return Boolean(value);
+});
+
+export const collectPrismaSetupContextEffect = Effect.fn("PrismaSetup.collectContext")(function* (
+  input: PrismaSetupCommandInput,
+  options: { projectDir?: string; template?: CreateTemplate } = {},
+) {
+  const projectDir = path.resolve(options.projectDir ?? process.cwd());
+  const { json, output, useDefaults } = resolveExecutionSettings(input);
+  const databaseProvider =
+    input.provider ??
+    (useDefaults ? DEFAULT_DATABASE_PROVIDER : yield* promptForDatabaseProvider(output));
+  const authoring =
+    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : yield* promptForAuthoringStyle(output));
+  const detectedPackageManager = yield* detectPackageManagerEffect(projectDir);
+  const packageManager =
+    input.packageManager ??
+    (useDefaults
+      ? detectedPackageManager
+      : yield* promptForPackageManager(detectedPackageManager, output));
+
+  if (packageManager === "deno" && databaseProvider !== "postgres") {
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Deno support currently requires PostgreSQL.",
+    });
+  }
+  if (packageManager === "deno" && options.template && options.template !== "minimal") {
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Deno support currently requires the minimal template.",
+    });
+  }
+  if (packageManager === "deno" && input.deploy === true) {
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Prisma Compute does not support Deno deployments yet. Use --no-deploy.",
+    });
+  }
+
+  const shouldDeploy =
+    packageManager === "deno"
+      ? false
+      : (input.deploy ?? (json ? true : useDefaults ? false : yield* promptForDeployment(output)));
+  return {
+    projectDir,
+    verbose: input.verbose === true,
+    json,
+    output,
+    databaseProvider,
+    authoring,
+    packageManager,
+    shouldDeploy,
+    shouldPromptForWorkspace: !useDefaults,
+    ...(input.workspace ? { workspace: input.workspace } : {}),
+  } satisfies PrismaSetupContext;
+});

--- a/src/tasks/prisma-setup/presentation.ts
+++ b/src/tasks/prisma-setup/presentation.ts
@@ -1,0 +1,69 @@
+import path from "node:path";
+
+import type { ComposerDeployResult, CreateNextStep } from "../../result";
+import { getRunScriptCommand } from "../../utils/package-manager";
+import type { PrismaSetupContext, PrismaSetupRunOptions } from "./types";
+
+export const formatNextSteps = (steps: CreateNextStep[]) =>
+  steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
+
+const formatPlatformTarget = (name: string | null, id: string) => (name ? `${name} (${id})` : id);
+
+export function formatProjectSummary(options: {
+  createdProjectPath?: string;
+  deployment?: ComposerDeployResult;
+}): string {
+  const lines: string[] = [];
+  if (options.createdProjectPath) lines.push(`Path: ${path.resolve(options.createdProjectPath)}`);
+  if (options.deployment?.workspace) {
+    lines.push(
+      `Workspace: ${formatPlatformTarget(options.deployment.workspace.name, options.deployment.workspace.id)}`,
+    );
+  }
+  if (options.deployment) {
+    lines.push(
+      `Project: ${
+        options.deployment.project.id
+          ? formatPlatformTarget(options.deployment.project.name, options.deployment.project.id)
+          : options.deployment.project.name
+      }`,
+    );
+    lines.push(`App: ${options.deployment.appUrl ?? options.deployment.appName}`);
+    if (options.deployment.project.consoleUrl) {
+      lines.push(`Console: ${options.deployment.project.consoleUrl}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function buildNextSteps(
+  context: PrismaSetupContext,
+  options: PrismaSetupRunOptions,
+): CreateNextStep[] {
+  const nextSteps = [...(options.prependNextSteps ?? [])];
+  if (context.databaseProvider === "mongo") {
+    nextSteps.push({
+      command: "Set MONGODB_URL in your environment",
+      description: "Composer uses this secret when deploying the MongoDB template.",
+    });
+  }
+  if (options.includeDevNextStep) {
+    nextSteps.push({
+      command: getRunScriptCommand(
+        context.packageManager,
+        context.packageManager === "deno" ? "dev" : "dev:composer",
+      ),
+      description:
+        context.packageManager === "deno"
+          ? "Start the Deno app after setting DATABASE_URL in .env."
+          : "Build and start the app with Prisma Composer locally.",
+    });
+  }
+  if (context.packageManager !== "deno") {
+    nextSteps.push({
+      command: getRunScriptCommand(context.packageManager, "deploy"),
+      description: "Build and deploy the app with Prisma Composer.",
+    });
+  }
+  return nextSteps;
+}

--- a/src/tasks/prisma-setup/project-files.ts
+++ b/src/tasks/prisma-setup/project-files.ts
@@ -1,0 +1,52 @@
+import { Effect, FileSystem } from "effect";
+import path from "node:path";
+
+export const ensureGitignoreEntry = Effect.fn("PrismaSetup.ensureGitignoreEntry")(function* (
+  projectDir: string,
+  entry: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const gitignorePath = path.join(projectDir, ".gitignore");
+  const existing = (yield* fs.exists(gitignorePath)) ? yield* fs.readFileString(gitignorePath) : "";
+  const entries = existing.split(/\r?\n/).map((line) => line.trim());
+  if (entries.includes(entry) || entries.includes(`/${entry}`)) return;
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  yield* fs.writeFileString(gitignorePath, `${existing}${separator}${entry}\n`);
+});
+
+export const ensureMongoEnvironment = Effect.fn("PrismaSetup.ensureMongoEnvironment")(function* (
+  projectDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const envPath = path.join(projectDir, ".env");
+  if (!(yield* fs.exists(envPath))) {
+    yield* fs.writeFileString(
+      envPath,
+      'DATABASE_URL="mongodb://localhost:27017/mydb?replicaSet=rs0&directConnection=true"\n',
+    );
+  }
+  yield* ensureGitignoreEntry(projectDir, ".env");
+});
+
+export const ensureComposerTypeScriptOptions = Effect.fn(
+  "PrismaSetup.ensureComposerTypeScriptOptions",
+)(function* (projectDir: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const tsconfigPath = path.join(projectDir, "tsconfig.json");
+  const tsconfig = yield* fs.readFileString(tsconfigPath);
+  const additions: string[] = [];
+  if (!/"allowImportingTsExtensions"\s*:/.test(tsconfig)) {
+    additions.push('    "allowImportingTsExtensions": true,');
+  }
+  if (!/"noEmit"\s*:/.test(tsconfig)) additions.push('    "noEmit": true,');
+  if (additions.length === 0) return;
+
+  const updated = tsconfig.replace(
+    /"compilerOptions"\s*:\s*\{/,
+    (match) => `${match}\n${additions.join("\n")}`,
+  );
+  if (updated === tsconfig) {
+    return yield* Effect.fail(new Error("tsconfig.json is missing compilerOptions."));
+  }
+  yield* fs.writeFileString(tsconfigPath, updated);
+});

--- a/src/tasks/prisma-setup/types.ts
+++ b/src/tasks/prisma-setup/types.ts
@@ -1,0 +1,37 @@
+import type { spinner } from "@clack/prompts";
+import type { Writable } from "node:stream";
+
+import type { ComposerDeployResult, CreateNextStep } from "../../result";
+import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../../types";
+import type { GitInitializationResult } from "../initialize-git";
+
+export type PrismaSetupRunOptions = {
+  prependNextSteps?: CreateNextStep[];
+  projectDir?: string;
+  projectName?: string;
+  template?: CreateTemplate;
+  createdProjectPath?: string;
+  includeDevNextStep?: boolean;
+  initializeGit?: boolean;
+  progressSpinner?: ReturnType<typeof spinner>;
+};
+
+export type PrismaSetupContext = {
+  projectDir: string;
+  verbose: boolean;
+  json: boolean;
+  output: Writable;
+  databaseProvider: DatabaseProvider;
+  authoring: AuthoringStyle;
+  packageManager: PackageManager;
+  shouldDeploy: boolean;
+  shouldPromptForWorkspace: boolean;
+  workspace?: string;
+};
+
+export type PrismaSetupSuccess = {
+  deployment: ComposerDeployResult | null;
+  nextSteps: CreateNextStep[];
+  gitInitialization?: GitInitializationResult;
+  warnings: string[];
+};

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -1,18 +1,18 @@
 import { cancel, confirm, isCancel, log, note, outro, select, spinner } from "@clack/prompts";
-import fs from "fs-extra";
+import { Effect, FileSystem, Schema } from "effect";
 import path from "node:path";
 import type { Writable } from "node:stream";
 
 import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
-  ClassifiedCreateError,
   CreateCancellationError,
-  getCreateFailureReason,
+  CreateFailure,
   type CreateFailureReason,
   type CreateFailureStage,
 } from "../create-outcome";
-import type { CreateNextStep } from "../result";
-import { scaffoldCreateSharedTemplates } from "../templates/render-create-template";
+import type { ComposerDeployResult, CreateNextStep } from "../result";
+import { applicationRuntime } from "../runtime";
+import { scaffoldCreateSharedTemplatesEffect } from "../templates/render-create-template";
 import {
   AuthoringStyleSchema,
   DatabaseProviderSchema,
@@ -27,15 +27,15 @@ import {
 import { resolveExecutionSettings } from "../ui/output";
 import { getErrorMessage } from "../utils/errors";
 import {
-  detectPackageManager,
+  detectPackageManagerEffect,
   getInstallCommand,
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
-import { deployNewProjectWithComposer, type ComposerDeployResult } from "./deploy-with-composer";
-import { initializeGitRepository, type GitInitializationResult } from "./initialize-git";
-import { installProjectDependencies, writePrismaDependencies } from "./install";
+import { deployNewProjectWithComposerEffect } from "./deploy-with-composer";
+import { initializeGitRepositoryEffect, type GitInitializationResult } from "./initialize-git";
+import { installProjectDependenciesEffect, writePrismaDependenciesEffect } from "./install";
 
 const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
 const DEFAULT_AUTHORING: AuthoringStyle = "psl";
@@ -64,64 +64,67 @@ export type PrismaSetupContext = {
   workspace?: string;
 };
 
-export type PrismaSetupExecutionResult =
-  | {
-      ok: true;
-      deployment: ComposerDeployResult | null;
-      nextSteps: CreateNextStep[];
-      gitInitialization?: GitInitializationResult;
-      warnings: string[];
-    }
-  | {
-      ok: false;
-      cancelled: true;
-      stage: "select_workspace";
-      errorReported?: boolean;
-    }
-  | {
-      ok: false;
-      cancelled?: false;
-      stage: CreateFailureStage;
-      reason: CreateFailureReason;
-      error?: unknown;
-      errorReported?: boolean;
-    };
+export type PrismaSetupSuccess = {
+  deployment: ComposerDeployResult | null;
+  nextSteps: CreateNextStep[];
+  gitInitialization?: GitInitializationResult;
+  warnings: string[];
+};
 
-async function promptForDatabaseProvider(output: Writable): Promise<DatabaseProvider> {
-  const databaseProvider = await select({
-    message: "Select your database",
-    initialValue: DEFAULT_DATABASE_PROVIDER,
-    options: [
-      { value: "postgres", label: "PostgreSQL", hint: "Prisma Postgres with Composer" },
-      { value: "mongo", label: "MongoDB", hint: "Connect an existing MongoDB database" },
-    ],
-    output,
-  });
-  if (isCancel(databaseProvider)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("database_provider");
+const decodePromptValue = <A>(schema: Schema.Codec<A>, value: unknown) =>
+  Schema.decodeUnknownEffect(schema)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CreateFailure({
+          stage: "collect_context",
+          reason: "invalid_input",
+          message: cause.message,
+          cause,
+        }),
+    ),
+  );
+
+const promptForDatabaseProvider = Effect.fn("Prompts.databaseProvider")(function* (
+  output: Writable,
+) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Select your database",
+      initialValue: DEFAULT_DATABASE_PROVIDER,
+      options: [
+        { value: "postgres", label: "PostgreSQL", hint: "Prisma Postgres with Composer" },
+        { value: "mongo", label: "MongoDB", hint: "Connect an existing MongoDB database" },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "database_provider" });
   }
-  return DatabaseProviderSchema.parse(databaseProvider);
-}
+  return yield* decodePromptValue(DatabaseProviderSchema, value);
+});
 
-async function promptForAuthoringStyle(output: Writable): Promise<AuthoringStyle> {
-  const authoring = await select({
-    message: "Choose contract authoring style",
-    initialValue: DEFAULT_AUTHORING,
-    options: [
-      { value: "psl", label: "PSL", hint: "Prisma schema syntax" },
-      { value: "typescript", label: "TypeScript", hint: "TypeScript contract builder" },
-    ],
-    output,
-  });
-  if (isCancel(authoring)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("authoring_style");
+const promptForAuthoringStyle = Effect.fn("Prompts.authoringStyle")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Choose contract authoring style",
+      initialValue: DEFAULT_AUTHORING,
+      options: [
+        { value: "psl", label: "PSL", hint: "Prisma schema syntax" },
+        { value: "typescript", label: "TypeScript", hint: "TypeScript contract builder" },
+      ],
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "authoring_style" });
   }
-  return AuthoringStyleSchema.parse(authoring);
-}
+  return yield* decodePromptValue(AuthoringStyleSchema, value);
+});
 
-function getPackageManagerHint(option: PackageManager, detected: PackageManager) {
+const packageManagerHint = (option: PackageManager, detected: PackageManager) => {
   const hints = {
     npm: "Node.js default",
     pnpm: "Fast, disk-efficient package manager",
@@ -130,83 +133,86 @@ function getPackageManagerHint(option: PackageManager, detected: PackageManager)
     deno: "Deno runtime (minimal PostgreSQL apps)",
   } satisfies Record<PackageManager, string>;
   return option === detected ? `Detected; ${hints[option]}` : hints[option];
-}
+};
 
-async function promptForPackageManager(
+const promptForPackageManager = Effect.fn("Prompts.packageManager")(function* (
   detected: PackageManager,
   output: Writable,
-): Promise<PackageManager> {
-  const packageManager = await select({
-    message: "Choose package manager",
-    initialValue: detected,
-    options: packageManagers.map((value) => ({
-      value,
-      label: value,
-      hint: getPackageManagerHint(value, detected),
-    })),
-    output,
-  });
-  if (isCancel(packageManager)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("package_manager");
+) {
+  const value = yield* Effect.tryPromise(() =>
+    select({
+      message: "Choose package manager",
+      initialValue: detected,
+      options: packageManagers.map((packageManager) => ({
+        value: packageManager,
+        label: packageManager,
+        hint: packageManagerHint(packageManager, detected),
+      })),
+      output,
+    }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "package_manager" });
   }
-  return PackageManagerSchema.parse(packageManager);
-}
+  return yield* decodePromptValue(PackageManagerSchema, value);
+});
 
-async function promptForDeployment(output: Writable): Promise<boolean> {
-  const shouldDeploy = await confirm({
-    message: "Deploy to Prisma now?",
-    initialValue: true,
-    output,
-  });
-  if (isCancel(shouldDeploy)) {
-    cancel("Operation cancelled.", { output });
-    throw new CreateCancellationError("deployment_intent");
+const promptForDeployment = Effect.fn("Prompts.deployment")(function* (output: Writable) {
+  const value = yield* Effect.tryPromise(() =>
+    confirm({ message: "Deploy to Prisma now?", initialValue: true, output }),
+  );
+  if (isCancel(value)) {
+    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
+    return yield* new CreateCancellationError({ stage: "deployment_intent" });
   }
-  return Boolean(shouldDeploy);
-}
+  return Boolean(value);
+});
 
-export async function collectPrismaSetupContext(
+export const collectPrismaSetupContextEffect = Effect.fn("PrismaSetup.collectContext")(function* (
   input: PrismaSetupCommandInput,
   options: { projectDir?: string; template?: CreateTemplate } = {},
-): Promise<PrismaSetupContext> {
+) {
   const projectDir = path.resolve(options.projectDir ?? process.cwd());
   const { json, output, useDefaults } = resolveExecutionSettings(input);
-
   const databaseProvider =
     input.provider ??
-    (useDefaults ? DEFAULT_DATABASE_PROVIDER : await promptForDatabaseProvider(output));
+    (useDefaults ? DEFAULT_DATABASE_PROVIDER : yield* promptForDatabaseProvider(output));
   const authoring =
-    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : await promptForAuthoringStyle(output));
-  const detectedPackageManager = await detectPackageManager(projectDir);
+    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : yield* promptForAuthoringStyle(output));
+  const detectedPackageManager = yield* detectPackageManagerEffect(projectDir);
   const packageManager =
     input.packageManager ??
     (useDefaults
       ? detectedPackageManager
-      : await promptForPackageManager(detectedPackageManager, output));
+      : yield* promptForPackageManager(detectedPackageManager, output));
+
   if (packageManager === "deno" && databaseProvider !== "postgres") {
-    throw new ClassifiedCreateError(
-      "unsupported_configuration",
-      "Deno support currently requires PostgreSQL.",
-    );
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Deno support currently requires PostgreSQL.",
+    });
   }
   if (packageManager === "deno" && options.template && options.template !== "minimal") {
-    throw new ClassifiedCreateError(
-      "unsupported_configuration",
-      "Deno support currently requires the minimal template.",
-    );
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Deno support currently requires the minimal template.",
+    });
   }
   if (packageManager === "deno" && input.deploy === true) {
-    throw new ClassifiedCreateError(
-      "unsupported_configuration",
-      "Prisma Compute does not support Deno deployments yet. Use --no-deploy.",
-    );
+    return yield* new CreateFailure({
+      stage: "collect_context",
+      reason: "unsupported_configuration",
+      message: "Prisma Compute does not support Deno deployments yet. Use --no-deploy.",
+    });
   }
 
   const shouldDeploy =
     packageManager === "deno"
       ? false
-      : (input.deploy ?? (json ? true : useDefaults ? false : await promptForDeployment(output)));
+      : (input.deploy ?? (json ? true : useDefaults ? false : yield* promptForDeployment(output)));
   return {
     projectDir,
     verbose: input.verbose === true,
@@ -218,25 +224,45 @@ export async function collectPrismaSetupContext(
     shouldDeploy,
     shouldPromptForWorkspace: !useDefaults,
     ...(input.workspace ? { workspace: input.workspace } : {}),
-  };
-}
+  } satisfies PrismaSetupContext;
+});
 
-function getContractPath(authoring: AuthoringStyle) {
-  return `src/prisma/contract${authoring === "typescript" ? ".ts" : ".prisma"}`;
-}
+const getContractPath = (authoring: AuthoringStyle) =>
+  `src/prisma/contract${authoring === "typescript" ? ".ts" : ".prisma"}`;
+const getInitTarget = (provider: DatabaseProvider) =>
+  provider === "mongo" ? ("mongodb" as const) : ("postgres" as const);
+const getPrismaCliInvocation = (packageManager: PackageManager, args: string[]) =>
+  getPackageExecutionArgs(packageManager, [
+    packageManager === "deno" ? PRISMA_DENO_CLI_PACKAGE : PRISMA_PLATFORM_CLI_PACKAGE,
+    ...args,
+  ]);
 
-function getInitTarget(provider: DatabaseProvider): "postgres" | "mongodb" {
-  return provider === "mongo" ? "mongodb" : "postgres";
-}
+const runPrismaCli = Effect.fn("PrismaSetup.runCli")(function* (
+  context: PrismaSetupContext,
+  projectDir: string,
+  args: string[],
+) {
+  const invocation = getPrismaCliInvocation(context.packageManager, args);
+  yield* Effect.sync(() => {
+    if (context.verbose) {
+      log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
+    }
+  });
+  yield* runSetupCommand({
+    command: invocation.command,
+    args: invocation.args,
+    cwd: projectDir,
+    env: { ...process.env, CI: "1" },
+    verbose: context.verbose,
+    json: context.json,
+  });
+});
 
-function getPrismaCliInvocation(packageManager: PackageManager, args: string[]) {
-  const packageName =
-    packageManager === "deno" ? PRISMA_DENO_CLI_PACKAGE : PRISMA_PLATFORM_CLI_PACKAGE;
-  return getPackageExecutionArgs(packageManager, [packageName, ...args]);
-}
-
-async function runPrismaInit(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  const args = [
+const runPrismaInit = Effect.fn("PrismaSetup.init")(function* (
+  context: PrismaSetupContext,
+  projectDir: string,
+) {
+  yield* runPrismaCli(context, projectDir, [
     "orm",
     "init",
     "--yes",
@@ -248,149 +274,83 @@ async function runPrismaInit(context: PrismaSetupContext, projectDir: string): P
     "--schema-path",
     getContractPath(context.authoring),
     "--skip-install",
-  ];
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
-  if (context.verbose) {
-    log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`, {
-      output: context.output,
-    });
+  ]);
+  if (context.packageManager === "deno") {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(path.join(projectDir, "prisma-next.md"), { force: true });
   }
-  await runSetupCommand({
-    command: invocation.command,
-    args: invocation.args,
-    cwd: projectDir,
-    env: { ...process.env, CI: "1" },
-    verbose: context.verbose,
-    json: context.json,
-  });
-  if (context.packageManager === "deno") await fs.remove(path.join(projectDir, "prisma-next.md"));
-}
+});
 
-async function initializeAgentSkills(
+const initializeAgentSkills = Effect.fn("PrismaSetup.initializeSkills")(function* (
   context: PrismaSetupContext,
   projectDir: string,
-): Promise<void> {
+) {
   if (context.packageManager === "deno") return;
+  yield* runPrismaCli(context, projectDir, ["init", "--yes", "--no-interactive"]);
+});
 
-  const invocation = getPrismaCliInvocation(context.packageManager, [
-    "init",
-    "--yes",
-    "--no-interactive",
-  ]);
-  if (context.verbose) {
-    log.step(`Running ${[invocation.command, ...invocation.args].join(" ")}`, {
-      output: context.output,
-    });
-  }
-  await runSetupCommand({
-    command: invocation.command,
-    args: invocation.args,
-    cwd: projectDir,
-    env: { ...process.env, CI: "1" },
-    verbose: context.verbose,
-    json: context.json,
-  });
-}
-
-async function ensureGitignoreEntry(projectDir: string, entry: string): Promise<void> {
+const ensureGitignoreEntry = Effect.fn("PrismaSetup.ensureGitignoreEntry")(function* (
+  projectDir: string,
+  entry: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const gitignorePath = path.join(projectDir, ".gitignore");
-  const existing = (await fs.pathExists(gitignorePath))
-    ? await fs.readFile(gitignorePath, "utf8")
-    : "";
-  const lines = existing.split(/\r?\n/).map((line) => line.trim());
-  if (lines.includes(entry) || lines.includes(`/${entry}`)) return;
+  const existing = (yield* fs.exists(gitignorePath)) ? yield* fs.readFileString(gitignorePath) : "";
+  const entries = existing.split(/\r?\n/).map((line) => line.trim());
+  if (entries.includes(entry) || entries.includes(`/${entry}`)) return;
   const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-  await fs.writeFile(gitignorePath, `${existing}${separator}${entry}\n`, "utf8");
-}
+  yield* fs.writeFileString(gitignorePath, `${existing}${separator}${entry}\n`);
+});
 
-async function ensureMongoEnvironment(projectDir: string): Promise<void> {
+const ensureMongoEnvironment = Effect.fn("PrismaSetup.ensureMongoEnvironment")(function* (
+  projectDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const envPath = path.join(projectDir, ".env");
-  if (!(await fs.pathExists(envPath))) {
-    await fs.writeFile(
+  if (!(yield* fs.exists(envPath))) {
+    yield* fs.writeFileString(
       envPath,
       'DATABASE_URL="mongodb://localhost:27017/mydb?replicaSet=rs0&directConnection=true"\n',
-      "utf8",
     );
   }
-  await ensureGitignoreEntry(projectDir, ".env");
-}
+  yield* ensureGitignoreEntry(projectDir, ".env");
+});
 
-async function ensureComposerTypeScriptOptions(projectDir: string): Promise<void> {
-  const tsconfigPath = path.join(projectDir, "tsconfig.json");
-  const tsconfig = await fs.readFile(tsconfigPath, "utf8");
-  const additions: string[] = [];
-  if (!/"allowImportingTsExtensions"\s*:/.test(tsconfig)) {
-    additions.push('    "allowImportingTsExtensions": true,');
-  }
-  if (!/"noEmit"\s*:/.test(tsconfig)) {
-    additions.push('    "noEmit": true,');
-  }
-  if (additions.length === 0) return;
+const ensureComposerTypeScriptOptions = Effect.fn("PrismaSetup.ensureComposerTypeScriptOptions")(
+  function* (projectDir: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const tsconfigPath = path.join(projectDir, "tsconfig.json");
+    const tsconfig = yield* fs.readFileString(tsconfigPath);
+    const additions: string[] = [];
+    if (!/"allowImportingTsExtensions"\s*:/.test(tsconfig)) {
+      additions.push('    "allowImportingTsExtensions": true,');
+    }
+    if (!/"noEmit"\s*:/.test(tsconfig)) additions.push('    "noEmit": true,');
+    if (additions.length === 0) return;
 
-  const updated = tsconfig.replace(
-    /"compilerOptions"\s*:\s*\{/,
-    (match) => `${match}\n${additions.join("\n")}`,
-  );
-  if (updated === tsconfig) {
-    throw new Error("tsconfig.json is missing compilerOptions.");
-  }
-  await fs.writeFile(tsconfigPath, updated, "utf8");
-}
+    const updated = tsconfig.replace(
+      /"compilerOptions"\s*:\s*\{/,
+      (match) => `${match}\n${additions.join("\n")}`,
+    );
+    if (updated === tsconfig)
+      return yield* Effect.fail(new Error("tsconfig.json is missing compilerOptions."));
+    yield* fs.writeFileString(tsconfigPath, updated);
+  },
+);
 
-async function runPrismaCli(
-  context: PrismaSetupContext,
-  projectDir: string,
-  args: string[],
-): Promise<void> {
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
-  if (context.verbose) {
-    log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
-  }
-  await runSetupCommand({
-    command: invocation.command,
-    args: invocation.args,
-    cwd: projectDir,
-    env: { ...process.env, CI: "1" },
-    verbose: context.verbose,
-    json: context.json,
-  });
-}
-
-async function emitContract(context: PrismaSetupContext, projectDir: string): Promise<void> {
-  await runPrismaCli(context, projectDir, ["contract", "emit"]);
-}
-
-// Composer deploys are replay-only: they apply committed migrations and never
-// create schema, so the scaffold authors the baseline itself.
-async function planBaselineMigration(
-  context: PrismaSetupContext,
-  projectDir: string,
-): Promise<void> {
-  await runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]);
-}
-
-function formatNextSteps(steps: CreateNextStep[]): string {
-  return steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
-}
-
-function formatPlatformTarget(name: string | null, id: string): string {
-  return name ? `${name} (${id})` : id;
-}
+const formatNextSteps = (steps: CreateNextStep[]) =>
+  steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
+const formatPlatformTarget = (name: string | null, id: string) => (name ? `${name} (${id})` : id);
 
 function formatProjectSummary(options: {
   createdProjectPath?: string;
   deployment?: ComposerDeployResult;
 }): string {
   const lines: string[] = [];
-  if (options.createdProjectPath) {
-    lines.push(`Path: ${path.resolve(options.createdProjectPath)}`);
-  }
+  if (options.createdProjectPath) lines.push(`Path: ${path.resolve(options.createdProjectPath)}`);
   if (options.deployment?.workspace) {
     lines.push(
-      `Workspace: ${formatPlatformTarget(
-        options.deployment.workspace.name,
-        options.deployment.workspace.id,
-      )}`,
+      `Workspace: ${formatPlatformTarget(options.deployment.workspace.name, options.deployment.workspace.id)}`,
     );
   }
   if (options.deployment) {
@@ -432,20 +392,32 @@ function buildNextSteps(
           : "Build and start the app with Prisma Composer locally.",
     });
   }
-  if (context.packageManager === "deno") {
-    return nextSteps;
+  if (context.packageManager !== "deno") {
+    nextSteps.push({
+      command: getRunScriptCommand(context.packageManager, "deploy"),
+      description: "Build and deploy the app with Prisma Composer.",
+    });
   }
-  nextSteps.push({
-    command: getRunScriptCommand(context.packageManager, "deploy"),
-    description: "Build and deploy the app with Prisma Composer.",
-  });
   return nextSteps;
 }
 
-export async function executePrismaSetupContext(
+const atStage = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  stage: CreateFailureStage,
+  reason: CreateFailureReason,
+) =>
+  effect.pipe(
+    Effect.mapError((error) =>
+      error instanceof CreateFailure || error instanceof CreateCancellationError
+        ? error
+        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
+    ),
+  );
+
+export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(function* (
   context: PrismaSetupContext,
   options: PrismaSetupRunOptions = {},
-): Promise<PrismaSetupExecutionResult> {
+) {
   const projectDir = path.resolve(options.projectDir ?? context.projectDir);
   const projectName = options.projectName ?? path.basename(projectDir);
   const template = options.template ?? "minimal";
@@ -454,147 +426,173 @@ export async function executePrismaSetupContext(
     : (options.progressSpinner ?? spinner({ output: context.output }));
   const ownsProgress = progress !== undefined && !options.progressSpinner;
   let gitInitialization: GitInitializationResult | undefined;
-  let setupStage: CreateFailureStage = "initialize_prisma";
-  let setupReason: CreateFailureReason = "prisma_init_failed";
-  if (ownsProgress) progress.start("Creating Prisma 8 project...");
+  if (ownsProgress) yield* Effect.sync(() => progress.start("Creating Prisma 8 project..."));
 
-  try {
-    progress?.message("Preparing Prisma 8 project files...");
-    await runPrismaInit(context, projectDir);
+  const setup = Effect.gen(function* () {
+    yield* Effect.sync(() => progress?.message("Preparing Prisma 8 project files..."));
+    yield* atStage(runPrismaInit(context, projectDir), "initialize_prisma", "prisma_init_failed");
 
-    setupStage = "configure_project";
-    setupReason = "project_configuration_failed";
-    await scaffoldCreateSharedTemplates({
-      projectDir,
-      projectName,
-      template,
-      provider: context.databaseProvider,
-      authoring: context.authoring,
-      packageManager: context.packageManager,
-    });
-    await writePrismaDependencies(
-      context.databaseProvider,
-      context.packageManager,
-      context.authoring,
-      projectDir,
+    yield* atStage(
+      Effect.gen(function* () {
+        yield* scaffoldCreateSharedTemplatesEffect({
+          projectDir,
+          projectName,
+          template,
+          provider: context.databaseProvider,
+          authoring: context.authoring,
+          packageManager: context.packageManager,
+        });
+        yield* writePrismaDependenciesEffect(
+          context.databaseProvider,
+          context.packageManager,
+          context.authoring,
+          projectDir,
+        );
+        yield* ensureComposerTypeScriptOptions(projectDir);
+        if (context.databaseProvider === "mongo") yield* ensureMongoEnvironment(projectDir);
+        if (context.packageManager !== "deno") {
+          yield* ensureGitignoreEntry(projectDir, "/.alchemy");
+          yield* ensureGitignoreEntry(projectDir, "/.prisma-composer");
+        }
+      }),
+      "configure_project",
+      "project_configuration_failed",
     );
-    await ensureComposerTypeScriptOptions(projectDir);
-    if (context.databaseProvider === "mongo") await ensureMongoEnvironment(projectDir);
-    if (context.packageManager !== "deno") {
-      await ensureGitignoreEntry(projectDir, "/.alchemy");
-      await ensureGitignoreEntry(projectDir, "/.prisma-composer");
-    }
 
-    progress?.message(
-      `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
+    yield* Effect.sync(() =>
+      progress?.message(
+        `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
+      ),
     );
-    setupStage = "install_dependencies";
-    setupReason = "dependency_install_failed";
-    await installProjectDependencies(context.packageManager, projectDir, {
-      verbose: context.verbose,
-      json: context.json,
-    });
+    yield* atStage(
+      installProjectDependenciesEffect(context.packageManager, projectDir, {
+        verbose: context.verbose,
+        json: context.json,
+      }),
+      "install_dependencies",
+      "dependency_install_failed",
+    );
 
-    progress?.message("Installing Prisma agent skills...");
-    setupStage = "initialize_agent_skills";
-    setupReason = "agent_skills_init_failed";
-    await initializeAgentSkills(context, projectDir);
+    yield* Effect.sync(() => progress?.message("Installing Prisma agent skills..."));
+    yield* atStage(
+      initializeAgentSkills(context, projectDir),
+      "initialize_agent_skills",
+      "agent_skills_init_failed",
+    );
 
-    progress?.message("Generating Prisma 8 contract artifacts...");
-    setupStage = "emit_contract";
-    setupReason = "contract_emit_failed";
-    await emitContract(context, projectDir);
+    yield* Effect.sync(() => progress?.message("Generating Prisma 8 contract artifacts..."));
+    yield* atStage(
+      runPrismaCli(context, projectDir, ["contract", "emit"]),
+      "emit_contract",
+      "contract_emit_failed",
+    );
 
     if (context.databaseProvider === "postgres") {
-      progress?.message("Authoring the baseline migration...");
-      setupStage = "plan_migration";
-      setupReason = "migration_plan_failed";
-      await planBaselineMigration(context, projectDir);
+      yield* Effect.sync(() => progress?.message("Authoring the baseline migration..."));
+      yield* atStage(
+        runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]),
+        "plan_migration",
+        "migration_plan_failed",
+      );
     }
 
     if (options.initializeGit) {
-      progress?.message("Initializing Git repository...");
-      setupStage = "initialize_git";
-      setupReason = "git_initialization_failed";
-      gitInitialization = await initializeGitRepository(projectDir);
+      yield* Effect.sync(() => progress?.message("Initializing Git repository..."));
+      gitInitialization = yield* atStage(
+        initializeGitRepositoryEffect(projectDir),
+        "initialize_git",
+        "git_initialization_failed",
+      );
     }
-    progress?.stop("Prisma 8 project ready.");
-    if (gitInitialization?.status === "initialized" && context.verbose) {
-      log.success("Initialized Git repository with an initial commit.", { output: context.output });
-    } else if (gitInitialization?.status === "skipped") {
-      log.warn(`Could not initialize Git repository: ${gitInitialization.reason}`, {
-        output: context.output,
-      });
-    }
-  } catch (error) {
-    progress?.error("Could not create Prisma 8 project.");
-    cancel(getErrorMessage(error), { output: context.output });
-    return {
-      ok: false,
-      stage: setupStage,
-      reason: getCreateFailureReason(error, setupReason),
-      error,
-      errorReported: true,
-    };
-  }
+  });
 
-  let deployment: ComposerDeployResult | undefined;
-  if (context.shouldDeploy) {
-    const deploymentResult = await deployNewProjectWithComposer({
-      appName: projectName,
-      packageManager: context.packageManager,
-      projectDir,
-      shouldPromptForWorkspace: context.shouldPromptForWorkspace,
-      verbose: context.verbose,
-      output: context.output,
-      allowInteractiveLogin: !context.json,
-      json: context.json,
-      ...(context.workspace ? { workspace: context.workspace } : {}),
-    });
-    if (!deploymentResult.ok) {
-      if (deploymentResult.cancelled) {
-        return {
-          ok: false,
-          cancelled: true,
-          stage: deploymentResult.stage,
-          errorReported: true,
-        };
-      }
-      return {
-        ok: false,
-        stage: deploymentResult.stage,
-        reason: deploymentResult.reason,
-        error: deploymentResult.error,
-        errorReported: true,
-      };
-    }
-    deployment = deploymentResult.deployment;
-  }
+  yield* setup.pipe(
+    Effect.tap(() =>
+      Effect.sync(() => {
+        progress?.stop("Prisma 8 project ready.");
+        if (gitInitialization?.status === "initialized" && context.verbose) {
+          log.success("Initialized Git repository with an initial commit.", {
+            output: context.output,
+          });
+        } else if (gitInitialization?.status === "skipped") {
+          log.warn(`Could not initialize Git repository: ${gitInitialization.reason}`, {
+            output: context.output,
+          });
+        }
+      }),
+    ),
+    Effect.tapError((error) =>
+      Effect.sync(() => {
+        progress?.error("Could not create Prisma 8 project.");
+        if (!(error instanceof CreateCancellationError))
+          cancel(getErrorMessage(error), { output: context.output });
+      }),
+    ),
+    Effect.mapError((error) =>
+      error instanceof CreateFailure
+        ? new CreateFailure({
+            stage: error.stage,
+            reason: error.reason,
+            message: error.message,
+            cause: error.cause,
+            errorReported: true,
+          })
+        : error,
+    ),
+  );
+
+  const deployment = context.shouldDeploy
+    ? yield* deployNewProjectWithComposerEffect({
+        appName: projectName,
+        packageManager: context.packageManager,
+        projectDir,
+        shouldPromptForWorkspace: context.shouldPromptForWorkspace,
+        verbose: context.verbose,
+        output: context.output,
+        allowInteractiveLogin: !context.json,
+        json: context.json,
+        ...(context.workspace ? { workspace: context.workspace } : {}),
+      })
+    : null;
 
   const nextSteps = buildNextSteps(context, options);
   const warnings =
     gitInitialization?.status === "skipped"
       ? [`Could not initialize Git repository: ${gitInitialization.reason}`]
       : [];
-
   const projectSummary = formatProjectSummary({
     createdProjectPath: options.createdProjectPath,
-    deployment,
+    ...(deployment ? { deployment } : {}),
   });
-  if (projectSummary) {
-    note(projectSummary, context.shouldDeploy ? "Deployment" : "Project", {
+  yield* Effect.sync(() => {
+    if (projectSummary) {
+      note(projectSummary, context.shouldDeploy ? "Deployment" : "Project", {
+        output: context.output,
+      });
+    }
+    note(formatNextSteps(nextSteps), "Next steps", { output: context.output });
+    outro(context.shouldDeploy ? "Prisma 8 app deployed." : "Prisma 8 project ready.", {
       output: context.output,
     });
-  }
-  note(formatNextSteps(nextSteps), "Next steps", { output: context.output });
-  outro(context.shouldDeploy ? "Prisma 8 app deployed." : "Prisma 8 project ready.", {
-    output: context.output,
   });
   return {
-    ok: true,
-    deployment: deployment ?? null,
+    deployment,
     nextSteps,
     ...(gitInitialization ? { gitInitialization } : {}),
     warnings,
-  };
+  } satisfies PrismaSetupSuccess;
+});
+
+export function collectPrismaSetupContext(
+  input: PrismaSetupCommandInput,
+  options: { projectDir?: string; template?: CreateTemplate } = {},
+): Promise<PrismaSetupContext> {
+  return applicationRuntime.runPromise(collectPrismaSetupContextEffect(input, options));
+}
+
+export function executePrismaSetupContext(
+  context: PrismaSetupContext,
+  options: PrismaSetupRunOptions = {},
+): Promise<PrismaSetupSuccess> {
+  return applicationRuntime.runPromise(executePrismaSetupContextEffect(context, options));
 }

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -3,7 +3,6 @@ import { Effect, FileSystem, Schema } from "effect";
 import path from "node:path";
 import type { Writable } from "node:stream";
 
-import { PRISMA_DENO_CLI_PACKAGE, PRISMA_PLATFORM_CLI_PACKAGE } from "../constants/dependencies";
 import {
   CreateCancellationError,
   CreateFailure,
@@ -29,7 +28,7 @@ import { getErrorMessage } from "../utils/errors";
 import {
   detectPackageManagerEffect,
   getInstallCommand,
-  getPackageExecutionArgs,
+  getLocalPackageBinaryArgs,
   getRunScriptCommand,
 } from "../utils/package-manager";
 import { runSetupCommand } from "../utils/run-command";
@@ -232,10 +231,7 @@ const getContractPath = (authoring: AuthoringStyle) =>
 const getInitTarget = (provider: DatabaseProvider) =>
   provider === "mongo" ? ("mongodb" as const) : ("postgres" as const);
 const getPrismaCliInvocation = (packageManager: PackageManager, args: string[]) =>
-  getPackageExecutionArgs(packageManager, [
-    packageManager === "deno" ? PRISMA_DENO_CLI_PACKAGE : PRISMA_PLATFORM_CLI_PACKAGE,
-    ...args,
-  ]);
+  getLocalPackageBinaryArgs(packageManager, "prisma", args);
 
 const runPrismaCli = Effect.fn("PrismaSetup.runCli")(function* (
   context: PrismaSetupContext,
@@ -429,32 +425,13 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
   if (ownsProgress) yield* Effect.sync(() => progress.start("Creating Prisma 8 project..."));
 
   const setup = Effect.gen(function* () {
-    yield* Effect.sync(() => progress?.message("Preparing Prisma 8 project files..."));
-    yield* atStage(runPrismaInit(context, projectDir), "initialize_prisma", "prisma_init_failed");
-
     yield* atStage(
-      Effect.gen(function* () {
-        yield* scaffoldCreateSharedTemplatesEffect({
-          projectDir,
-          projectName,
-          template,
-          provider: context.databaseProvider,
-          authoring: context.authoring,
-          packageManager: context.packageManager,
-        });
-        yield* writePrismaDependenciesEffect(
-          context.databaseProvider,
-          context.packageManager,
-          context.authoring,
-          projectDir,
-        );
-        yield* ensureComposerTypeScriptOptions(projectDir);
-        if (context.databaseProvider === "mongo") yield* ensureMongoEnvironment(projectDir);
-        if (context.packageManager !== "deno") {
-          yield* ensureGitignoreEntry(projectDir, "/.alchemy");
-          yield* ensureGitignoreEntry(projectDir, "/.prisma-composer");
-        }
-      }),
+      writePrismaDependenciesEffect(
+        context.databaseProvider,
+        context.packageManager,
+        context.authoring,
+        projectDir,
+      ),
       "configure_project",
       "project_configuration_failed",
     );
@@ -471,6 +448,30 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
       }),
       "install_dependencies",
       "dependency_install_failed",
+    );
+
+    yield* Effect.sync(() => progress?.message("Preparing Prisma 8 project files..."));
+    yield* atStage(runPrismaInit(context, projectDir), "initialize_prisma", "prisma_init_failed");
+
+    yield* atStage(
+      Effect.gen(function* () {
+        yield* scaffoldCreateSharedTemplatesEffect({
+          projectDir,
+          projectName,
+          template,
+          provider: context.databaseProvider,
+          authoring: context.authoring,
+          packageManager: context.packageManager,
+        });
+        yield* ensureComposerTypeScriptOptions(projectDir);
+        if (context.databaseProvider === "mongo") yield* ensureMongoEnvironment(projectDir);
+        if (context.packageManager !== "deno") {
+          yield* ensureGitignoreEntry(projectDir, "/.alchemy");
+          yield* ensureGitignoreEntry(projectDir, "/.prisma-composer");
+        }
+      }),
+      "configure_project",
+      "project_configuration_failed",
     );
 
     yield* Effect.sync(() => progress?.message("Installing Prisma agent skills..."));

--- a/src/tasks/setup-prisma.ts
+++ b/src/tasks/setup-prisma.ts
@@ -1,414 +1,30 @@
-import { cancel, confirm, isCancel, log, note, outro, select, spinner } from "@clack/prompts";
-import { Effect, FileSystem, Schema } from "effect";
+import { cancel, log, note, outro, spinner } from "@clack/prompts";
+import { Effect } from "effect";
 import path from "node:path";
-import type { Writable } from "node:stream";
 
-import {
-  CreateCancellationError,
-  CreateFailure,
-  type CreateFailureReason,
-  type CreateFailureStage,
-} from "../create-outcome";
-import type { ComposerDeployResult, CreateNextStep } from "../result";
+import { CreateCancellationError, CreateFailure } from "../create-outcome";
 import { applicationRuntime } from "../runtime";
 import { scaffoldCreateSharedTemplatesEffect } from "../templates/render-create-template";
-import {
-  AuthoringStyleSchema,
-  DatabaseProviderSchema,
-  PackageManagerSchema,
-  packageManagers,
-  type AuthoringStyle,
-  type CreateTemplate,
-  type DatabaseProvider,
-  type PackageManager,
-  type PrismaSetupCommandInput,
-} from "../types";
-import { resolveExecutionSettings } from "../ui/output";
+import type { CreateTemplate, PrismaSetupCommandInput } from "../types";
 import { getErrorMessage } from "../utils/errors";
-import {
-  detectPackageManagerEffect,
-  getInstallCommand,
-  getLocalPackageBinaryArgs,
-  getRunScriptCommand,
-} from "../utils/package-manager";
-import { runSetupCommand } from "../utils/run-command";
+import { getInstallCommand } from "../utils/package-manager";
+import { atCreateStage } from "../workflow/failure";
 import { deployNewProjectWithComposerEffect } from "./deploy-with-composer";
 import { initializeGitRepositoryEffect, type GitInitializationResult } from "./initialize-git";
 import { installProjectDependenciesEffect, writePrismaDependenciesEffect } from "./install";
-
-const DEFAULT_DATABASE_PROVIDER: DatabaseProvider = "postgres";
-const DEFAULT_AUTHORING: AuthoringStyle = "psl";
-
-type PrismaSetupRunOptions = {
-  prependNextSteps?: CreateNextStep[];
-  projectDir?: string;
-  projectName?: string;
-  template?: CreateTemplate;
-  createdProjectPath?: string;
-  includeDevNextStep?: boolean;
-  initializeGit?: boolean;
-  progressSpinner?: ReturnType<typeof spinner>;
-};
-
-export type PrismaSetupContext = {
-  projectDir: string;
-  verbose: boolean;
-  json: boolean;
-  output: Writable;
-  databaseProvider: DatabaseProvider;
-  authoring: AuthoringStyle;
-  packageManager: PackageManager;
-  shouldDeploy: boolean;
-  shouldPromptForWorkspace: boolean;
-  workspace?: string;
-};
-
-export type PrismaSetupSuccess = {
-  deployment: ComposerDeployResult | null;
-  nextSteps: CreateNextStep[];
-  gitInitialization?: GitInitializationResult;
-  warnings: string[];
-};
-
-const decodePromptValue = <A>(schema: Schema.Codec<A>, value: unknown) =>
-  Schema.decodeUnknownEffect(schema)(value).pipe(
-    Effect.mapError(
-      (cause) =>
-        new CreateFailure({
-          stage: "collect_context",
-          reason: "invalid_input",
-          message: cause.message,
-          cause,
-        }),
-    ),
-  );
-
-const promptForDatabaseProvider = Effect.fn("Prompts.databaseProvider")(function* (
-  output: Writable,
-) {
-  const value = yield* Effect.tryPromise(() =>
-    select({
-      message: "Select your database",
-      initialValue: DEFAULT_DATABASE_PROVIDER,
-      options: [
-        { value: "postgres", label: "PostgreSQL", hint: "Prisma Postgres with Composer" },
-        { value: "mongo", label: "MongoDB", hint: "Connect an existing MongoDB database" },
-      ],
-      output,
-    }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "database_provider" });
-  }
-  return yield* decodePromptValue(DatabaseProviderSchema, value);
-});
-
-const promptForAuthoringStyle = Effect.fn("Prompts.authoringStyle")(function* (output: Writable) {
-  const value = yield* Effect.tryPromise(() =>
-    select({
-      message: "Choose contract authoring style",
-      initialValue: DEFAULT_AUTHORING,
-      options: [
-        { value: "psl", label: "PSL", hint: "Prisma schema syntax" },
-        { value: "typescript", label: "TypeScript", hint: "TypeScript contract builder" },
-      ],
-      output,
-    }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "authoring_style" });
-  }
-  return yield* decodePromptValue(AuthoringStyleSchema, value);
-});
-
-const packageManagerHint = (option: PackageManager, detected: PackageManager) => {
-  const hints = {
-    npm: "Node.js default",
-    pnpm: "Fast, disk-efficient package manager",
-    yarn: "Yarn package manager",
-    bun: "Fast runtime and package manager",
-    deno: "Deno runtime (minimal PostgreSQL apps)",
-  } satisfies Record<PackageManager, string>;
-  return option === detected ? `Detected; ${hints[option]}` : hints[option];
-};
-
-const promptForPackageManager = Effect.fn("Prompts.packageManager")(function* (
-  detected: PackageManager,
-  output: Writable,
-) {
-  const value = yield* Effect.tryPromise(() =>
-    select({
-      message: "Choose package manager",
-      initialValue: detected,
-      options: packageManagers.map((packageManager) => ({
-        value: packageManager,
-        label: packageManager,
-        hint: packageManagerHint(packageManager, detected),
-      })),
-      output,
-    }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "package_manager" });
-  }
-  return yield* decodePromptValue(PackageManagerSchema, value);
-});
-
-const promptForDeployment = Effect.fn("Prompts.deployment")(function* (output: Writable) {
-  const value = yield* Effect.tryPromise(() =>
-    confirm({ message: "Deploy to Prisma now?", initialValue: true, output }),
-  );
-  if (isCancel(value)) {
-    yield* Effect.sync(() => cancel("Operation cancelled.", { output }));
-    return yield* new CreateCancellationError({ stage: "deployment_intent" });
-  }
-  return Boolean(value);
-});
-
-export const collectPrismaSetupContextEffect = Effect.fn("PrismaSetup.collectContext")(function* (
-  input: PrismaSetupCommandInput,
-  options: { projectDir?: string; template?: CreateTemplate } = {},
-) {
-  const projectDir = path.resolve(options.projectDir ?? process.cwd());
-  const { json, output, useDefaults } = resolveExecutionSettings(input);
-  const databaseProvider =
-    input.provider ??
-    (useDefaults ? DEFAULT_DATABASE_PROVIDER : yield* promptForDatabaseProvider(output));
-  const authoring =
-    input.authoring ?? (useDefaults ? DEFAULT_AUTHORING : yield* promptForAuthoringStyle(output));
-  const detectedPackageManager = yield* detectPackageManagerEffect(projectDir);
-  const packageManager =
-    input.packageManager ??
-    (useDefaults
-      ? detectedPackageManager
-      : yield* promptForPackageManager(detectedPackageManager, output));
-
-  if (packageManager === "deno" && databaseProvider !== "postgres") {
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "unsupported_configuration",
-      message: "Deno support currently requires PostgreSQL.",
-    });
-  }
-  if (packageManager === "deno" && options.template && options.template !== "minimal") {
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "unsupported_configuration",
-      message: "Deno support currently requires the minimal template.",
-    });
-  }
-  if (packageManager === "deno" && input.deploy === true) {
-    return yield* new CreateFailure({
-      stage: "collect_context",
-      reason: "unsupported_configuration",
-      message: "Prisma Compute does not support Deno deployments yet. Use --no-deploy.",
-    });
-  }
-
-  const shouldDeploy =
-    packageManager === "deno"
-      ? false
-      : (input.deploy ?? (json ? true : useDefaults ? false : yield* promptForDeployment(output)));
-  return {
-    projectDir,
-    verbose: input.verbose === true,
-    json,
-    output,
-    databaseProvider,
-    authoring,
-    packageManager,
-    shouldDeploy,
-    shouldPromptForWorkspace: !useDefaults,
-    ...(input.workspace ? { workspace: input.workspace } : {}),
-  } satisfies PrismaSetupContext;
-});
-
-const getContractPath = (authoring: AuthoringStyle) =>
-  `src/prisma/contract${authoring === "typescript" ? ".ts" : ".prisma"}`;
-const getInitTarget = (provider: DatabaseProvider) =>
-  provider === "mongo" ? ("mongodb" as const) : ("postgres" as const);
-const getPrismaCliInvocation = (packageManager: PackageManager, args: string[]) =>
-  getLocalPackageBinaryArgs(packageManager, "prisma", args);
-
-const runPrismaCli = Effect.fn("PrismaSetup.runCli")(function* (
-  context: PrismaSetupContext,
-  projectDir: string,
-  args: string[],
-) {
-  const invocation = getPrismaCliInvocation(context.packageManager, args);
-  yield* Effect.sync(() => {
-    if (context.verbose) {
-      log.step([invocation.command, ...invocation.args].join(" "), { output: context.output });
-    }
-  });
-  yield* runSetupCommand({
-    command: invocation.command,
-    args: invocation.args,
-    cwd: projectDir,
-    env: { ...process.env, CI: "1" },
-    verbose: context.verbose,
-    json: context.json,
-  });
-});
-
-const runPrismaInit = Effect.fn("PrismaSetup.init")(function* (
-  context: PrismaSetupContext,
-  projectDir: string,
-) {
-  yield* runPrismaCli(context, projectDir, [
-    "orm",
-    "init",
-    "--yes",
-    "--no-interactive",
-    "--target",
-    getInitTarget(context.databaseProvider),
-    "--authoring",
-    context.authoring,
-    "--schema-path",
-    getContractPath(context.authoring),
-    "--skip-install",
-  ]);
-  if (context.packageManager === "deno") {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(path.join(projectDir, "prisma-next.md"), { force: true });
-  }
-});
-
-const initializeAgentSkills = Effect.fn("PrismaSetup.initializeSkills")(function* (
-  context: PrismaSetupContext,
-  projectDir: string,
-) {
-  if (context.packageManager === "deno") return;
-  yield* runPrismaCli(context, projectDir, ["init", "--yes", "--no-interactive"]);
-});
-
-const ensureGitignoreEntry = Effect.fn("PrismaSetup.ensureGitignoreEntry")(function* (
-  projectDir: string,
-  entry: string,
-) {
-  const fs = yield* FileSystem.FileSystem;
-  const gitignorePath = path.join(projectDir, ".gitignore");
-  const existing = (yield* fs.exists(gitignorePath)) ? yield* fs.readFileString(gitignorePath) : "";
-  const entries = existing.split(/\r?\n/).map((line) => line.trim());
-  if (entries.includes(entry) || entries.includes(`/${entry}`)) return;
-  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-  yield* fs.writeFileString(gitignorePath, `${existing}${separator}${entry}\n`);
-});
-
-const ensureMongoEnvironment = Effect.fn("PrismaSetup.ensureMongoEnvironment")(function* (
-  projectDir: string,
-) {
-  const fs = yield* FileSystem.FileSystem;
-  const envPath = path.join(projectDir, ".env");
-  if (!(yield* fs.exists(envPath))) {
-    yield* fs.writeFileString(
-      envPath,
-      'DATABASE_URL="mongodb://localhost:27017/mydb?replicaSet=rs0&directConnection=true"\n',
-    );
-  }
-  yield* ensureGitignoreEntry(projectDir, ".env");
-});
-
-const ensureComposerTypeScriptOptions = Effect.fn("PrismaSetup.ensureComposerTypeScriptOptions")(
-  function* (projectDir: string) {
-    const fs = yield* FileSystem.FileSystem;
-    const tsconfigPath = path.join(projectDir, "tsconfig.json");
-    const tsconfig = yield* fs.readFileString(tsconfigPath);
-    const additions: string[] = [];
-    if (!/"allowImportingTsExtensions"\s*:/.test(tsconfig)) {
-      additions.push('    "allowImportingTsExtensions": true,');
-    }
-    if (!/"noEmit"\s*:/.test(tsconfig)) additions.push('    "noEmit": true,');
-    if (additions.length === 0) return;
-
-    const updated = tsconfig.replace(
-      /"compilerOptions"\s*:\s*\{/,
-      (match) => `${match}\n${additions.join("\n")}`,
-    );
-    if (updated === tsconfig)
-      return yield* Effect.fail(new Error("tsconfig.json is missing compilerOptions."));
-    yield* fs.writeFileString(tsconfigPath, updated);
-  },
-);
-
-const formatNextSteps = (steps: CreateNextStep[]) =>
-  steps.map((step) => `${step.command}\n  ${step.description}`).join("\n\n");
-const formatPlatformTarget = (name: string | null, id: string) => (name ? `${name} (${id})` : id);
-
-function formatProjectSummary(options: {
-  createdProjectPath?: string;
-  deployment?: ComposerDeployResult;
-}): string {
-  const lines: string[] = [];
-  if (options.createdProjectPath) lines.push(`Path: ${path.resolve(options.createdProjectPath)}`);
-  if (options.deployment?.workspace) {
-    lines.push(
-      `Workspace: ${formatPlatformTarget(options.deployment.workspace.name, options.deployment.workspace.id)}`,
-    );
-  }
-  if (options.deployment) {
-    lines.push(
-      `Project: ${
-        options.deployment.project.id
-          ? formatPlatformTarget(options.deployment.project.name, options.deployment.project.id)
-          : options.deployment.project.name
-      }`,
-    );
-    lines.push(`App: ${options.deployment.appUrl ?? options.deployment.appName}`);
-    if (options.deployment.project.consoleUrl) {
-      lines.push(`Console: ${options.deployment.project.consoleUrl}`);
-    }
-  }
-  return lines.join("\n");
-}
-
-function buildNextSteps(
-  context: PrismaSetupContext,
-  options: PrismaSetupRunOptions,
-): CreateNextStep[] {
-  const nextSteps = [...(options.prependNextSteps ?? [])];
-  if (context.databaseProvider === "mongo") {
-    nextSteps.push({
-      command: "Set MONGODB_URL in your environment",
-      description: "Composer uses this secret when deploying the MongoDB template.",
-    });
-  }
-  if (options.includeDevNextStep) {
-    nextSteps.push({
-      command: getRunScriptCommand(
-        context.packageManager,
-        context.packageManager === "deno" ? "dev" : "dev:composer",
-      ),
-      description:
-        context.packageManager === "deno"
-          ? "Start the Deno app after setting DATABASE_URL in .env."
-          : "Build and start the app with Prisma Composer locally.",
-    });
-  }
-  if (context.packageManager !== "deno") {
-    nextSteps.push({
-      command: getRunScriptCommand(context.packageManager, "deploy"),
-      description: "Build and deploy the app with Prisma Composer.",
-    });
-  }
-  return nextSteps;
-}
-
-const atStage = <A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  stage: CreateFailureStage,
-  reason: CreateFailureReason,
-) =>
-  effect.pipe(
-    Effect.mapError((error) =>
-      error instanceof CreateFailure || error instanceof CreateCancellationError
-        ? error
-        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
-    ),
-  );
+import { initializeAgentSkills, runPrismaCli, runPrismaInit } from "./prisma-setup/commands";
+import { collectPrismaSetupContextEffect } from "./prisma-setup/context";
+import {
+  ensureComposerTypeScriptOptions,
+  ensureGitignoreEntry,
+  ensureMongoEnvironment,
+} from "./prisma-setup/project-files";
+import { buildNextSteps, formatNextSteps, formatProjectSummary } from "./prisma-setup/presentation";
+import type {
+  PrismaSetupContext,
+  PrismaSetupRunOptions,
+  PrismaSetupSuccess,
+} from "./prisma-setup/types";
 
 export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(function* (
   context: PrismaSetupContext,
@@ -425,7 +41,7 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
   if (ownsProgress) yield* Effect.sync(() => progress.start("Creating Prisma 8 project..."));
 
   const setup = Effect.gen(function* () {
-    yield* atStage(
+    yield* atCreateStage(
       writePrismaDependenciesEffect(
         context.databaseProvider,
         context.packageManager,
@@ -441,7 +57,7 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
         `Installing dependencies with ${getInstallCommand(context.packageManager)}...`,
       ),
     );
-    yield* atStage(
+    yield* atCreateStage(
       installProjectDependenciesEffect(context.packageManager, projectDir, {
         verbose: context.verbose,
         json: context.json,
@@ -451,9 +67,13 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
     );
 
     yield* Effect.sync(() => progress?.message("Preparing Prisma 8 project files..."));
-    yield* atStage(runPrismaInit(context, projectDir), "initialize_prisma", "prisma_init_failed");
+    yield* atCreateStage(
+      runPrismaInit(context, projectDir),
+      "initialize_prisma",
+      "prisma_init_failed",
+    );
 
-    yield* atStage(
+    yield* atCreateStage(
       Effect.gen(function* () {
         yield* scaffoldCreateSharedTemplatesEffect({
           projectDir,
@@ -475,14 +95,14 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
     );
 
     yield* Effect.sync(() => progress?.message("Installing Prisma agent skills..."));
-    yield* atStage(
+    yield* atCreateStage(
       initializeAgentSkills(context, projectDir),
       "initialize_agent_skills",
       "agent_skills_init_failed",
     );
 
     yield* Effect.sync(() => progress?.message("Generating Prisma 8 contract artifacts..."));
-    yield* atStage(
+    yield* atCreateStage(
       runPrismaCli(context, projectDir, ["contract", "emit"]),
       "emit_contract",
       "contract_emit_failed",
@@ -490,7 +110,7 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
 
     if (context.databaseProvider === "postgres") {
       yield* Effect.sync(() => progress?.message("Authoring the baseline migration..."));
-      yield* atStage(
+      yield* atCreateStage(
         runPrismaCli(context, projectDir, ["migration", "plan", "--name", "init"]),
         "plan_migration",
         "migration_plan_failed",
@@ -499,7 +119,7 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
 
     if (options.initializeGit) {
       yield* Effect.sync(() => progress?.message("Initializing Git repository..."));
-      gitInitialization = yield* atStage(
+      gitInitialization = yield* atCreateStage(
         initializeGitRepositoryEffect(projectDir),
         "initialize_git",
         "git_initialization_failed",
@@ -525,8 +145,9 @@ export const executePrismaSetupContextEffect = Effect.fn("PrismaSetup.execute")(
     Effect.tapError((error) =>
       Effect.sync(() => {
         progress?.error("Could not create Prisma 8 project.");
-        if (!(error instanceof CreateCancellationError))
+        if (!(error instanceof CreateCancellationError)) {
           cancel(getErrorMessage(error), { output: context.output });
+        }
       }),
     ),
     Effect.mapError((error) =>
@@ -597,3 +218,10 @@ export function executePrismaSetupContext(
 ): Promise<PrismaSetupSuccess> {
   return applicationRuntime.runPromise(executePrismaSetupContextEffect(context, options));
 }
+
+export { collectPrismaSetupContextEffect } from "./prisma-setup/context";
+export type {
+  PrismaSetupContext,
+  PrismaSetupRunOptions,
+  PrismaSetupSuccess,
+} from "./prisma-setup/types";

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,39 +1,32 @@
-import fs from "fs-extra";
+import { Effect, FileSystem, Schema } from "effect";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { PostHog } from "posthog-node";
 
+import { applicationRuntime } from "../runtime";
+
 const TELEMETRY_API_KEY = process.env.CREATE_PRISMA_TELEMETRY_API_KEY ?? "";
 const TELEMETRY_HOST = process.env.CREATE_PRISMA_TELEMETRY_HOST || "https://us.i.posthog.com";
 const TELEMETRY_CONFIG_FILE = "telemetry.json";
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const AnonymousId = Schema.String.check(Schema.isUUID(4));
+const decodeAnonymousId = Schema.decodeUnknownExit(AnonymousId);
 
 type TelemetryValue = boolean | number | string | string[] | null | undefined;
 type TelemetryProperties = Record<string, TelemetryValue>;
 
-type TelemetryConfig = {
-  anonymousId: string;
-};
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return ["1", "true", "yes", "on"].includes(
+const isTruthyEnvValue = (value: string | undefined) =>
+  ["1", "true", "yes", "on"].includes(
     String(value ?? "")
       .trim()
       .toLowerCase(),
   );
-}
 
 function shouldDisableTelemetry(): boolean {
-  if (TELEMETRY_API_KEY.length === 0) {
-    return true;
-  }
-
-  if (isTruthyEnvValue(process.env.CI) || isTruthyEnvValue(process.env.GITHUB_ACTIONS)) {
-    return true;
-  }
-
   return (
+    TELEMETRY_API_KEY.length === 0 ||
+    isTruthyEnvValue(process.env.CI) ||
+    isTruthyEnvValue(process.env.GITHUB_ACTIONS) ||
     process.env.CREATE_PRISMA_DISABLE_TELEMETRY !== undefined ||
     process.env.CREATE_PRISMA_TELEMETRY_DISABLED !== undefined ||
     process.env.DO_NOT_TRACK !== undefined
@@ -44,104 +37,94 @@ function getTelemetryConfigDir(): string {
   if (process.platform === "darwin") {
     return path.join(os.homedir(), "Library", "Application Support", "create-prisma");
   }
-
   if (process.platform === "win32") {
     return path.join(
       process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming"),
       "create-prisma",
     );
   }
-
   return path.join(
     process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config"),
     "create-prisma",
   );
 }
 
-async function getAnonymousId(): Promise<string> {
-  const telemetryConfigPath = path.join(getTelemetryConfigDir(), TELEMETRY_CONFIG_FILE);
-
-  try {
-    const config = (await fs.readJSON(telemetryConfigPath)) as Partial<TelemetryConfig>;
-    if (typeof config.anonymousId === "string" && UUID_V4_REGEX.test(config.anonymousId)) {
-      return config.anonymousId;
-    }
-  } catch {
-    // Ignore missing or invalid config and fall back to generating a new ID.
-  }
+const getAnonymousIdEffect = Effect.fn("Telemetry.getAnonymousId")(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const configPath = path.join(getTelemetryConfigDir(), TELEMETRY_CONFIG_FILE);
+  const persisted = yield* fs.readFileString(configPath).pipe(
+    Effect.flatMap((source) =>
+      Effect.try({
+        try: () => JSON.parse(source) as { anonymousId?: unknown },
+        catch: () => ({ anonymousId: undefined }),
+      }),
+    ),
+    Effect.catch(() => Effect.succeed({ anonymousId: undefined })),
+  );
+  const decoded = decodeAnonymousId(persisted.anonymousId);
+  if (decoded._tag === "Success") return decoded.value;
 
   const anonymousId = randomUUID();
-
-  try {
-    await fs.ensureDir(path.dirname(telemetryConfigPath));
-    await fs.writeJSON(
-      telemetryConfigPath,
-      {
-        anonymousId,
-      } satisfies TelemetryConfig,
-      {
-        spaces: 2,
-      },
-    );
-  } catch {
-    // If the config file cannot be persisted, keep using the generated ID for this run.
-  }
-
+  yield* Effect.gen(function* () {
+    yield* fs.makeDirectory(path.dirname(configPath), { recursive: true });
+    yield* fs.writeFileString(configPath, `${JSON.stringify({ anonymousId }, null, 2)}\n`);
+  }).pipe(Effect.catch(() => Effect.void));
   return anonymousId;
-}
+});
 
-function getCommonProperties(): TelemetryProperties {
-  return {
-    "cli-version": process.env.CREATE_PRISMA_CLI_VERSION ?? "0.0.0",
-    "node-version": process.version,
-    platform: process.platform,
-    arch: process.arch,
-  };
-}
+const getCommonProperties = (): TelemetryProperties => ({
+  "cli-version": process.env.CREATE_PRISMA_CLI_VERSION ?? "0.0.0",
+  "node-version": process.version,
+  platform: process.platform,
+  arch: process.arch,
+});
 
-function sanitizeProperties(
-  properties: TelemetryProperties,
-): Record<string, Exclude<TelemetryValue, undefined>> {
-  return Object.fromEntries(
+const sanitizeProperties = (properties: TelemetryProperties) =>
+  Object.fromEntries(
     Object.entries(properties).filter(([, value]) => value !== undefined),
   ) as Record<string, Exclude<TelemetryValue, undefined>>;
-}
 
-export async function trackCliTelemetry(
+export const trackCliTelemetryEffect = Effect.fn("Telemetry.track")(function* (
   event: string,
   properties: TelemetryProperties,
-): Promise<void> {
-  if (shouldDisableTelemetry()) {
-    return;
-  }
-
-  let client: PostHog | undefined;
-  try {
-    const distinctId = await getAnonymousId();
-    const sanitizedProperties = sanitizeProperties({
-      ...getCommonProperties(),
-      ...properties,
-      $process_person_profile: false,
-    });
-
-    client = new PostHog(TELEMETRY_API_KEY, {
-      host: TELEMETRY_HOST,
-      disableGeoip: true,
-      flushAt: 1,
-      flushInterval: 0,
-    });
-
-    await client.captureImmediate({
+) {
+  if (shouldDisableTelemetry()) return;
+  const distinctId = yield* getAnonymousIdEffect();
+  const client = yield* Effect.acquireRelease(
+    Effect.sync(
+      () =>
+        new PostHog(TELEMETRY_API_KEY, {
+          host: TELEMETRY_HOST,
+          disableGeoip: true,
+          flushAt: 1,
+          flushInterval: 0,
+        }),
+    ),
+    (posthog) =>
+      Effect.tryPromise({
+        try: () => posthog.shutdown(),
+        catch: () => undefined,
+      }).pipe(Effect.catch(() => Effect.void)),
+  );
+  yield* Effect.tryPromise(() =>
+    client.captureImmediate({
       distinctId,
       event,
-      properties: sanitizedProperties,
+      properties: sanitizeProperties({
+        ...getCommonProperties(),
+        ...properties,
+        $process_person_profile: false,
+      }),
       disableGeoip: true,
-    });
-  } catch {
-    // Telemetry should never interfere with CLI execution.
-  } finally {
-    if (client) {
-      await client.shutdown().catch(() => {});
-    }
-  }
+    }),
+  );
+});
+
+export function trackCliTelemetry(event: string, properties: TelemetryProperties): Promise<void> {
+  return applicationRuntime.runPromise(
+    trackCliTelemetryEffect(event, properties).pipe(
+      Effect.scoped,
+      Effect.catch(() => Effect.void),
+    ),
+  );
 }

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -9,6 +9,7 @@ import { applicationRuntime } from "../runtime";
 const TELEMETRY_API_KEY = process.env.CREATE_PRISMA_TELEMETRY_API_KEY ?? "";
 const TELEMETRY_HOST = process.env.CREATE_PRISMA_TELEMETRY_HOST || "https://us.i.posthog.com";
 const TELEMETRY_CONFIG_FILE = "telemetry.json";
+export const TELEMETRY_TIMEOUT_MS = 2_000;
 const AnonymousId = Schema.String.check(Schema.isUUID(4));
 const decodeAnonymousId = Schema.decodeUnknownExit(AnonymousId);
 
@@ -84,6 +85,19 @@ const sanitizeProperties = (properties: TelemetryProperties) =>
     Object.entries(properties).filter(([, value]) => value !== undefined),
   ) as Record<string, Exclude<TelemetryValue, undefined>>;
 
+export const shutdownTelemetryClientEffect = (
+  client: Pick<PostHog, "shutdown">,
+  timeoutMs = TELEMETRY_TIMEOUT_MS,
+) =>
+  Effect.tryPromise({
+    try: () => Promise.resolve(client.shutdown(timeoutMs)),
+    catch: () => undefined,
+  }).pipe(
+    Effect.timeout(timeoutMs),
+    Effect.interruptible,
+    Effect.catch(() => Effect.void),
+  );
+
 export const trackCliTelemetryEffect = Effect.fn("Telemetry.track")(function* (
   event: string,
   properties: TelemetryProperties,
@@ -100,11 +114,7 @@ export const trackCliTelemetryEffect = Effect.fn("Telemetry.track")(function* (
           flushInterval: 0,
         }),
     ),
-    (posthog) =>
-      Effect.tryPromise({
-        try: () => posthog.shutdown(),
-        catch: () => undefined,
-      }).pipe(Effect.catch(() => Effect.void)),
+    (posthog) => shutdownTelemetryClientEffect(posthog),
   );
   yield* Effect.tryPromise(() =>
     client.captureImmediate({
@@ -124,7 +134,7 @@ export function trackCliTelemetry(event: string, properties: TelemetryProperties
   return applicationRuntime.runPromise(
     trackCliTelemetryEffect(event, properties).pipe(
       Effect.scoped,
-      Effect.timeout("2 seconds"),
+      Effect.timeout(TELEMETRY_TIMEOUT_MS),
       Effect.catch(() => Effect.void),
     ),
   );

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -124,6 +124,7 @@ export function trackCliTelemetry(event: string, properties: TelemetryProperties
   return applicationRuntime.runPromise(
     trackCliTelemetryEffect(event, properties).pipe(
       Effect.scoped,
+      Effect.timeout("2 seconds"),
       Effect.catch(() => Effect.void),
     ),
   );

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -1,3 +1,5 @@
+import { Effect } from "effect";
+
 import type { CreatePromptContext } from "../commands/create";
 import type {
   CreateCancellationStage,
@@ -5,8 +7,9 @@ import type {
   CreateFailureStage,
 } from "../create-outcome";
 import type { CreateCommandInput } from "../types";
+import { applicationRuntime } from "../runtime";
 
-import { trackCliTelemetry } from "./client";
+import { trackCliTelemetryEffect } from "./client";
 
 export const CREATE_PRISMA_NEXT_COMPLETED_EVENT = "cli:create_prisma_next_command_completed";
 export const CREATE_PRISMA_NEXT_FAILED_EVENT = "cli:create_prisma_next_command_failed";
@@ -97,26 +100,31 @@ function getPrismaCliFailureProperty(
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-export async function trackCreateCompleted(params: {
-  input: CreateCommandInput;
-  context: CreatePromptContext;
-  durationMs: number;
-}): Promise<void> {
-  await trackCliTelemetry(CREATE_PRISMA_NEXT_COMPLETED_EVENT, {
-    ...getBaseCreateProperties(params.input, params.context),
-    "duration-ms": params.durationMs,
-  });
-}
+export const trackCreateCompletedEffect = Effect.fn("Telemetry.createCompleted")(
+  function* (params: {
+    input: CreateCommandInput;
+    context: CreatePromptContext;
+    durationMs: number;
+  }) {
+    yield* trackCliTelemetryEffect(CREATE_PRISMA_NEXT_COMPLETED_EVENT, {
+      ...getBaseCreateProperties(params.input, params.context),
+      "duration-ms": params.durationMs,
+    }).pipe(
+      Effect.scoped,
+      Effect.catch(() => Effect.void),
+    );
+  },
+);
 
-export async function trackCreateFailed(params: {
+export const trackCreateFailedEffect = Effect.fn("Telemetry.createFailed")(function* (params: {
   input: CreateCommandInput;
   context?: CreatePromptContext;
   durationMs: number;
   error?: unknown;
   stage: CreateTelemetryFailureStage;
   reason: CreateFailureReason;
-}): Promise<void> {
-  await trackCliTelemetry(CREATE_PRISMA_NEXT_FAILED_EVENT, {
+}) {
+  yield* trackCliTelemetryEffect(CREATE_PRISMA_NEXT_FAILED_EVENT, {
     ...getBaseCreateProperties(params.input, params.context),
     "duration-ms": params.durationMs,
     "failure-class": getFailureClass(params.reason),
@@ -126,18 +134,33 @@ export async function trackCreateFailed(params: {
     "error-code": getErrorCode(params.error),
     "prisma-cli-command": getPrismaCliFailureProperty(params.error, "prismaCliCommand"),
     "prisma-cli-error-code": getPrismaCliFailureProperty(params.error, "prismaCliErrorCode"),
-  });
-}
+  }).pipe(
+    Effect.scoped,
+    Effect.catch(() => Effect.void),
+  );
+});
 
-export async function trackCreateCancelled(params: {
-  input: CreateCommandInput;
-  context?: CreatePromptContext;
-  durationMs: number;
-  stage: CreateCancellationStage;
-}): Promise<void> {
-  await trackCliTelemetry(CREATE_PRISMA_NEXT_CANCELLED_EVENT, {
-    ...getBaseCreateProperties(params.input, params.context),
-    "duration-ms": params.durationMs,
-    "cancellation-stage": params.stage,
-  });
-}
+export const trackCreateCancelledEffect = Effect.fn("Telemetry.createCancelled")(
+  function* (params: {
+    input: CreateCommandInput;
+    context?: CreatePromptContext;
+    durationMs: number;
+    stage: CreateCancellationStage;
+  }) {
+    yield* trackCliTelemetryEffect(CREATE_PRISMA_NEXT_CANCELLED_EVENT, {
+      ...getBaseCreateProperties(params.input, params.context),
+      "duration-ms": params.durationMs,
+      "cancellation-stage": params.stage,
+    }).pipe(
+      Effect.scoped,
+      Effect.catch(() => Effect.void),
+    );
+  },
+);
+
+export const trackCreateCompleted = (params: Parameters<typeof trackCreateCompletedEffect>[0]) =>
+  applicationRuntime.runPromise(trackCreateCompletedEffect(params));
+export const trackCreateFailed = (params: Parameters<typeof trackCreateFailedEffect>[0]) =>
+  applicationRuntime.runPromise(trackCreateFailedEffect(params));
+export const trackCreateCancelled = (params: Parameters<typeof trackCreateCancelledEffect>[0]) =>
+  applicationRuntime.runPromise(trackCreateCancelledEffect(params));

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -9,7 +9,7 @@ import type {
 import type { CreateCommandInput } from "../types";
 import { applicationRuntime } from "../runtime";
 
-import { trackCliTelemetryEffect } from "./client";
+import { TELEMETRY_TIMEOUT_MS, trackCliTelemetryEffect } from "./client";
 
 export const CREATE_PRISMA_NEXT_COMPLETED_EVENT = "cli:create_prisma_next_command_completed";
 export const CREATE_PRISMA_NEXT_FAILED_EVENT = "cli:create_prisma_next_command_failed";
@@ -111,7 +111,7 @@ export const trackCreateCompletedEffect = Effect.fn("Telemetry.createCompleted")
       "duration-ms": params.durationMs,
     }).pipe(
       Effect.scoped,
-      Effect.timeout("2 seconds"),
+      Effect.timeout(TELEMETRY_TIMEOUT_MS),
       Effect.catch(() => Effect.void),
     );
   },
@@ -137,7 +137,7 @@ export const trackCreateFailedEffect = Effect.fn("Telemetry.createFailed")(funct
     "prisma-cli-error-code": getPrismaCliFailureProperty(params.error, "prismaCliErrorCode"),
   }).pipe(
     Effect.scoped,
-    Effect.timeout("2 seconds"),
+    Effect.timeout(TELEMETRY_TIMEOUT_MS),
     Effect.catch(() => Effect.void),
   );
 });
@@ -155,7 +155,7 @@ export const trackCreateCancelledEffect = Effect.fn("Telemetry.createCancelled")
       "cancellation-stage": params.stage,
     }).pipe(
       Effect.scoped,
-      Effect.timeout("2 seconds"),
+      Effect.timeout(TELEMETRY_TIMEOUT_MS),
       Effect.catch(() => Effect.void),
     );
   },

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -111,6 +111,7 @@ export const trackCreateCompletedEffect = Effect.fn("Telemetry.createCompleted")
       "duration-ms": params.durationMs,
     }).pipe(
       Effect.scoped,
+      Effect.timeout("2 seconds"),
       Effect.catch(() => Effect.void),
     );
   },
@@ -136,6 +137,7 @@ export const trackCreateFailedEffect = Effect.fn("Telemetry.createFailed")(funct
     "prisma-cli-error-code": getPrismaCliFailureProperty(params.error, "prismaCliErrorCode"),
   }).pipe(
     Effect.scoped,
+    Effect.timeout("2 seconds"),
     Effect.catch(() => Effect.void),
   );
 });
@@ -153,6 +155,7 @@ export const trackCreateCancelledEffect = Effect.fn("Telemetry.createCancelled")
       "cancellation-stage": params.stage,
     }).pipe(
       Effect.scoped,
+      Effect.timeout("2 seconds"),
       Effect.catch(() => Effect.void),
     );
   },

--- a/src/templates/render-create-template.ts
+++ b/src/templates/render-create-template.ts
@@ -1,5 +1,8 @@
+import { Effect } from "effect";
+
+import { applicationRuntime } from "../runtime";
 import type { AuthoringStyle, CreateTemplate, DatabaseProvider, PackageManager } from "../types";
-import { renderTemplateTree, resolveTemplatesDir } from "./shared";
+import { renderTemplateTreeEffect, resolveTemplatesDirEffect } from "./shared";
 
 type CreateTemplateContext = {
   projectName: string;
@@ -10,6 +13,15 @@ type CreateTemplateContext = {
   tsdownEntry: string | null;
 };
 
+export type ScaffoldCreateTemplateOptions = {
+  projectDir: string;
+  projectName: string;
+  template: CreateTemplate;
+  provider: DatabaseProvider;
+  authoring: AuthoringStyle;
+  packageManager?: PackageManager;
+};
+
 const tsdownEntries: Partial<Record<CreateTemplate, string>> = {
   minimal: "src/index.ts",
   hono: "src/index.ts",
@@ -17,73 +29,58 @@ const tsdownEntries: Partial<Record<CreateTemplate, string>> = {
   nest: "src/main.ts",
 };
 
-function getCreateTemplateDir(template: CreateTemplate): string {
-  return resolveTemplatesDir(`templates/create/${template}`);
-}
-
-function getCreateSharedTemplateDir(): string {
-  return resolveTemplatesDir("templates/create/_shared");
-}
-
-function createTemplateContext(
-  projectName: string,
-  template: CreateTemplate,
-  provider: DatabaseProvider,
-  authoring: AuthoringStyle,
-  packageManager?: PackageManager,
-): CreateTemplateContext {
+function createTemplateContext(options: ScaffoldCreateTemplateOptions): CreateTemplateContext {
   return {
-    projectName,
-    template,
-    provider,
-    authoring,
-    packageManager,
-    tsdownEntry: tsdownEntries[template] ?? null,
+    projectName: options.projectName,
+    template: options.template,
+    provider: options.provider,
+    authoring: options.authoring,
+    packageManager: options.packageManager,
+    tsdownEntry: tsdownEntries[options.template] ?? null,
   };
 }
 
-export async function scaffoldCreateSharedTemplates(opts: {
-  projectDir: string;
-  projectName: string;
-  template: CreateTemplate;
-  provider: DatabaseProvider;
-  authoring: AuthoringStyle;
-  packageManager?: PackageManager;
-}): Promise<void> {
-  const { projectDir, projectName, template, provider, authoring, packageManager } = opts;
-  await renderTemplateTree<CreateTemplateContext>({
-    templateRoot: getCreateSharedTemplateDir(),
-    outputDir: projectDir,
-    context: createTemplateContext(projectName, template, provider, authoring, packageManager),
-  });
-}
-
-export async function scaffoldCreateTemplate(opts: {
-  projectDir: string;
-  projectName: string;
-  template: CreateTemplate;
-  provider: DatabaseProvider;
-  authoring: AuthoringStyle;
-  packageManager?: PackageManager;
-}): Promise<void> {
-  await scaffoldCreateFrameworkTemplate(opts);
-  await scaffoldCreateSharedTemplates(opts);
-}
-
-export async function scaffoldCreateFrameworkTemplate(opts: {
-  projectDir: string;
-  projectName: string;
-  template: CreateTemplate;
-  provider: DatabaseProvider;
-  authoring: AuthoringStyle;
-  packageManager?: PackageManager;
-}): Promise<void> {
-  const { projectDir, projectName, template, provider, authoring, packageManager } = opts;
-  const templateRoot = getCreateTemplateDir(template);
-  const context = createTemplateContext(projectName, template, provider, authoring, packageManager);
-  await renderTemplateTree<CreateTemplateContext>({
+export const scaffoldCreateSharedTemplatesEffect = Effect.fn("Templates.scaffoldShared")(function* (
+  options: ScaffoldCreateTemplateOptions,
+) {
+  const templateRoot = yield* resolveTemplatesDirEffect("templates/create/_shared");
+  yield* renderTemplateTreeEffect({
     templateRoot,
-    outputDir: projectDir,
-    context,
+    outputDir: options.projectDir,
+    context: createTemplateContext(options),
   });
+});
+
+export const scaffoldCreateFrameworkTemplateEffect = Effect.fn("Templates.scaffoldFramework")(
+  function* (options: ScaffoldCreateTemplateOptions) {
+    const templateRoot = yield* resolveTemplatesDirEffect(`templates/create/${options.template}`);
+    yield* renderTemplateTreeEffect({
+      templateRoot,
+      outputDir: options.projectDir,
+      context: createTemplateContext(options),
+    });
+  },
+);
+
+export const scaffoldCreateTemplateEffect = Effect.fn("Templates.scaffold")(function* (
+  options: ScaffoldCreateTemplateOptions,
+) {
+  yield* scaffoldCreateFrameworkTemplateEffect(options);
+  yield* scaffoldCreateSharedTemplatesEffect(options);
+});
+
+export function scaffoldCreateSharedTemplates(
+  options: ScaffoldCreateTemplateOptions,
+): Promise<void> {
+  return applicationRuntime.runPromise(scaffoldCreateSharedTemplatesEffect(options));
+}
+
+export function scaffoldCreateFrameworkTemplate(
+  options: ScaffoldCreateTemplateOptions,
+): Promise<void> {
+  return applicationRuntime.runPromise(scaffoldCreateFrameworkTemplateEffect(options));
+}
+
+export function scaffoldCreateTemplate(options: ScaffoldCreateTemplateOptions): Promise<void> {
+  return applicationRuntime.runPromise(scaffoldCreateTemplateEffect(options));
 }

--- a/src/templates/shared.ts
+++ b/src/templates/shared.ts
@@ -1,9 +1,9 @@
+import { Effect, FileSystem } from "effect";
 import Handlebars from "handlebars";
-import fs from "fs-extra";
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { applicationRuntime } from "../runtime";
 import type { PackageManager } from "../types";
 import {
   getPackageManagerManifestValue,
@@ -30,114 +30,104 @@ Handlebars.registerHelper(
     sourceEntrypoint: string,
     builtEntrypoint: string | undefined,
     _options: Handlebars.HelperOptions,
-  ) => {
-    if (!packageManager) {
-      return "";
-    }
-    return getRuntimeScriptCommand(packageManager, kind, {
-      sourceEntrypoint,
-      builtEntrypoint,
-    });
-  },
+  ) =>
+    packageManager
+      ? getRuntimeScriptCommand(packageManager, kind, { sourceEntrypoint, builtEntrypoint })
+      : "",
 );
 
-export function findPackageRoot(startDir: string): string {
+export const findPackageRootEffect = Effect.fn("Templates.findPackageRoot")(function* (
+  startDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   let currentDir = startDir;
 
   while (true) {
-    const packageJsonPath = path.join(currentDir, "package.json");
-    if (existsSync(packageJsonPath)) {
-      return currentDir;
-    }
-
+    if (yield* fs.exists(path.join(currentDir, "package.json"))) return currentDir;
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir) {
-      break;
+      return yield* Effect.fail(new Error(`Unable to locate package root from: ${startDir}`));
     }
-
     currentDir = parentDir;
   }
+});
 
-  throw new Error(`Unable to locate package root from: ${startDir}`);
-}
-
-export function resolveTemplatesDir(relativeTemplatesDir: string): string {
+export const resolveTemplatesDirEffect = Effect.fn("Templates.resolveDirectory")(function* (
+  relativeTemplatesDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const currentFilePath = fileURLToPath(import.meta.url);
-  const packageRoot = findPackageRoot(path.dirname(currentFilePath));
+  const packageRoot = yield* findPackageRootEffect(path.dirname(currentFilePath));
   const templatePath = path.join(packageRoot, relativeTemplatesDir);
-
-  if (!existsSync(templatePath)) {
-    throw new Error(`Template directory not found at: ${templatePath}`);
+  if (!(yield* fs.exists(templatePath))) {
+    return yield* Effect.fail(new Error(`Template directory not found at: ${templatePath}`));
   }
-
   return templatePath;
+});
+
+const ensureTrailingNewline = (content: string) =>
+  content.endsWith("\n") ? content : `${content}\n`;
+const stripHbsExtension = (filePath: string) =>
+  filePath.endsWith(".hbs") ? filePath.slice(0, -4) : filePath;
+
+export const renderTemplateFileEffect = Effect.fn("Templates.renderFile")(function* <
+  TContext,
+>(opts: { templateFilePath: string; outputPath: string; context: TContext }) {
+  const fs = yield* FileSystem.FileSystem;
+  const templateContent = yield* fs.readFileString(opts.templateFilePath);
+  const outputContent = yield* Effect.try({
+    try: () =>
+      opts.templateFilePath.endsWith(".hbs")
+        ? Handlebars.compile<TContext>(templateContent, { noEscape: true, strict: true })(
+            opts.context,
+          )
+        : templateContent,
+    catch: (cause) => new Error(`Could not render ${opts.templateFilePath}`, { cause }),
+  });
+  if (opts.templateFilePath.endsWith(".hbs") && outputContent.trim().length === 0) return;
+
+  yield* fs.makeDirectory(path.dirname(opts.outputPath), { recursive: true });
+  yield* fs.writeFileString(opts.outputPath, ensureTrailingNewline(outputContent));
+});
+
+export const renderTemplateTreeEffect = Effect.fn("Templates.renderTree")(function* <
+  TContext,
+>(opts: { templateRoot: string; outputDir: string; context: TContext }) {
+  const fs = yield* FileSystem.FileSystem;
+  const entries = yield* fs.readDirectory(opts.templateRoot, { recursive: true });
+
+  for (const relativePath of entries) {
+    const templateFilePath = path.join(opts.templateRoot, relativePath);
+    const info = yield* fs.stat(templateFilePath);
+    if (info.type !== "File") continue;
+    yield* renderTemplateFileEffect({
+      templateFilePath,
+      outputPath: path.join(opts.outputDir, stripHbsExtension(relativePath)),
+      context: opts.context,
+    });
+  }
+});
+
+export function findPackageRoot(startDir: string): Promise<string> {
+  return applicationRuntime.runPromise(findPackageRootEffect(startDir));
 }
 
-async function getTemplateFilesRecursively(dir: string): Promise<string[]> {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  const files = await Promise.all(
-    entries.map(async (entry): Promise<string[]> => {
-      const entryPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        return getTemplateFilesRecursively(entryPath);
-      }
-
-      if (!entry.isFile()) {
-        return [];
-      }
-
-      return [entryPath];
-    }),
-  );
-
-  return files.flat();
+export function resolveTemplatesDir(relativeTemplatesDir: string): Promise<string> {
+  return applicationRuntime.runPromise(resolveTemplatesDirEffect(relativeTemplatesDir));
 }
 
-function stripHbsExtension(filePath: string): string {
-  return filePath.endsWith(".hbs") ? filePath.slice(0, -4) : filePath;
-}
-
-function ensureTrailingNewline(content: string): string {
-  return content.endsWith("\n") ? content : `${content}\n`;
-}
-
-export async function renderTemplateFile<TContext>(opts: {
+export function renderTemplateFile<TContext>(opts: {
   templateFilePath: string;
   outputPath: string;
   context: TContext;
 }): Promise<void> {
-  const { templateFilePath, outputPath, context } = opts;
-  const templateContent = await fs.readFile(templateFilePath, "utf8");
-  const outputContent = templateFilePath.endsWith(".hbs")
-    ? Handlebars.compile<TContext>(templateContent, {
-        noEscape: true,
-        strict: true,
-      })(context)
-    : templateContent;
-
-  if (templateFilePath.endsWith(".hbs") && outputContent.trim().length === 0) {
-    return;
-  }
-
-  await fs.outputFile(outputPath, ensureTrailingNewline(outputContent), "utf8");
+  return applicationRuntime.runPromise(renderTemplateFileEffect(opts));
 }
 
-export async function renderTemplateTree<TContext>(opts: {
+export function renderTemplateTree<TContext>(opts: {
   templateRoot: string;
   outputDir: string;
   context: TContext;
 }): Promise<void> {
-  const { templateRoot, outputDir, context } = opts;
-  const templateFiles = await getTemplateFilesRecursively(templateRoot);
-
-  for (const templateFilePath of templateFiles) {
-    const relativeTemplatePath = path.relative(templateRoot, templateFilePath);
-    const relativeOutputPath = stripHbsExtension(relativeTemplatePath);
-    const outputPath = path.join(outputDir, relativeOutputPath);
-    await renderTemplateFile({
-      templateFilePath,
-      outputPath,
-      context,
-    });
-  }
+  return applicationRuntime.runPromise(renderTemplateTreeEffect(opts));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,7 @@
-import { z } from "zod";
+import { Effect, Schema, SchemaTransformation } from "effect";
 
 export const databaseProviders = ["postgres", "mongo"] as const;
 export const databaseProviderInputs = ["postgres", "postgresql", "mongo", "mongodb"] as const;
-
 export const packageManagers = ["npm", "pnpm", "yarn", "bun", "deno"] as const;
 export const authoringStyles = ["psl", "typescript"] as const;
 export const createTemplates = [
@@ -17,76 +16,71 @@ export const createTemplates = [
   "tanstack-start",
 ] as const;
 
-type NormalizedDatabaseProvider = (typeof databaseProviders)[number];
-type DatabaseProviderInput = (typeof databaseProviderInputs)[number];
+export const DatabaseProviderInputSchema = Schema.Literals(databaseProviderInputs);
+export const DatabaseProviderSchema = Schema.Literals(databaseProviders);
+export type DatabaseProvider = typeof DatabaseProviderSchema.Type;
+export type DatabaseProviderInput = typeof DatabaseProviderInputSchema.Type;
 
-function normalizeDatabaseProvider(value: DatabaseProviderInput): NormalizedDatabaseProvider {
-  if (value === "postgresql") {
-    return "postgres";
-  }
-  if (value === "mongodb") {
-    return "mongo";
-  }
+export const PackageManagerSchema = Schema.Literals(packageManagers);
+export type PackageManager = typeof PackageManagerSchema.Type;
 
-  return value;
+export const AuthoringStyleSchema = Schema.Literals(authoringStyles);
+export type AuthoringStyle = typeof AuthoringStyleSchema.Type;
+
+export const CreateTemplateSchema = Schema.Literals(createTemplates);
+export type CreateTemplate = typeof CreateTemplateSchema.Type;
+
+const OptionalBoolean = Schema.optionalKey(Schema.Boolean);
+const OptionalTrimmedString = Schema.optionalKey(Schema.Trim);
+const OptionalNonEmptyTrimmedString = Schema.optionalKey(
+  Schema.Trim.pipe(Schema.decodeTo(Schema.NonEmptyString, SchemaTransformation.passthrough())),
+);
+
+export const CommonCommandOptionsSchema = Schema.Struct({
+  yes: OptionalBoolean,
+  verbose: OptionalBoolean,
+  json: OptionalBoolean,
+});
+
+export const PrismaSetupOptionsSchema = Schema.Struct({
+  provider: Schema.optionalKey(DatabaseProviderSchema),
+  authoring: Schema.optionalKey(AuthoringStyleSchema),
+  packageManager: Schema.optionalKey(PackageManagerSchema),
+  deploy: OptionalBoolean,
+  workspace: OptionalNonEmptyTrimmedString,
+});
+
+export const PrismaSetupCommandInputSchema = Schema.Struct({
+  ...CommonCommandOptionsSchema.fields,
+  ...PrismaSetupOptionsSchema.fields,
+});
+export type PrismaSetupCommandInput = typeof PrismaSetupCommandInputSchema.Type;
+
+export const CreateScaffoldOptionsSchema = Schema.Struct({
+  name: OptionalTrimmedString,
+  template: Schema.optionalKey(CreateTemplateSchema),
+  force: OptionalBoolean,
+});
+
+export const CreateCommandInputSchema = Schema.Struct({
+  ...PrismaSetupCommandInputSchema.fields,
+  ...CreateScaffoldOptionsSchema.fields,
+});
+export type CreateCommandInput = typeof CreateCommandInputSchema.Type;
+
+export const decodeCreateCommandInput = Schema.decodeUnknownEffect(CreateCommandInputSchema);
+
+export function normalizeDatabaseProvider(value: DatabaseProviderInput): DatabaseProvider {
+  switch (value) {
+    case "postgresql":
+      return "postgres";
+    case "mongodb":
+      return "mongo";
+    default:
+      return value;
+  }
 }
 
-export const DatabaseProviderSchema = z
-  .enum(databaseProviderInputs)
-  .transform(normalizeDatabaseProvider);
-export type DatabaseProvider = z.infer<typeof DatabaseProviderSchema>;
-export const PackageManagerSchema = z.enum(packageManagers);
-export type PackageManager = z.infer<typeof PackageManagerSchema>;
-export const AuthoringStyleSchema = z.enum(authoringStyles);
-export type AuthoringStyle = z.infer<typeof AuthoringStyleSchema>;
-export const CreateTemplateSchema = z.enum(createTemplates);
-export type CreateTemplate = z.infer<typeof CreateTemplateSchema>;
-
-export const CommonCommandOptionsSchema = z.object({
-  yes: z.boolean().optional().describe("Skip prompts and accept default choices"),
-  verbose: z.boolean().optional().describe("Show verbose command output during setup"),
-  json: z
-    .boolean()
-    .optional()
-    .describe(
-      "Emit one quiet JSON result for agents and automation (non-interactive; deploys unless --no-deploy)",
-    ),
-});
-
-export const PrismaSetupOptionsSchema = z.object({
-  provider: DatabaseProviderSchema.optional().describe(
-    "Prisma 8 database target: PostgreSQL relational models or MongoDB document models",
-  ),
-  authoring: AuthoringStyleSchema.optional().describe("Contract authoring style"),
-  packageManager: PackageManagerSchema.optional().describe(
-    "Package manager used for dependency installation",
-  ),
-  deploy: z.boolean().optional().describe("Deploy the generated app to Prisma immediately"),
-  workspace: z
-    .string()
-    .trim()
-    .min(1, "Please enter a valid workspace id or name")
-    .optional()
-    .describe("Prisma workspace id or name to deploy into"),
-});
-
-export const PrismaSetupCommandInputSchema = CommonCommandOptionsSchema.extend(
-  PrismaSetupOptionsSchema.shape,
-);
-export type PrismaSetupCommandInput = z.infer<typeof PrismaSetupCommandInputSchema>;
-
-export const CreateScaffoldOptionsSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "Please enter a valid project name")
-    .optional()
-    .describe("Project name / directory"),
-  template: CreateTemplateSchema.optional().describe("Project template"),
-  force: z.boolean().optional().describe("Allow scaffolding into a non-empty target directory"),
-});
-
-export const CreateCommandInputSchema = PrismaSetupCommandInputSchema.extend(
-  CreateScaffoldOptionsSchema.shape,
-);
-export type CreateCommandInput = z.infer<typeof CreateCommandInputSchema>;
+export function decodeCreateCommandInputSync(input: unknown): CreateCommandInput {
+  return Effect.runSync(decodeCreateCommandInput(input));
+}

--- a/src/ui/json-output.ts
+++ b/src/ui/json-output.ts
@@ -1,33 +1,11 @@
-import type { Logger } from "trpc-cli";
+import { Effect } from "effect";
 
-import { createCommandFailureResult, type CreateCommandResult } from "../result";
+import type { CreateCommandResult } from "../result";
 
-function isCreateCommandResult(value: unknown): value is CreateCommandResult {
-  if (typeof value !== "object" || value === null) return false;
-  return Reflect.get(value, "schemaVersion") === 1 && typeof Reflect.get(value, "ok") === "boolean";
-}
-
-function formatLoggerMessage(values: unknown[]): string {
-  return values
-    .map((value) => {
-      if (value instanceof Error) return value.message;
-      if (typeof value === "string") return value.trim();
-      try {
-        return JSON.stringify(value);
-      } catch {
-        return String(value);
-      }
-    })
-    .filter(Boolean)
-    .join(" ");
-}
-
-export function isJsonOutputRequested(argv: string[]): boolean {
+export function isJsonOutputRequested(argv: readonly string[]): boolean {
   let requested = false;
   for (const [index, argument] of argv.entries()) {
-    if (argument === "--json") {
-      requested = argv[index + 1]?.toLowerCase() !== "false";
-    }
+    if (argument === "--json") requested = argv[index + 1]?.toLowerCase() !== "false";
     if (argument.startsWith("--json=")) {
       requested = argument.slice("--json=".length).toLowerCase() !== "false";
     }
@@ -36,38 +14,6 @@ export function isJsonOutputRequested(argv: string[]): boolean {
   return requested;
 }
 
-export function createJsonOutputLogger(
-  write: (output: string) => void = (output) => process.stdout.write(output),
-): Logger {
-  let didWrite = false;
-  const writeResult = (result: CreateCommandResult) => {
-    if (didWrite) return;
-    didWrite = true;
-    write(`${JSON.stringify(result)}\n`);
-  };
-
-  return {
-    info(...values: unknown[]) {
-      const result = values.length === 1 ? values[0] : undefined;
-      if (isCreateCommandResult(result)) {
-        writeResult(result);
-        return;
-      }
-
-      writeResult(
-        createCommandFailureResult(
-          "parse_arguments",
-          formatLoggerMessage(values) || "The CLI returned an unexpected result.",
-        ),
-      );
-    },
-    error(...values: unknown[]) {
-      writeResult(
-        createCommandFailureResult(
-          "parse_arguments",
-          formatLoggerMessage(values) || "Could not parse command arguments.",
-        ),
-      );
-    },
-  };
-}
+export const writeJsonResult = Effect.fn("JsonOutput.write")((result: CreateCommandResult) =>
+  Effect.sync(() => process.stdout.write(`${JSON.stringify(result)}\n`)),
+);

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,7 +1,8 @@
-import fs from "fs-extra";
+import { Effect, FileSystem } from "effect";
 import path from "node:path";
 
-import { PackageManagerSchema, type PackageManager } from "../types";
+import { applicationRuntime } from "../runtime";
+import { packageManagers, type PackageManager } from "../types";
 
 type CommandAndArgs = {
   command: string;
@@ -55,31 +56,47 @@ function parsePackageManagerField(packageManagerField: unknown): PackageManager 
   }
 
   const managerName = packageManagerField.split("@")[0];
-  const parsed = PackageManagerSchema.safeParse(managerName);
-  return parsed.success ? parsed.data : null;
+  return packageManagers.includes(managerName as PackageManager)
+    ? (managerName as PackageManager)
+    : null;
 }
 
-async function detectFromPackageJson(projectDir: string): Promise<PackageManager | null> {
+const detectFromPackageJson = Effect.fn("PackageManager.detectFromPackageJson")(function* (
+  projectDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const packageJsonPath = path.join(projectDir, "package.json");
-  if (!(await fs.pathExists(packageJsonPath))) {
+  if (!(yield* fs.exists(packageJsonPath))) {
     return null;
   }
 
-  const packageJson = await fs.readJson(packageJsonPath);
-  return parsePackageManagerField(packageJson.packageManager);
-}
+  const packageJsonSource = yield* fs
+    .readFileString(packageJsonPath)
+    .pipe(Effect.catch(() => Effect.succeed("")));
+  const packageJson = yield* Effect.try({
+    try: () => JSON.parse(packageJsonSource) as Record<string, unknown>,
+    catch: () => null,
+  });
+  return packageJson ? parsePackageManagerField(packageJson.packageManager) : null;
+});
 
-async function detectFromDenoConfig(projectDir: string): Promise<PackageManager | null> {
+const detectFromDenoConfig = Effect.fn("PackageManager.detectFromDenoConfig")(function* (
+  projectDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   for (const configFile of ["deno.json", "deno.jsonc"]) {
-    if (await fs.pathExists(path.join(projectDir, configFile))) {
+    if (yield* fs.exists(path.join(projectDir, configFile))) {
       return "deno";
     }
   }
 
   return null;
-}
+});
 
-async function detectFromLockfile(projectDir: string): Promise<PackageManager | null> {
+const detectFromLockfile = Effect.fn("PackageManager.detectFromLockfile")(function* (
+  projectDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const lockfileChecks: Array<{ manager: PackageManager; lockfile: string }> = [
     { manager: "pnpm", lockfile: "pnpm-lock.yaml" },
     { manager: "yarn", lockfile: "yarn.lock" },
@@ -91,26 +108,28 @@ async function detectFromLockfile(projectDir: string): Promise<PackageManager | 
   ];
 
   for (const check of lockfileChecks) {
-    if (await fs.pathExists(path.join(projectDir, check.lockfile))) {
+    if (yield* fs.exists(path.join(projectDir, check.lockfile))) {
       return check.manager;
     }
   }
 
   return null;
-}
+});
 
-export async function detectPackageManager(projectDir = process.cwd()): Promise<PackageManager> {
-  const fromPackageJson = await detectFromPackageJson(projectDir);
+export const detectPackageManagerEffect = Effect.fn("PackageManager.detect")(function* (
+  projectDir = process.cwd(),
+) {
+  const fromPackageJson = yield* detectFromPackageJson(projectDir);
   if (fromPackageJson) {
     return fromPackageJson;
   }
 
-  const fromLockfile = await detectFromLockfile(projectDir);
+  const fromLockfile = yield* detectFromLockfile(projectDir);
   if (fromLockfile) {
     return fromLockfile;
   }
 
-  const fromDenoConfig = await detectFromDenoConfig(projectDir);
+  const fromDenoConfig = yield* detectFromDenoConfig(projectDir);
   if (fromDenoConfig) {
     return fromDenoConfig;
   }
@@ -121,6 +140,10 @@ export async function detectPackageManager(projectDir = process.cwd()): Promise<
   }
 
   return "npm";
+});
+
+export function detectPackageManager(projectDir = process.cwd()): Promise<PackageManager> {
+  return applicationRuntime.runPromise(detectPackageManagerEffect(projectDir));
 }
 
 export function getPackageManagerManifestValue(

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -281,7 +281,7 @@ export function getLocalPackageBinaryArgs(
     case "deno":
       return {
         command: "deno",
-        args: ["run", "-A", DENO_ALLOW_FRESH_DEPENDENCIES, `npm:${binaryName}`, ...binaryArgs],
+        args: ["run", "-A", "--frozen", `npm:${binaryName}@latest`, ...binaryArgs],
       };
     case "pnpm":
       return { command: "pnpm", args: ["exec", binaryName, ...binaryArgs] };
@@ -291,7 +291,10 @@ export function getLocalPackageBinaryArgs(
       return { command: "bun", args: [binaryName, ...binaryArgs] };
     case "npm":
     default:
-      return { command: "npm", args: ["exec", binaryName, "--", ...binaryArgs] };
+      return {
+        command: "npm",
+        args: ["exec", "--offline", "--yes=false", "--", binaryName, ...binaryArgs],
+      };
   }
 }
 

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -73,10 +73,9 @@ const detectFromPackageJson = Effect.fn("PackageManager.detectFromPackageJson")(
   const packageJsonSource = yield* fs
     .readFileString(packageJsonPath)
     .pipe(Effect.catch(() => Effect.succeed("")));
-  const packageJson = yield* Effect.try({
-    try: () => JSON.parse(packageJsonSource) as Record<string, unknown>,
-    catch: () => null,
-  });
+  const packageJson = yield* Effect.try(
+    () => JSON.parse(packageJsonSource) as Record<string, unknown>,
+  ).pipe(Effect.catch(() => Effect.succeed(null)));
   return packageJson ? parsePackageManagerField(packageJson.packageManager) : null;
 });
 

--- a/src/utils/run-command.ts
+++ b/src/utils/run-command.ts
@@ -1,21 +1,22 @@
-import { execa } from "execa";
+import { Effect } from "effect";
 
-/**
- * Runs a setup command without allowing child output to corrupt structured CLI output.
- * Human verbose mode keeps native streaming; JSON mode always captures child output.
- */
-export async function runSetupCommand(options: {
+import { CommandRunner } from "../services/command-runner";
+
+export const runSetupCommand = Effect.fn("runSetupCommand")(function* (options: {
   command: string;
   args: string[];
   cwd: string;
   env?: NodeJS.ProcessEnv;
   verbose: boolean;
   json: boolean;
-}): Promise<void> {
+}) {
+  const runner = yield* CommandRunner;
   const shouldInheritOutput = options.verbose && !options.json;
-  await execa(options.command, options.args, {
+  yield* runner.runChecked({
+    command: options.command,
+    args: options.args,
     cwd: options.cwd,
-    env: options.env,
+    ...(options.env ? { env: options.env } : {}),
     stdio: shouldInheritOutput ? "inherit" : "pipe",
   });
-}
+});

--- a/src/workflow/failure.ts
+++ b/src/workflow/failure.ts
@@ -1,0 +1,22 @@
+import { Effect } from "effect";
+
+import {
+  CreateCancellationError,
+  CreateFailure,
+  type CreateFailureReason,
+  type CreateFailureStage,
+} from "../create-outcome";
+import { getErrorMessage } from "../utils/errors";
+
+export const atCreateStage = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  stage: CreateFailureStage,
+  reason: CreateFailureReason,
+) =>
+  effect.pipe(
+    Effect.mapError((error) =>
+      error instanceof CreateFailure || error instanceof CreateCancellationError
+        ? error
+        : new CreateFailure({ stage, reason, message: getErrorMessage(error), cause: error }),
+    ),
+  );

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -58,7 +58,7 @@ async function runCommand(projectDir: string, args: string[]) {
 
 async function runCreatePrismaJson(rootDir: string, args: string[]) {
   const child = Bun.spawn({
-    cmd: [process.execPath, path.join(import.meta.dir, "../../src/cli.ts"), "create", ...args],
+    cmd: [process.execPath, path.join(import.meta.dir, "../../src/cli.ts"), ...args],
     cwd: rootDir,
     env: { ...Bun.env, CI: "1", CREATE_PRISMA_DISABLE_TELEMETRY: "1" },
     stdout: "pipe",

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -267,7 +267,7 @@ describe("create-prisma e2e", () => {
     expect(JSON.parse(stdout)).toMatchObject({
       schemaVersion: 1,
       ok: false,
-      error: { stage: "initialize_prisma" },
+      error: { stage: "install_dependencies" },
     });
     expect(stderr).toBe("");
     expect(await pathExists(path.join(rootDir, "failed-app", "package.json"))).toBe(true);

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -13,6 +13,7 @@ import {
 import { authoringStyles, createTemplates, databaseProviders, packageManagers } from "../src/types";
 import {
   getInstallArgs,
+  getLocalPackageBinaryArgs,
   getPackageExecutionArgs,
   getRunScriptCommand,
 } from "../src/utils/package-manager";
@@ -132,6 +133,17 @@ describe("Composer package-manager commands", () => {
     expect(getPackageExecutionArgs("deno", ["prisma@8.0.0-rc.11", "orm", "init"])).toEqual({
       command: "deno",
       args: ["run", "-A", "--minimum-dependency-age=0", "npm:prisma@8.0.0-rc.11", "orm", "init"],
+    });
+  });
+
+  test("runs the installed Prisma CLI without registry fallback", () => {
+    expect(getLocalPackageBinaryArgs("npm", "prisma", ["contract", "emit"])).toEqual({
+      command: "npm",
+      args: ["exec", "--offline", "--yes=false", "--", "prisma", "contract", "emit"],
+    });
+    expect(getLocalPackageBinaryArgs("deno", "prisma", ["contract", "emit"])).toEqual({
+      command: "deno",
+      args: ["run", "-A", "--frozen", "npm:prisma@latest", "contract", "emit"],
     });
   });
 });

--- a/tests/json-output.test.ts
+++ b/tests/json-output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
 
-import { createJsonOutputLogger, isJsonOutputRequested } from "../src/ui/json-output";
+import { isJsonOutputRequested, writeJsonResult } from "../src/ui/json-output";
 
 describe("isJsonOutputRequested", () => {
   test("uses the last explicit JSON flag", () => {
@@ -13,12 +14,40 @@ describe("isJsonOutputRequested", () => {
   });
 });
 
-describe("createJsonOutputLogger", () => {
-  test("writes one compact success result", () => {
-    const outputs: string[] = [];
-    const logger = createJsonOutputLogger((output) => outputs.push(output));
+describe("writeJsonResult", () => {
+  test("writes one compact success result", async () => {
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((output: string) => {
+      writes.push(output);
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await Effect.runPromise(
+        writeJsonResult({
+          schemaVersion: 1,
+          ok: true,
+          project: {
+            name: "my-app",
+            path: "/tmp/my-app",
+            template: "minimal",
+            databaseProvider: "postgres",
+            authoring: "psl",
+            packageManager: "bun",
+          },
+          deployment: null,
+          nextSteps: [],
+          warnings: [],
+        }),
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
 
-    logger.info?.({
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.split("\n")).toHaveLength(2);
+    expect(writes[0]?.endsWith("\n")).toBe(true);
+    expect(JSON.parse(writes[0]!)).toEqual({
       schemaVersion: 1,
       ok: true,
       project: {
@@ -32,57 +61,6 @@ describe("createJsonOutputLogger", () => {
       deployment: null,
       nextSteps: [],
       warnings: [],
-    });
-
-    expect(outputs).toHaveLength(1);
-    expect(outputs[0]?.split("\n")).toHaveLength(2);
-    expect(outputs[0]?.endsWith("\n")).toBe(true);
-    expect(JSON.parse(outputs[0]!)).toEqual({
-      schemaVersion: 1,
-      ok: true,
-      project: {
-        name: "my-app",
-        path: "/tmp/my-app",
-        template: "minimal",
-        databaseProvider: "postgres",
-        authoring: "psl",
-        packageManager: "bun",
-      },
-      deployment: null,
-      nextSteps: [],
-      warnings: [],
-    });
-  });
-
-  test("turns parser errors into one structured failure", () => {
-    const outputs: string[] = [];
-    const logger = createJsonOutputLogger((output) => outputs.push(output));
-
-    logger.error?.("Invalid template");
-    logger.info?.({ unexpected: true });
-
-    expect(outputs).toHaveLength(1);
-    expect(JSON.parse(outputs[0]!)).toEqual({
-      schemaVersion: 1,
-      ok: false,
-      error: { stage: "parse_arguments", message: "Invalid template" },
-    });
-  });
-
-  test("turns unexpected info values into a structured failure", () => {
-    const outputs: string[] = [];
-    const logger = createJsonOutputLogger((output) => outputs.push(output));
-
-    logger.info?.({ unexpected: true });
-
-    expect(outputs).toHaveLength(1);
-    expect(JSON.parse(outputs[0]!)).toEqual({
-      schemaVersion: 1,
-      ok: false,
-      error: {
-        stage: "parse_arguments",
-        message: '{"unexpected":true}',
-      },
     });
   });
 });

--- a/tests/telemetry-client.test.ts
+++ b/tests/telemetry-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { shutdownTelemetryClientEffect } from "../src/telemetry/client";
+
+describe("telemetry client shutdown", () => {
+  test("bounds cleanup even when the client does not settle", async () => {
+    let receivedTimeout: number | undefined;
+    const startedAt = performance.now();
+
+    await Effect.runPromise(
+      Effect.acquireRelease(
+        Effect.succeed({
+          shutdown: (timeoutMs) => {
+            receivedTimeout = timeoutMs;
+            return new Promise<void>(() => {});
+          },
+        }),
+        (client) => shutdownTelemetryClientEffect(client, 20),
+      ).pipe(Effect.scoped),
+    );
+
+    expect(receivedTimeout).toBe(20);
+    expect(performance.now() - startedAt).toBeLessThan(500);
+  });
+});

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Effect } from "effect";
 
 import type { CreatePromptContext } from "../src/commands/create";
 import type { CreateCommandInput } from "../src/types";
 
 const trackCliTelemetry = mock(async () => {});
 
-mock.module("../src/telemetry/client", () => ({ trackCliTelemetry }));
+mock.module("../src/telemetry/client", () => ({
+  trackCliTelemetryEffect: (event: string, properties: Record<string, unknown>) =>
+    Effect.promise(() => trackCliTelemetry(event, properties)),
+}));
 
 const {
   CREATE_PRISMA_NEXT_CANCELLED_EVENT,


### PR DESCRIPTION
## Summary

Migrate create-prisma's runtime and CLI architecture to Effect v4.

- replace `trpc-cli`, oRPC, Zod, and `fs-extra` with Effect v4
- define the command with `effect/unstable/cli`, including typed positional arguments, flags, negated booleans, help, version, completions, and wizard support
- model input, result envelopes, Prisma CLI responses, failure stages, and domain errors with Effect Schema
- move filesystem work, command orchestration, telemetry lifecycles, cancellation, timing, and workflow composition into Effects
- add a layered, interruptible command runner while keeping Execa as the small Windows-safe process adapter
- install dependencies once before Prisma initialization, then reuse the project-local CLI for init, skills, contracts, migrations, auth, and deployment
- preserve the human Clack experience, deterministic one-line `--json` output, exit codes, default root command, explicit `create` compatibility, and the public Promise API
- use only Effect's required Node filesystem/CLI layers from `@effect/platform-node-shared`; this avoids pulling the aggregate platform package's unused Redis and HTTP dependencies

The implementation was checked against the full Effect repository at Effect-TS/effect@bd393d63c19bdd0ab212d95576cec89051c8501c.

## Architecture

The application layer provides the Node services required by Effect CLI plus a `CommandRunner` service. Workflow code now composes typed Effects end to end; Promise boundaries remain only where the public API or third-party libraries require them.

Composer deployment continues to consume the Prisma CLI's official JSON envelopes. Effect Schema now validates each command result before it enters the deployment workflow.

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test:unit` — 46 passed
- `bun run test:e2e` — 8 passed
  - real Composer-backed PostgreSQL app: generated, built, migrated, started, and queried
  - Next.js TypeScript contract build
  - every raw Node template build
  - Deno minimal app generation and check
  - structured JSON and failure exit-code cases
- packed npm artifact installed into a clean consumer project; CLI help/version work and no Redis peer is installed
- Windows creation smoke passed in GitHub Actions
- the published `create-prisma@pr86` preview scaffolded a Hono/PostgreSQL project in JSON mode and the generated app built successfully
- published tarball: 40.7 kB; built output: 101.31 kB
