### PR TITLE
fix: protect migration history before forced scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ older cached version. Prisma Compute does not support Deno deployments yet.
 - `--deploy` / `--no-deploy`
 - `--workspace <id-or-name>`
 - `--yes`
-- `--force`: overwrite generated starter and Prisma files in a non-empty directory. This replaces existing Prisma config, contract, and database-client files; back up edits first.
+- `--force`: overwrite generated starter and Prisma files in a non-empty directory without migration history. This replaces existing Prisma config, contract, and database-client files; back up edits first. A non-empty `migrations` path is protected: use a new directory for a fresh starter, or continue working in the existing project with the Prisma CLI.
 - `--verbose`
 - `--json`
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ older cached version. Prisma Compute does not support Deno deployments yet.
 - `--deploy` / `--no-deploy`
 - `--workspace <id-or-name>`
 - `--yes`
-- `--force`: overwrite generated starter and Prisma files in a non-empty directory without migration history. This replaces existing Prisma config, contract, and database-client files; back up edits first. A non-empty `migrations` path is protected: use a new directory for a fresh starter, or continue working in the existing project with the Prisma CLI.
+- `--force`: overwrite generated starter and Prisma files in a non-empty directory. This replaces existing Prisma config, contract, and database-client files; back up edits first. A non-empty standard `migrations` path is protected: use a new directory for a fresh starter, or continue working in the existing project with the Prisma CLI. Custom migration paths are not detected.
 - `--verbose`
 - `--json`
 

--- a/src/commands/create-context.ts
+++ b/src/commands/create-context.ts
@@ -178,6 +178,20 @@ export const collectCreateContext = Effect.fn("Create.collectContext")(function*
     });
   }
 
