### PR TITLE
chore(release): 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 Release notes are generated from merged pull requests using `changelogithub`.
+
+## 0.11.5
+
+- Write pnpm build permissions before installing dependencies so fresh projects can install successfully. See [#90](https://github.com/prisma/create-prisma/pull/90).


### PR DESCRIPTION
## Release 0.11.5
The pnpm fix from #90 is merged and package.json already contains 0.11.5, but npm publishing was skipped because the squash commit title was `fix: configure pnpm before installing dependencies (#90)`.

This release-only follow-up adds the changelog entry. No runtime code or dependencies change.

**Squash-merge with the commit title exactly `chore(release): 0.11.5`.** The existing trusted-publishing workflow requires this prefix. The single commit also uses that title so GitHub can retain it as the default.

npm @latest is still 0.11.4; 0.11.5 has not been published. This will publish 0.11.5 to @latest without changing @next or @stable.

Verification of the fix: 47 unit tests, typecheck, lint, format, and build passed; fresh pnpm Minimal, Next.js, and Astro scaffolds, builds, and local Composer responses with seeded users passed. Changelog formatting checked again.