### PR TITLE
chore(release): 0.11.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
Release create-prisma 0.11.7 with #94: reject forced scaffolding before overwriting projects with a non-empty standard migrations path. Partial-scaffold retries remain supported. Squash-merge to trigger the existing npm trusted-publishing workflow.