### PR TITLE
chore: scaffold with Composer 0.19.0 and Prisma ORM 8.0.0-rc.10

### DIFF
--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -3,11 +3,11 @@ import type { CreateTemplate, PackageManager } from "../types";
 export const dependencyVersionMap = {
   "@astrojs/node": "^10.0.2",
   "@elysiajs/node": "^1.4.5",
-  "@prisma/composer": "0.17.0",
-  "@prisma/composer-prisma-cloud": "0.17.0",
-  "@prisma/orm-mongo": "8.0.0-rc.8",
+  "@prisma/composer": "0.19.0",
+  "@prisma/composer-prisma-cloud": "0.19.0",
+  "@prisma/orm-mongo": "8.0.0-rc.10",
   // Must match @prisma/composer-prisma-cloud's exact peerDependency.
-  "@prisma/orm-postgres": "8.0.0-rc.8",
+  "@prisma/orm-postgres": "8.0.0-rc.10",
   "@sveltejs/adapter-node": "^5.3.2",
   "@types/node": "^25.6.2",
   alchemy: "2.0.0-beta.74",

--- a/src/tasks/prisma-setup/commands.ts
+++ b/src/tasks/prisma-setup/commands.ts
@@ -59,7 +59,9 @@ export const runPrismaInit = Effect.fn("PrismaSetup.init")(function* (
   ]);
   if (context.packageManager === "deno") {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(path.join(projectDir, "prisma-next.md"), { force: true });
+    for (const primer of ["prisma-8.md", "prisma-next.md"]) {
+      yield* fs.remove(path.join(projectDir, primer), { force: true });
+    }
   }
 });
 

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -4,10 +4,10 @@ import { dependencyVersionMap, getDependencyVersion } from "../src/constants/dep
 
 describe("Prisma 8 dependency versions", () => {
   test("uses the selected Prisma 8 and Composer releases", () => {
-    expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.8");
-    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.8");
-    expect(getDependencyVersion("@prisma/composer")).toBe("0.17.0");
-    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.17.0");
+    expect(getDependencyVersion("@prisma/orm-postgres")).toBe("8.0.0-rc.10");
+    expect(getDependencyVersion("@prisma/orm-mongo")).toBe("8.0.0-rc.10");
+    expect(getDependencyVersion("@prisma/composer")).toBe("0.19.0");
+    expect(getDependencyVersion("@prisma/composer-prisma-cloud")).toBe("0.19.0");
     expect(getDependencyVersion("prisma")).toBe("latest");
     expect(getDependencyVersion("alchemy")).toBe("2.0.0-beta.74");
     expect(getDependencyVersion("effect")).toBe("4.0.0-rc.112");

--- a/tests/e2e/create-prisma.e2e.test.ts
+++ b/tests/e2e/create-prisma.e2e.test.ts
@@ -20,7 +20,7 @@ import { writeCreateTemplateDependencies, writePrismaDependencies } from "../../
 
 const TEST_TIMEOUT = Number(process.env.CREATE_PRISMA_E2E_TIMEOUT_MS ?? 300_000);
 const tempRoots: string[] = [];
-const TEST_PSL_CONTRACT = `// use prisma-next
+const TEST_PSL_CONTRACT = `// use prisma-8
 
 model User {
   id    Int    @id @default(autoincrement())
@@ -560,8 +560,8 @@ describe("create-prisma e2e", () => {
       expect(packageJson.scripts.postinstall).toBeUndefined();
       expect(packageJson.scripts["skills:sync"]).toBeUndefined();
       expect(configSource).toContain("agents: [],");
-      // prisma-next.md is the human quick reference `prisma orm init` writes; it is not an agent file.
-      expect(await pathExists(path.join(projectDir, "prisma-next.md"))).toBe(true);
+      // prisma-8.md is the human quick reference `prisma orm init` writes; it is not an agent file.
+      expect(await pathExists(path.join(projectDir, "prisma-8.md"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
     },
     TEST_TIMEOUT,
@@ -695,6 +695,7 @@ describe("create-prisma e2e", () => {
       expect(await pathExists(path.join(projectDir, "deno.json"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.json"))).toBe(true);
       expect(await pathExists(path.join(projectDir, "src/prisma/contract.d.ts"))).toBe(true);
+      expect(await pathExists(path.join(projectDir, "prisma-8.md"))).toBe(false);
       expect(await pathExists(path.join(projectDir, "prisma-next.md"))).toBe(false);
       expect(await pathExists(path.join(projectDir, "module.ts"))).toBe(false);
       expect(await pathExists(path.join(projectDir, "service.ts"))).toBe(false);


### PR DESCRIPTION
- `@prisma/composer` and `@prisma/composer-prisma-cloud` 0.17.0 → 0.19.0; `@prisma/orm-postgres` and `@prisma/orm-mongo` 8.0.0-rc.8 → 8.0.0-rc.10 (matches composer-prisma-cloud's exact peer).
- ORM rc.10 renames the primer `orm init` writes from `prisma-next.md` to `prisma-8.md`. The Deno cleanup now removes either name, so Deno scaffolds stop keeping the primer once `prisma@latest` is 8.0.0-rc.14.
- The e2e suite's sample schema uses the new `// use prisma-8` header and expects `prisma-8.md`.

Unit tests, typecheck, and lint pass. Merge after `prisma@8.0.0-rc.14` is on npm (prisma/prisma-cli), because scaffolds install `prisma@latest` and rc.13 still carries the rc.8 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)