### PR TITLE
chore(release): 0.11.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
Release create-prisma 0.11.6 with #92: forward explicit Prisma init overwrite consent, preserve structured setup errors, and redact stored command errors. Squash-merge to trigger the existing npm trusted-publishing workflow.