### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-prisma",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "private": false,
   "description": "Create Prisma 8 projects with first-party templates and great DX.",
   "homepage": "https://github.com/prisma/create-prisma",


### PR DESCRIPTION
## Release v0.12.0

Bumps `create-prisma` to `0.12.0`. Scaffolds now install Composer 0.19.0 and Prisma ORM 8.0.0-rc.10 (#97), and users can opt out of agent skill files at scaffold time (#96).

**Squash-merge this PR.** The release workflow reads the squash commit title to publish to npm using trusted publishing; a merge commit will skip the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)