### PR TITLE
chore: update Composer to 0.17.0

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,8 +3,8 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/composer": "0.16.0",
-  "@prisma/composer-prisma-cloud": "0.16.0",
+  "@prisma/composer": "0.17.0",
+  "@prisma/composer-prisma-cloud": "0.17.0",
   "@prisma/orm-mongo": "8.0.0-rc.8",
   // Must match @prisma/composer-prisma-cloud's exact peerDependency.
   "@prisma/orm-postgres": "8.0.0-rc.8",

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -6,8 +6,8 @@ describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
     expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.8");
     expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.8");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.16.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.16.0");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.17.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.17.0");
     expect(getDependencyVersion("prisma")).toBe("latest");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.112");

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -425,10 +425,14 @@ describe("create-prisma e2e", () => {
       // need an authored path from empty to the contract.
       expect(await pathExists(path.join(projectDir, "migrations/app"))).toBe(true);
       expect(
-        await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
+        await pathExists(
+          path.join(projectDir, ".agents/skills/prisma-composer-core-concepts/SKILL.md"),
+        ),
       ).toBe(true);
       expect(
-        await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
+        await pathExists(
+          path.join(projectDir, ".claude/skills/prisma-composer-core-concepts/SKILL.md"),
+        ),
       ).toBe(true);
       expect(packageJson.devDependencies.prisma).toBe("latest");
       expect(packageJson.scripts.postinstall).toBe("prisma skills sync || exit 0");
@@ -485,10 +489,14 @@ describe("create-prisma e2e", () => {
       expect(await pathExists(path.join(projectDir, "prisma.config.ts"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "migrations/app"))).toBe(true);
       expect(
-        await pathExists(path.join(projectDir, ".agents/skills/prisma-composer/SKILL.md")),
+        await pathExists(
+          path.join(projectDir, ".agents/skills/prisma-composer-core-concepts/SKILL.md"),
+        ),
       ).toBe(true);
       expect(
-        await pathExists(path.join(projectDir, ".claude/skills/prisma-composer/SKILL.md")),
+        await pathExists(
+          path.join(projectDir, ".claude/skills/prisma-composer-core-concepts/SKILL.md"),
+        ),
       ).toBe(true);
 
       await runCommand(projectDir, ["bun", "run", "build"]);


### PR DESCRIPTION
## Summary

- update generated projects to @prisma/composer 0.17.0
- update @prisma/composer-prisma-cloud to the matching 0.17.0 release
- follow the official renamed prisma-composer-core-concepts agent skill in E2E coverage

This aligns create-prisma with prisma 8.0.0-rc.13, which upgraded its Composer product versions to 0.17.0.

## Verification

- bun run check
- bun run typecheck
- bun run test:unit (46 passed)
- bun run test:e2e (8 passed)
- bun run build
- local Composer 0.17.0 smoke: converge, migration, seed, and HTTP 200 response