+  if (force && targetPathState.exists) {
+    const migrations = yield* inspectTargetPath(path.join(targetDirectory, "migrations"));
+    if (migrations.exists && !migrations.isEmptyDirectory) {
+      const message = `Target directory ${formatPathForDisplay(targetDirectory)} contains migration history. Create a starter in a new directory, or continue working in the existing project with the Prisma CLI. --force cannot overwrite a project with existing migrations.`;
+      yield* Effect.sync(() => cancel(message, { output }));
+      return yield* new CreateFailure({
+        stage: "collect_context",
+        reason: "target_has_migrations",
+        message,
+        errorReported: true,
+      });
+    }
+  }
+
   const prismaSetupContext = yield* collectPrismaSetupContextEffect(input, {
     projectDir: targetDirectory,
     template,

--- a/src/create-outcome.ts
+++ b/src/create-outcome.ts
@@ -26,6 +26,7 @@ export const CreateFailureReasonSchema = Schema.Literals([
   "invalid_project_name",
   "target_path_not_directory",
   "target_directory_not_empty",
+  "target_has_migrations",
   "unsupported_configuration",
   "template_scaffold_failed",
   "prisma_init_failed",

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export const createPrismaCommand = Command.make(
     workspace: optionalString("workspace", "Prisma workspace id or name to deploy into"),
     force: optionalBoolean(
       "force",
-      "Overwrite generated starter and Prisma files in a non-empty directory",
+      "Overwrite generated starter and Prisma files in a directory without migration history",
     ),
     yes: optionalBoolean("yes", "Skip prompts and accept default choices"),
     verbose: optionalBoolean("verbose", "Show verbose command output during setup"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export const createPrismaCommand = Command.make(
     workspace: optionalString("workspace", "Prisma workspace id or name to deploy into"),
     force: optionalBoolean(
       "force",
-      "Overwrite generated starter and Prisma files in a directory without migration history",
+      "Overwrite generated starter and Prisma files; refuses a non-empty migrations path",
     ),
     yes: optionalBoolean("yes", "Skip prompts and accept default choices"),
     verbose: optionalBoolean("verbose", "Show verbose command output during setup"),

--- a/src/telemetry/create.ts
+++ b/src/telemetry/create.ts
@@ -23,6 +23,7 @@ const expectedRejectionReasons = new Set<CreateFailureReason>([
   "invalid_project_name",
   "target_path_not_directory",
   "target_directory_not_empty",
+  "target_has_migrations",
   "unsupported_configuration",
   "not_authenticated",
   "workspace_missing",

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   readdir,
   realpath,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -264,6 +265,35 @@ describe("create-prisma e2e", () => {
         "Unrelated user file\n",
       );
       await runCommand(projectDir, ["bun", "run", "build"]);
+
+      await writeFile(contractPath, `${TEST_PSL_CONTRACT}\n// Keep this existing project edit\n`);
+      const preservedPaths = ["package.json", "prisma.config.ts", "src/prisma/contract.prisma"];
+      const migrationPaths = await readdir(path.join(projectDir, "migrations"), {
+        recursive: true,
+      });
+      for (const relativePath of migrationPaths) {
+        const filePath = path.join("migrations", relativePath);
+        if ((await stat(path.join(projectDir, filePath))).isFile()) {
+          preservedPaths.push(filePath);
+        }
+      }
+      const before = await Promise.all(
+        preservedPaths.map((filePath) => readFile(path.join(projectDir, filePath), "utf8")),
+      );
+      const completeRetry = await runCreatePrismaJson(rootDir, [...args, "--force"]);
+      expect(completeRetry.exitCode).toBe(1);
+      expect(completeRetry.result).toMatchObject({
+        ok: false,
+        error: { stage: "collect_context", message: expect.stringContaining("migration history") },
+      });
+      expect(await readdir(path.join(projectDir, "migrations"), { recursive: true })).toEqual(
+        migrationPaths,
+      );
+      expect(
+        await Promise.all(
+          preservedPaths.map((filePath) => readFile(path.join(projectDir, filePath), "utf8")),
+        ),
+      ).toEqual(before);
     },
     TEST_TIMEOUT,
   );

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -84,7 +84,11 @@ describe("create telemetry", () => {
   });
 
   test("separates expected input and environment rejections from technical failures", async () => {
-    for (const reason of ["target_directory_not_empty", "workspace_missing"] as const) {
+    for (const reason of [
+      "target_directory_not_empty",
+      "target_has_migrations",
+      "workspace_missing",
+    ] as const) {
       await trackCreateFailed({
         input: createInput,
         context: createContext,
@@ -94,9 +98,10 @@ describe("create telemetry", () => {
       });
     }
     const calls = trackCliTelemetry.mock.calls as Array<[string, Record<string, unknown>]>;
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
     expect(calls.map(([, properties]) => properties["failure-reason"])).toEqual([
       "target_directory_not_empty",
+      "target_has_migrations",
       "workspace_missing",
     ]);
     for (const [, properties] of calls) {


### PR DESCRIPTION
## Problem
A forced rerun into a completed starter overwrites its config and contract, then fails at migration planning with MIGRATION.PLAN_ORIGIN_UNKNOWN. Reproduced against prisma@8.0.0-rc.13 (current latest).

The Prisma CLI guard is intentional: existing migrations plus no db ref or explicit origin must not silently produce another empty-origin migration. This PR does not change that upstream behavior.

## Change
- Reject a forced scaffold when the target has a non-empty migrations path, before installing dependencies or writing starter files.
- Keep partial-scaffold retries without migration history working.
- Tell the user to choose a new directory or continue using the existing project with the Prisma CLI.
- Classify the rejection as target_has_migrations / expected_rejection in telemetry.
- Update --force help and README to state the boundary.

This is an early safety rejection, not automatic migration-history recovery. It does not delete history, guess a starting contract, fabricate a db ref, or bypass Prisma with --from @empty. Protection covers the standard migrations path used by generated starters; it does not execute existing user config to discover custom paths.

## Verification
- Regression first failed on the old behavior at plan_migration.
- Real CLI regression: partial scaffold completes with --force; rerunning after migration creation rejects before writes and preserves edited contract, config, package manifest, migration file contents, and directory entries.
- 56 unit tests passed.
- All 9 E2E tests passed, including local Composer/Postgres, Next.js TypeScript build, raw Node template builds, and minimal Deno checks.
- Final expanded file-preservation regression rerun passed.
- Typecheck, formatting, lint, and build passed.
- Test telemetry disabled. No cloud deployment was performed for this change.

## Separate analytics follow-up
The initial 0.11.6 sample contained three expected non-empty-directory rejections, two Linux dependency-install failures (minimal template, npm and Yarn, Node v24.7.0), one cancellation, and no completions. No Prisma initialization or skills failures were recorded in that small sample. Install events only expose exit code 1, so their cause is not established and this PR does not claim to fix them.